### PR TITLE
Be more careful in input checking

### DIFF
--- a/src/main/java/imagej/ops/OpService.java
+++ b/src/main/java/imagej/ops/OpService.java
@@ -105,7 +105,7 @@ public class OpService extends AbstractPTService<Op> {
 					break;
 				}
 			}
-			if (match) return op;
+			if (i == args.length && match) return op;
 		}
 		return null;
 	}


### PR DESCRIPTION
This addresses the conundrum discussed between @ctrueden @dietzc and @hornm: the unit test passed  and nobody knew why (suspecting that it should have failed).

The real reason why this was not caught is that the call to the `ConvertUtils.canConvert()` method is commented-out (because it is not yet in any released version of scijava-common).
