### PR TITLE
Convolve fix

### DIFF
--- a/src/main/java/net/imagej/ops/convolve/ConvolveFourier.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveFourier.java
@@ -74,7 +74,7 @@ public class ConvolveFourier<I extends RealType<I>, K extends RealType<K>, O ext
 		if (last != input) {
 			last = input;
 			fc =
-				FFTConvolution.create(last, output, kernel, kernel, output,
+				FFTConvolution.create(last, kernel, output,
 					new ArrayImgFactory<ComplexFloatType>());
 			fc.setKernel(kernel);
 			fc.setKeepImgFFT(true);

--- a/src/test/java/net/imagej/ops/convolve/ConvolveTest.java
+++ b/src/test/java/net/imagej/ops/convolve/ConvolveTest.java
@@ -31,11 +31,15 @@
 package net.imagej.ops.convolve;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Op;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.Point;
+import net.imglib2.algorithm.region.hypersphere.HyperSphere;
 
 import org.junit.Test;
 
@@ -67,5 +71,59 @@ public class ConvolveTest extends AbstractOpTest {
 		op = ops.op("convolve", in, out, kernel);
 		assertSame(ConvolveFourier.class, op.getClass());
 
+	}
+
+	@Test
+	public void testConvolve() {
+
+		int[] size = new int[] { 225, 167 };
+		int[] kernelSize = new int[] { 27, 39 };
+
+		// create an input with a small sphere at the center
+		Img<ShortType> in =
+			new ArrayImgFactory<ShortType>().create(size, new ShortType());
+		placeSphereInCenter(in);
+
+		// create an output
+		Img<ShortType> out =
+			new ArrayImgFactory<ShortType>().create(size, new ShortType());;
+
+		// create a kernel with a small sphere in the center
+		Img<ShortType> kernel =
+			new ArrayImgFactory<ShortType>().create(kernelSize, new ShortType());
+		placeSphereInCenter(kernel);
+
+		// create variables to hold the image sums
+		ShortType inSum = new ShortType();
+		ShortType kernelSum = new ShortType();
+		ShortType outSum = new ShortType();
+
+		// calculate sum of input and kernel
+		ops.run("sum", inSum, in);
+		ops.run("sum", kernelSum, kernel);
+
+		// convolve and calculate sum of output
+		ops.run("convolve", out, in, kernel);
+		ops.run("sum", outSum, out);
+
+		// multiply input sum by kernelSum and assert it is the same as outSum
+		inSum.mul(kernelSum);
+		assertEquals(inSum, outSum);
+	}
+
+	// utility to place a small sphere at the center of the image
+	private void placeSphereInCenter(Img<ShortType> img) {
+
+		final Point center = new Point(img.numDimensions());
+
+		for (int d = 0; d < img.numDimensions(); d++)
+			center.setPosition(img.dimension(d) / 2, d);
+
+		HyperSphere<ShortType> hyperSphere =
+			new HyperSphere<ShortType>(img, center, 2);
+
+		for (final ShortType value : hyperSphere) {
+			value.setReal(1);
+		}
 	}
 }


### PR DESCRIPTION
I noticed that the ConvolveFourier op was failing with an out of bounds error. The version of 'FFTConvolution.create' function used seems to require extended inputs.  (From the documentation of the function: "The input as well as the kernel need to be extended or infinite already as the {@link Interval} required to perform the Fourier convolution is significantly bigger than the {@link Interval} provided here.")

There is an alternative version of FFTConvolution.create that takes non-extended RAIs as input and extends the image using a mirror and the kernel by zero.   

My proposed solution is to:  
1.  Use the alternative version of FFTConvolution.create in the default ConvolveFourier op.
2.  In the future add a variation of ConvolveFourier that takes a flag indicating type of boundary extension to use (thus allowing the caller to choose a different type of boundary such as zero, exponential fade, etc).   In this version of the op pre-extend the inputs as desired before calling FFTConvolution.create.  

I also added a test to run a convolution and check the output.   
