### PR TITLE
Threshold output creation

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/global/AbstractComputeThresholdHistogram.java
+++ b/src/main/java/net/imagej/ops/threshold/global/AbstractComputeThresholdHistogram.java
@@ -33,7 +33,6 @@ package net.imagej.ops.threshold.global;
 import net.imagej.ops.AbstractOutputFunction;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.UnsignedShortType;
 
 /**
  * Abstract superclass of {@link ComputeThresholdHistogram} implementations.
@@ -47,10 +46,7 @@ public abstract class AbstractComputeThresholdHistogram<T extends RealType<T>>
 
 	@Override
 	public T createOutput(final Histogram1d<T> input) {
-		// FIXME: add API to Histogram1d to get the constituent type T
-		final Object type = new UnsignedShortType();
-		return (T) type;
-//		return null;
+		return input.firstDataValue().createVariable();
 	}
 
 	// -- Internal methods --


### PR DESCRIPTION
This branch fixes the `createOutput` method of `ComputeThresholdHistogram` implementations to work properly. The issue was that prior to the `imglib2-2.0.0-beta-27` release, there was no way to ask a `Histogram1d` what type of data it had counted. So passing one around lost the type reference. But that is now fixed as of https://github.com/imglib/imglib/commit/d8bed7b61c0de2d83d8510f3c5b5df7f7ed77a1e.
