### PR TITLE
Polygon ops

### DIFF
--- a/src/main/java/net/imagej/ops/geometric/interval/DefBoundingBox.java
+++ b/src/main/java/net/imagej/ops/geometric/interval/DefBoundingBox.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.geometric.interval;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.geometric.interval.GeometricIntervalOps.BoundingBoxInterval;
+import net.imagej.ops.geometric.polygon.Polygon;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RealPoint;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Returns the bounds of a polygon (a polygon consisting of four points).
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+@Plugin(type = Op.class, name = BoundingBoxInterval.NAME)
+public class DefBoundingBox implements BoundingBoxInterval {
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Interval output;
+
+	@Parameter(type = ItemIO.INPUT)
+	private Polygon input;
+
+	@Override
+	public void run() {
+		long min_x = Long.MAX_VALUE;
+		long max_x = Long.MIN_VALUE;
+		long min_y = Long.MAX_VALUE;
+		long max_y = Long.MIN_VALUE;
+
+		for (RealPoint point : input.getPoints()) {
+			if (point.getDoublePosition(0) < min_x) {
+				min_x = (long) point.getDoublePosition(0);
+			}
+			if (point.getDoublePosition(0) > max_x) {
+				max_x = (long) point.getDoublePosition(0);
+			}
+			if (point.getDoublePosition(1) < min_y) {
+				min_y = (long) point.getDoublePosition(1);
+			}
+			if (point.getDoublePosition(1) > max_y) {
+				max_y = (long) point.getDoublePosition(1);
+			}
+		}
+
+		output = new FinalInterval(new long[] { min_x, min_y }, new long[] {
+				max_x, max_y });
+	}
+
+	@Override
+	public Interval getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(Interval output) {
+		this.output = output;
+	}
+}

--- a/src/main/java/net/imagej/ops/geometric/polygon/DefBoundingBox.java
+++ b/src/main/java/net/imagej/ops/geometric/polygon/DefBoundingBox.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.geometric.polygon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.geometric.polygon.GeometricPolygonOps.BoundingBoxPolygon;
+import net.imglib2.RealPoint;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Returns the bounds of a polygon (a polygon consisting of four points).
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+@Plugin(type = Op.class, name = BoundingBoxPolygon.NAME)
+public class DefBoundingBox implements BoundingBoxPolygon {
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Polygon output;
+
+	@Parameter(type = ItemIO.INPUT)
+	private Polygon input;
+
+	@Override
+	public void run() {
+		double min_x = Double.POSITIVE_INFINITY;
+		double max_x = Double.NEGATIVE_INFINITY;
+		double min_y = Double.POSITIVE_INFINITY;
+		double max_y = Double.NEGATIVE_INFINITY;
+
+		for (RealPoint RealPoint : input.getPoints()) {
+			if (RealPoint.getDoublePosition(0) < min_x) {
+				min_x = RealPoint.getDoublePosition(0);
+			}
+			if (RealPoint.getDoublePosition(0) > max_x) {
+				max_x = RealPoint.getDoublePosition(0);
+			}
+			if (RealPoint.getDoublePosition(1) < min_y) {
+				min_y = RealPoint.getDoublePosition(1);
+			}
+			if (RealPoint.getDoublePosition(1) > max_y) {
+				max_y = RealPoint.getDoublePosition(1);
+			}
+		}
+
+		List<RealPoint> bounds = new ArrayList<RealPoint>();
+		bounds.add(new RealPoint(min_x, min_y));
+		bounds.add(new RealPoint(min_x, max_y));
+		bounds.add(new RealPoint(max_x, max_y));
+		bounds.add(new RealPoint(max_x, min_y));
+		output = new Polygon(bounds);
+	}
+
+	@Override
+	public Polygon getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(Polygon output) {
+		this.output = output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/geometric/polygon/DefConvexHull.java
+++ b/src/main/java/net/imagej/ops/geometric/polygon/DefConvexHull.java
@@ -1,0 +1,166 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.geometric.polygon;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.geometric.polygon.GeometricPolygonOps.ConvexHullPolygon;
+import net.imglib2.RealPoint;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+* Uses Andrew's monotone chain algorithm to calculate the Convex Hull of a
+* Polygon.
+*
+* @author Daniel Seebacher, University of Konstanz.
+*/
+@Plugin(type = Op.class, name = ConvexHullPolygon.NAME)
+public class DefConvexHull implements ConvexHullPolygon {
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Polygon output;
+
+	@Parameter(type = ItemIO.INPUT)
+	private Polygon input;
+
+	/**
+	 * Andrew's monotone chain convex hull algorithm constructs the convex hull
+	 * of a set of 2-dimensional RealPoints in O(n log n) time. It does so by
+	 * first sorting the RealPoints lexicographically (first by x-coordinate,
+	 * and in case of a tie, by y-coordinate), and then constructing upper and
+	 * lower hulls of the RealPoints in O(n) time. An upper hull is the part of
+	 * the convex hull, which is visible from the above. It runs from its
+	 * rightmost RealPoint to the leftmost RealPoint in counterclockwise order.
+	 * Lower hull is the remaining part of the convex hull.
+	 */
+	@Override
+	public void run() {
+
+		// create a copy of the points because these will get resorted, etc.
+		List<RealPoint> RealPoints = new ArrayList<RealPoint>(input.getPoints());
+
+		// Sort the RealPoints of P by x-coordinate (in case of a tie, sort by
+		// y-coordinate).
+		Collections.sort(RealPoints, new Comparator<RealPoint>() {
+			@Override
+			public int compare(final RealPoint o1, final RealPoint o2) {
+				final Double o1x = new Double(o1.getDoublePosition(0));
+				final Double o2x = new Double(o2.getDoublePosition(0));
+				final int result = o1x.compareTo(o2x);
+				if (result == 0) {
+					return new Double(o1.getDoublePosition(1))
+							.compareTo(new Double(o2.getDoublePosition(1)));
+				} else {
+					return result;
+				}
+			}
+		});
+		// Initialize U and L as empty lists.
+		// The lists will hold the vertices of upper and lower hulls
+		// respectively.
+		final List<RealPoint> U = new ArrayList<RealPoint>();
+		final List<RealPoint> L = new ArrayList<RealPoint>();
+		// build lower hull
+		for (final RealPoint p : RealPoints) {
+			// while L contains at least two RealPoints and the sequence of last
+			// two
+			// RealPoints of L and the RealPoint P[i] does not make a
+			// counter-clockwise
+			// turn: remove the last RealPoint from L
+			while (L.size() >= 2
+					&& ccw(L.get(L.size() - 2), L.get(L.size() - 1), p) <= 0) {
+				L.remove(L.size() - 1);
+			}
+			L.add(p);
+		}
+		// build upper hull
+		Collections.reverse(RealPoints);
+		for (final RealPoint p : RealPoints) {
+			// while U contains at least two RealPoints and the sequence of last
+			// two
+			// RealPoints of U and the RealPoint P[i] does not make a
+			// counter-clockwise
+			// turn: remove the last RealPoint from U
+			while (U.size() >= 2
+					&& ccw(U.get(U.size() - 2), U.get(U.size() - 1), p) <= 0) {
+				U.remove(U.size() - 1);
+			}
+			U.add(p);
+		}
+		// Remove the last RealPoint of each list (it's the same as the first
+		// RealPoint
+		// of the other list).
+		L.remove(L.size() - 1);
+		U.remove(U.size() - 1);
+		// concatenate L and U
+		L.addAll(U);
+
+		output = new Polygon(L);
+	}
+
+	/**
+	 * 2D cross product of OA and OB vectors, i.e. z-component of their 3D cross
+	 * product. Returns a positive value, if OAB makes a counter-clockwise turn,
+	 * negative for clockwise turn, and zero if the RealPoints are collinear.
+	 *
+	 * @param o
+	 *            first RealPoint
+	 * @param a
+	 *            second RealPoint
+	 * @param b
+	 *            third RealPoint
+	 * @return Returns a positive value, if OAB makes a counter-clockwise turn,
+	 *         negative for clockwise turn, and zero if the RealPoints are
+	 *         collinear.
+	 */
+	private double ccw(final RealPoint o, final RealPoint a, final RealPoint b) {
+		return (a.getDoublePosition(0) - o.getDoublePosition(0))
+				* (b.getDoublePosition(1) - o.getDoublePosition(1))
+				- (a.getDoublePosition(1) - o.getDoublePosition(1))
+				* (b.getDoublePosition(0) - o.getDoublePosition(0));
+	}
+
+	@Override
+	public Polygon getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(Polygon output) {
+		this.output = output;
+	}
+}

--- a/src/main/java/net/imagej/ops/geometric/polygon/DefMooreContours.java
+++ b/src/main/java/net/imagej/ops/geometric/polygon/DefMooreContours.java
@@ -1,0 +1,285 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.geometric.polygon;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.geometric.polygon.GeometricPolygonOps.MooreContoursPolygon;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPoint;
+import net.imglib2.type.Type;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.view.Views;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * MooreContourExtractionOp
+ *
+ * Implementation of the Moore contour extraction algorithm. Input: BitType
+ * RandomAccessible Output: A list of Polygons representing the found contours.
+ * Warning! There will be alot of duplicates.
+ *
+ *
+ * This operation only extracts one contour and then terminates. If you have
+ * multiple contours you want to extract, you may want to perform a CCA on them
+ * and then use BitMaskProvider to extract contours from the images of the
+ * labels.
+ *
+ * Also, using the the Jacobs Stopping Criterion is recommended, but turned on
+ * by default anyway. It leads to better results and doesn't significantly slow
+ * down the extraction. The original Jacobs stopping cirteria does not guarantee
+ * termination, therefore it was refined by Jonathan Hale for this
+ * implementation.
+ *
+ * @author Jonathan Hale, University of Konstanz.
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+@Plugin(type = Op.class, name = MooreContoursPolygon.NAME)
+public class DefMooreContours implements MooreContoursPolygon {
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Polygon output;
+
+	@Parameter(type = ItemIO.INPUT)
+	private RandomAccessibleInterval<BitType> input;
+
+	@Parameter(type = ItemIO.INPUT, description = "Set this flag to use the refined Jacobs stopping criteria")
+	private boolean useJacobs = true;
+
+	@Parameter(type = ItemIO.INPUT, description = "Set this flag to invert between foreground/background.")
+	private boolean isInverted = false;
+
+	/**
+	 * ClockwiseMooreNeighborhoodIterator Iterates clockwise through a 2D Moore
+	 * Neighborhood (8 connected Neighborhood).
+	 *
+	 * This iterator encourages reuse! Reset the iterator and move the
+	 * underlying random accessible, do not create new ones. That is more
+	 * resource efficient and faster.
+	 *
+	 * @author Jonathan Hale (University of Konstanz)
+	 */
+	final class ClockwiseMooreNeighborhoodIterator<T extends Type<T>>
+			implements java.util.Iterator<T> {
+		final private RandomAccess<T> m_ra;
+
+		final private int[][] CLOCKWISE_OFFSETS = { { 0, -1 }, { 1, 0 },
+				{ 1, 0 }, { 0, 1 }, { 0, 1 }, { -1, 0 }, { -1, 0 }, { 0, -1 } };
+
+		final private int[][] CCLOCKWISE_OFFSETS = { { 0, 1 }, { 0, 1 },
+				{ -1, 0 }, { -1, 0 }, { 0, -1 }, { 0, -1 }, { 1, 0 }, { 1, 0 } };
+
+		// index of offset to be executed at next next() call.
+		private int m_curOffset = 0;
+
+		// startIndex basically tells the Cursor when it performed
+		// every relative movement in CLOCKWISE_OFFSETS once. After
+		// backtrack, this is reset to go through all 8 offsets again.
+		private int m_startIndex = 7;
+
+		public ClockwiseMooreNeighborhoodIterator(final RandomAccess<T> ra) {
+			m_ra = ra;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public final boolean hasNext() {
+			return (m_curOffset != m_startIndex);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public final T next() {
+			m_ra.move(CLOCKWISE_OFFSETS[m_curOffset]);
+			m_curOffset = (m_curOffset + 1) & 7; // <=> (m_curOffset+1) % 8
+			return m_ra.get();
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public final void remove() {
+			throw new UnsupportedOperationException();
+		}
+
+		public final void backtrack() {
+			final int[] back = CCLOCKWISE_OFFSETS[m_curOffset];
+			m_ra.move(back); // undo last move
+
+			// find out, where to continue:
+			if (back[0] == 0) {
+				if (back[1] == 1) {
+					m_curOffset = 6;
+				} else {
+					m_curOffset = 2;
+				}
+			} else {
+				if (back[0] == 1) {
+					m_curOffset = 4;
+				} else {
+					m_curOffset = 0;
+				}
+			}
+
+			m_startIndex = (m_curOffset + 7) & 7; // set the Pixel to stop at
+		}
+
+		public final int getIndex() {
+			return m_curOffset;
+		}
+
+		/**
+		 * Reset the current offset index. This does not influence the
+		 * RandomAccess.
+		 */
+		public final void reset() {
+			m_curOffset = 0;
+			m_startIndex = 7;
+		}
+
+		/**
+		 * backtrack and set only part of the neighborhood to be iterated.
+		 */
+		public void backtrackSpecial() {
+			final int[] back = CCLOCKWISE_OFFSETS[m_curOffset];
+			m_ra.move(back); // undo last move
+
+			// find out, where to continue:
+			if (back[0] == 0) {
+				if (back[1] == 1) {
+					m_curOffset = 6;
+				} else {
+					m_curOffset = 2;
+				}
+			} else {
+				if (back[0] == 1) {
+					m_curOffset = 4;
+				} else {
+					m_curOffset = 0;
+				}
+			}
+
+			m_startIndex = (m_curOffset + 5) & 7; // set the Pixel to stop at
+		}
+	}
+
+	@Override
+	public void run() {
+
+		Polygon p = new Polygon();
+
+		final RandomAccess<BitType> raInput = Views.extendValue(input,
+				new BitType(!isInverted)).randomAccess();
+		final Cursor<BitType> cInput = Views.flatIterable(input).cursor();
+		final ClockwiseMooreNeighborhoodIterator<BitType> cNeigh = new ClockwiseMooreNeighborhoodIterator<BitType>(
+				raInput);
+
+		double[] position = new double[2];
+		double[] startPos = new double[2];
+
+		// find first black pixel
+		while (cInput.hasNext()) {
+			// we are looking for a black pixel
+			if (cInput.next().get() == isInverted) {
+				raInput.setPosition(cInput);
+				raInput.localize(startPos);
+
+				// add to polygon
+				p.add(new RealPoint(startPos[0], startPos[1]));
+
+				// backtrack:
+				raInput.move(-1, 0);
+
+				cNeigh.reset();
+
+				while (cNeigh.hasNext()) {
+					if (cNeigh.next().get() == isInverted) {
+
+						boolean specialBacktrack = false;
+
+						raInput.localize(position);
+						if (startPos[0] == position[0]
+								&& startPos[1] == position[1]) {
+							// startPoint was found.
+							if (useJacobs) {
+								// Jacobs stopping criteria
+								final int index = cNeigh.getIndex();
+								if (index == 1 || index == 0) {
+									// Jonathans refinement to the
+									// non-terminating jacobs criteria
+									specialBacktrack = true;
+								} else if (index == 2 || index == 3) {
+									// if index is 2 or 3, we entered the pixel
+									// by moving {1, 0}, therefore in the same
+									// way.
+									break;
+								} // else criteria not fulfilled, continue.
+							} else {
+								break;
+							}
+						}
+						// add found point to polygon
+						p.add(new RealPoint(position[0], position[1]));
+
+						if (specialBacktrack) {
+							cNeigh.backtrackSpecial();
+						} else {
+							cNeigh.backtrack();
+						}
+					}
+				}
+
+				break; // we only need to extract one contour.
+			}
+		}
+
+		output = p;
+	}
+
+	@Override
+	public Polygon getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(Polygon output) {
+		this.output = output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/geometric/polygon/DefMooreContours.java
+++ b/src/main/java/net/imagej/ops/geometric/polygon/DefMooreContours.java
@@ -29,6 +29,7 @@
  */
 package net.imagej.ops.geometric.polygon;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Op;
 import net.imagej.ops.geometric.polygon.GeometricPolygonOps.MooreContoursPolygon;
 import net.imglib2.Cursor;
@@ -66,7 +67,7 @@ import org.scijava.plugin.Plugin;
  * @author Daniel Seebacher, University of Konstanz.
  */
 @Plugin(type = Op.class, name = MooreContoursPolygon.NAME)
-public class DefMooreContours implements MooreContoursPolygon {
+public class DefMooreContours implements MooreContoursPolygon, Contingent {
 
 	@Parameter(type = ItemIO.OUTPUT)
 	private Polygon output;
@@ -280,6 +281,16 @@ public class DefMooreContours implements MooreContoursPolygon {
 	@Override
 	public void setOutput(Polygon output) {
 		this.output = output;
+	}
+
+	@Override
+	public boolean conforms() {
+
+		if (input.numDimensions() != 2) {
+			return false;
+		}
+
+		return true;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/geometric/polygon/Polygon.java
+++ b/src/main/java/net/imagej/ops/geometric/polygon/Polygon.java
@@ -1,0 +1,132 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.geometric.polygon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imglib2.RealPoint;
+
+/**
+ * Polygon class.
+ * 
+ * Currently only a list of {@link Point2D} to be able to store points with
+ * floating point coordinates.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+public class Polygon {
+
+	private final List<RealPoint> points;
+
+	/**
+	 * Default constructor, create a new empty polygon.
+	 */
+	public Polygon() {
+		this(new ArrayList<RealPoint>());
+	}
+
+	/**
+	 * Create a new polygon from the given list of points.
+	 * 
+	 * @param points
+	 *            A list of points
+	 */
+	public Polygon(List<RealPoint> points) {
+		this.points = points;
+	}
+
+	/**
+	 * @return the number of points of this polygon.
+	 */
+	public int size() {
+		return points.size() + 1;
+	}
+
+	/**
+	 * 
+	 * @param index
+	 *            an index
+	 * @return the point at the given index.
+	 */
+	public RealPoint getPoint(int index) {
+		if (index < points.size()) {
+			return points.get(index);
+		} else if (index == points.size()) {
+			return points.get(0);
+		} else {
+			throw new ArrayIndexOutOfBoundsException("");
+		}
+	}
+
+	/**
+	 * @return A list with the points of the polygon. DO NOT MODIFY!
+	 */
+	public List<RealPoint> getPoints() {
+		return points;
+	}
+
+	/**
+	 * Add the given point as the last one of the polygon.
+	 * 
+	 * @param point
+	 *            a point
+	 */
+	public void add(RealPoint point) {
+		points.add(point);
+	}
+
+	/**
+	 * Remove the given point from the polygon.
+	 * 
+	 * @param point
+	 *            a point
+	 */
+	public void remove(RealPoint point) {
+		points.remove(point);
+	}
+
+	/**
+	 * Remove the point at the given index from the polygon.
+	 * 
+	 * @param index
+	 *            an index
+	 */
+	public void remove(int index) {
+		points.remove(index);
+	}
+
+	/**
+	 * Removes every point from the polygon.
+	 */
+	public void clear() {
+		points.clear();
+	}
+}

--- a/src/main/templates/net/imagej/ops/geometric/GeometricOps.list
+++ b/src/main/templates/net/imagej/ops/geometric/GeometricOps.list
@@ -1,0 +1,8 @@
+[GeometricOps.java]
+ops = ```
+[
+{name: moore-contour, iface: MooreContours},
+{name: convex-hull, iface: ConvexHull},
+{name: bounding-box, iface: BoundingBox}
+]
+```

--- a/src/main/templates/net/imagej/ops/geometric/GeometricOps.vm
+++ b/src/main/templates/net/imagej/ops/geometric/GeometricOps.vm
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.geometric;
+
+import net.imagej.ops.Op;
+
+/**
+ * Static utility class containing ǵeometric ops.
+ * <p>
+ * These interfaces are intended to mark all ops using a particular name,
+ * regardless of the area of functionality. 
+ *
+ * </p>
+	 * <pre>
+	 * @Plugin(type = Op.class, name = GeometricOps.ConvexHullOp.NAME)
+	 * </pre>
+ *
+ * @author Daniel Seebacher, University of Konstanz
+ */
+public final class GeometricOps {
+
+	private GeometricOps() {
+		// NB: Prevent instantiation of utility class.
+	}
+#foreach ($op in $ops)
+
+	/**
+	 * Base interface for "$op.name" operations.
+	 * <p>
+	 * Implementing classes should be annotated with:
+	 * </p>
+	 *
+	 * <pre>
+#if ($op.aliases)
+	 * @Plugin(type = Op.class, name = GeometricOps.${op.iface}.NAME,
+	 *   attrs = { @Attr(name = "aliases", value = GeometricOps.${op.iface}.ALIASES) })
+#else
+	 * @Plugin(type = Op.class, name = GeometricOps.${op.iface}.NAME)
+#end
+	 * </pre>
+	 */
+	public interface $op.iface extends Op {
+		String NAME = "$op.name";
+#if ($op.aliases)
+		String ALIASES = "$op.aliases";
+#end
+	}
+#end
+
+}

--- a/src/main/templates/net/imagej/ops/geometric/interval/GeometricIntervalOps.list
+++ b/src/main/templates/net/imagej/ops/geometric/interval/GeometricIntervalOps.list
@@ -1,0 +1,6 @@
+[GeometricIntervalOps.java]
+ops = ```
+[
+{name: bounding-box, iface: BoundingBox}
+]
+```

--- a/src/main/templates/net/imagej/ops/geometric/interval/GeometricIntervalOps.vm
+++ b/src/main/templates/net/imagej/ops/geometric/interval/GeometricIntervalOps.vm
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.geometric.interval;
+
+import net.imglib2.Interval;
+
+import net.imagej.ops.OutputOp;
+import net.imagej.ops.geometric.GeometricOps;
+
+/**
+ * Static utility class containing built-in ops interfaces.
+ * <p>
+ * These interfaces are intended to mark all ops using a particular name,
+ * regardless of the area of functionality. 
+ *
+ * </p>
+	 * <pre>
+	 * @Plugin(type = Op.class, name = GeometricIntervalOps.ConvexHullOp.NAME)
+	 * </pre>
+ *
+ * @author Daniel Seebacher, University of Konstanz
+ */
+public final class GeometricIntervalOps {
+
+	private GeometricIntervalOps() {
+		// NB: Prevent instantiation of utility class.
+	}
+#foreach ($op in $ops)
+
+	/**
+	 * Base interface for "$op.name" operations.
+	 * <p>
+	 * Implementing classes should be annotated with:
+	 * </p>
+	 *
+	 * <pre>
+#if ($op.aliases)
+	 * @Plugin(type = Op.class, name = GeometricIntervalOps.${op.iface}.NAME,
+	 *   attrs = { @Attr(name = "aliases", value = GeometricIntervalOps.${op.iface}.ALIASES) })
+#else
+	 * @Plugin(type = Op.class, name = GeometricIntervalOps.${op.iface}.NAME)
+#end
+	 * </pre>
+	 */
+	public interface ${op.iface}Interval extends OutputOp<Interval>, GeometricOps.${op.iface}  {
+		String NAME = "$op.name";
+#if ($op.aliases)
+		String ALIASES = "$op.aliases";
+#end
+	}
+#end
+
+}

--- a/src/main/templates/net/imagej/ops/geometric/polygon/GeometricPolygonOps.list
+++ b/src/main/templates/net/imagej/ops/geometric/polygon/GeometricPolygonOps.list
@@ -1,0 +1,8 @@
+[GeometricPolygonOps.java]
+ops = ```
+[
+{name: moore-contour, iface: MooreContours},
+{name: convex-hull, iface: ConvexHull},
+{name: bounding-box, iface: BoundingBox}
+]
+```

--- a/src/main/templates/net/imagej/ops/geometric/polygon/GeometricPolygonOps.vm
+++ b/src/main/templates/net/imagej/ops/geometric/polygon/GeometricPolygonOps.vm
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.geometric.polygon;
+
+import net.imagej.ops.OutputOp;
+import net.imagej.ops.geometric.GeometricOps;
+
+/**
+ * Static utility class containing built-in ops interfaces.
+ * <p>
+ * These interfaces are intended to mark all ops using a particular name,
+ * regardless of the area of functionality. 
+ *
+ * </p>
+	 * <pre>
+	 * @Plugin(type = Op.class, name = GeometricPolygonOps.ConvexHullOp.NAME)
+	 * </pre>
+ *
+ * @author Daniel Seebacher, University of Konstanz
+ */
+public final class GeometricPolygonOps {
+
+	private GeometricPolygonOps() {
+		// NB: Prevent instantiation of utility class.
+	}
+#foreach ($op in $ops)
+
+	/**
+	 * Base interface for "$op.name" operations.
+	 * <p>
+	 * Implementing classes should be annotated with:
+	 * </p>
+	 *
+	 * <pre>
+#if ($op.aliases)
+	 * @Plugin(type = Op.class, name = GeometricPolygonOps.${op.iface}.NAME,
+	 *   attrs = { @Attr(name = "aliases", value = GeometricPolygonOps.${op.iface}.ALIASES) })
+#else
+	 * @Plugin(type = Op.class, name = GeometricPolygonOps.${op.iface}.NAME)
+#end
+	 * </pre>
+	 */
+	public interface ${op.iface}Polygon extends OutputOp<Polygon>, GeometricOps.${op.iface}  {
+		String NAME = "$op.name";
+#if ($op.aliases)
+		String ALIASES = "$op.aliases";
+#end
+	}
+#end
+
+}

--- a/src/test/java/net/imagej/ops/geometric/GeometricPolygonTest.java
+++ b/src/test/java/net/imagej/ops/geometric/GeometricPolygonTest.java
@@ -1,0 +1,164 @@
+package net.imagej.ops.geometric;
+
+import static org.junit.Assert.assertEquals;
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.geometric.GeometricOps.BoundingBox;
+import net.imagej.ops.geometric.GeometricOps.ConvexHull;
+import net.imagej.ops.geometric.GeometricOps.MooreContours;
+import net.imagej.ops.geometric.polygon.GeometricPolygonOps.MooreContoursPolygon;
+import net.imagej.ops.geometric.polygon.Polygon;
+import net.imglib2.RealPoint;
+import net.imglib2.algorithm.region.hypersphere.HyperSphereCursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+
+import org.junit.Test;
+
+/**
+ * Test the {@link PolygonOps}
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+public class GeometricPolygonTest extends AbstractOpTest {
+
+	/**
+	 * Test the {@link MooreContours} Op.
+	 */
+	@Test
+	public void testMooreContourOp() {
+
+		// create an image
+		Img<BitType> img1 = ArrayImgs.bits(100, 100);
+		HyperSphereCursor<BitType> hyperSphereCursor = new HyperSphereCursor<BitType>(
+				img1, new long[] { 50, 50 }, 20);
+		while (hyperSphereCursor.hasNext()) {
+			hyperSphereCursor.next().set(true);
+		}
+
+		Polygon contours = (Polygon) ops.run(MooreContoursPolygon.class, img1,
+				true, true);
+
+		// our polygon must at least contain the four extrema (top, left,
+		// bottom, right)
+		boolean containsTop = false;
+		boolean containsLeft = false;
+		boolean containsBottom = false;
+		boolean containsRight = false;
+		for (RealPoint rp : contours.getPoints()) {
+			if (rp.getDoublePosition(0) == 50 && rp.getDoublePosition(1) == 70) {
+				containsTop = true;
+			}
+			if (rp.getDoublePosition(0) == 30 && rp.getDoublePosition(1) == 50) {
+				containsLeft = true;
+			}
+			if (rp.getDoublePosition(0) == 50 && rp.getDoublePosition(1) == 30) {
+				containsBottom = true;
+			}
+			if (rp.getDoublePosition(0) == 70 && rp.getDoublePosition(1) == 50) {
+				containsRight = true;
+			}
+		}
+
+		assertEquals("Extrema Top", true, containsTop);
+		assertEquals("Extrema Left", true, containsLeft);
+		assertEquals("Extrema Bottom", true, containsBottom);
+		assertEquals("Extrema Right", true, containsRight);
+	}
+
+	/**
+	 * Test the {@link BoundingBox} Op.
+	 */
+	@Test
+	public void testBoundingBox() {
+		Polygon p = new Polygon();
+
+		// add four points (diamond like shape)
+		p.add(new RealPoint(50, 70));
+		p.add(new RealPoint(30, 50));
+		p.add(new RealPoint(50, 30));
+		p.add(new RealPoint(70, 50));
+
+		Polygon boundingBox = (Polygon) ops.run(BoundingBox.class, p);
+
+		// five points because the first and last one are equal
+		assertEquals("Polygon Size", 5, boundingBox.size());
+
+		// and now check that it only contains the four corner points
+		boolean containsBottomLeft = false;
+		boolean containsBottomRight = false;
+		boolean containsTopRight = false;
+		boolean containsTopLeft = false;
+
+		for (RealPoint rp : boundingBox.getPoints()) {
+			System.out.println(rp);
+
+			if (rp.getDoublePosition(0) == 30 && rp.getDoublePosition(1) == 30) {
+				containsBottomLeft = true;
+			}
+			if (rp.getDoublePosition(0) == 70 && rp.getDoublePosition(1) == 30) {
+				containsBottomRight = true;
+			}
+			if (rp.getDoublePosition(0) == 70 && rp.getDoublePosition(1) == 70) {
+				containsTopRight = true;
+			}
+			if (rp.getDoublePosition(0) == 30 && rp.getDoublePosition(1) == 70) {
+				containsTopLeft = true;
+			}
+		}
+
+		assertEquals("Extrema BottomLeft", true, containsBottomLeft);
+		assertEquals("Extrema BottomRight", true, containsBottomRight);
+		assertEquals("Extrema TopRight", true, containsTopRight);
+		assertEquals("Extrema TopLeft", true, containsTopLeft);
+	}
+
+	/**
+	 * Test the {@link ConvexHull} Op.
+	 */
+	@Test
+	public void testConvexHull() {
+		Polygon p = new Polygon();
+
+		// add 4 extrema
+		p.add(new RealPoint(0, 0));
+		p.add(new RealPoint(10, 0));
+		p.add(new RealPoint(10, 10));
+		p.add(new RealPoint(0, 10));
+
+		// add noise
+		for (int i = 0; i < 100; i++) {
+			p.add(new RealPoint(Math.random() * 10, Math.random() * 10));
+		}
+
+		Polygon convexHull = (Polygon) ops.run(ConvexHull.class, p);
+
+		// five points because the first and last one are equal
+		assertEquals("Polygon Size", 5, convexHull.size());
+
+		// and now check that it only contains the four corner points
+		boolean containsBottomLeft = false;
+		boolean containsBottomRight = false;
+		boolean containsTopRight = false;
+		boolean containsTopLeft = false;
+		for (RealPoint rp : convexHull.getPoints()) {
+			if (rp.getDoublePosition(0) == 0 && rp.getDoublePosition(1) == 0) {
+				containsBottomLeft = true;
+			}
+			if (rp.getDoublePosition(0) == 10 && rp.getDoublePosition(1) == 0) {
+				containsBottomRight = true;
+			}
+			if (rp.getDoublePosition(0) == 10 && rp.getDoublePosition(1) == 10) {
+				containsTopRight = true;
+			}
+			if (rp.getDoublePosition(0) == 0 && rp.getDoublePosition(1) == 10) {
+				containsTopLeft = true;
+			}
+		}
+
+		assertEquals("Extrema BottomLeft", true, containsBottomLeft);
+		assertEquals("Extrema BottomRight", true, containsBottomRight);
+		assertEquals("Extrema TopRight", true, containsTopRight);
+		assertEquals("Extrema TopLeft", true, containsTopLeft);
+	}
+}

--- a/src/test/java/net/imagej/ops/geometric/GeometricPolygonTest.java
+++ b/src/test/java/net/imagej/ops/geometric/GeometricPolygonTest.java
@@ -5,6 +5,7 @@ import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.geometric.GeometricOps.BoundingBox;
 import net.imagej.ops.geometric.GeometricOps.ConvexHull;
 import net.imagej.ops.geometric.GeometricOps.MooreContours;
+import net.imagej.ops.geometric.polygon.GeometricPolygonOps.BoundingBoxPolygon;
 import net.imagej.ops.geometric.polygon.GeometricPolygonOps.MooreContoursPolygon;
 import net.imagej.ops.geometric.polygon.Polygon;
 import net.imglib2.RealPoint;
@@ -79,7 +80,7 @@ public class GeometricPolygonTest extends AbstractOpTest {
 		p.add(new RealPoint(50, 30));
 		p.add(new RealPoint(70, 50));
 
-		Polygon boundingBox = (Polygon) ops.run(BoundingBox.class, p);
+		Polygon boundingBox = (Polygon) ops.run(BoundingBoxPolygon.class, p);
 
 		// five points because the first and last one are equal
 		assertEquals("Polygon Size", 5, boundingBox.size());
@@ -91,8 +92,6 @@ public class GeometricPolygonTest extends AbstractOpTest {
 		boolean containsTopLeft = false;
 
 		for (RealPoint rp : boundingBox.getPoints()) {
-			System.out.println(rp);
-
 			if (rp.getDoublePosition(0) == 30 && rp.getDoublePosition(1) == 30) {
 				containsBottomLeft = true;
 			}


### PR DESCRIPTION
The default java.awt.polygon only stores points in an int array, but it is possible to get coordinates which are denoted with double values. Therefore I created a simple polygon class. Currently it only consists of a list to store RealPoints but it can be extended later.

I added the Moore Contours algorithm which can extract polygons from BitType images. I also included a BoundingBox as well as a ConvexHull Op. 


Additionaly I created a JUnit Test for each Op.
