### PR TITLE
Fix README's example, once and for all

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Try this Jython script in
 # create a new blank image
 from jarray import array
 dims = array([150, 100], 'l')
-blank = ij.op().createImg(dims)
+blank = ij.op().createimg(dims)
 
 # fill in the image with a sinusoid using a formula
 formula = "10 * (Math.cos(0.3*p[0]) + Math.sin(0.3*p[1]))"
@@ -55,10 +55,10 @@ sinusoid = ij.op().equation(blank, formula)
 ij.op().add(sinusoid, 13.0)
 
 # generate a gradient image using a formula
-gradient = ij.op().equation(ij.op().createImg(dims), "p[0]+p[1]")
+gradient = ij.op().equation(ij.op().createimg(dims), "p[0]+p[1]")
 
 # add the two images
-composite = ij.op().createImg(dims)
+composite = ij.op().createimg(dims)
 ij.op().add(composite, sinusoid, gradient)
 
 # display the images

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-ij</artifactId>
 			<scope>test</scope>
-		</dependency>	
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
 			<artifactId>imglib2-ij</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scripting-jython</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -182,172 +182,172 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 
 	@Override
 	public Object add(final Object... args) {
-		return run("add", args);
+		return run(Ops.Add.NAME, args);
 	}
 
 	@Override
 	public Object ascii(Object... args) {
-		return run("ascii", args);
+		return run(Ops.ASCII.NAME, args);
 	}
 
 	@Override
 	public Object chunker(Object... args) {
-		return run("chunker", args);
+		return run(Ops.Chunker.NAME, args);
 	}
 
 	@Override
 	public Object convert(Object... args) {
-		return run("convert", args);
+		return run(Ops.Convert.NAME, args);
 	}
 
 	@Override
 	public Object convolve(Object... args) {
-		return run("convolve", args);
+		return run(Ops.Convolve.NAME, args);
 	}
 
 	@Override
 	public Object createimg(Object... args) {
-		return run("createimg", args);
+		return run(Ops.CreateImg.NAME, args);
 	}
 
 	@Override
 	public Object crop(Object... args) {
-		return run("crop", args);
+		return run(Ops.Crop.NAME, args);
 	}
 
 	@Override
 	public Object divide(Object... args) {
-		return run("divide", args);
+		return run(Ops.Divide.NAME, args);
 	}
 
 	@Override
 	public Object equation(Object... args) {
-		return run("equation", args);
+		return run(Ops.Equation.NAME, args);
 	}
 
 	@Override
 	public Object gauss(Object... args) {
-		return run("gauss", args);
+		return run(Ops.Gauss.NAME, args);
 	}
 
 	@Override
 	public Object histogram(Object... args) {
-		return run("histogram", args);
+		return run(Ops.Histogram.NAME, args);
 	}
 
 	@Override
 	public Object identity(Object... args) {
-		return run("identity", args);
+		return run(Ops.Identity.NAME, args);
 	}
 
 	@Override
 	public Object invert(Object... args) {
-		return run("invert", args);
+		return run(Ops.Invert.NAME, args);
 	}
 
 	@Override
 	public Object join(Object... args) {
-		return run("join", args);
+		return run(Ops.Join.NAME, args);
 	}
 
 	@Override
 	public Object lookup(Object... args) {
-		return run("lookup", args);
+		return run(Ops.Lookup.NAME, args);
 	}
 
 	@Override
 	public Object loop(Object... args) {
-		return run("loop", args);
+		return run(Ops.Loop.NAME, args);
 	}
 
 	@Override
 	public Object map(Object... args) {
-		return run("map", args);
+		return run(Ops.Map.NAME, args);
 	}
 
 	@Override
 	public Object max(Object... args) {
-		return run("max", args);
+		return run(Ops.Max.NAME, args);
 	}
 
 	@Override
 	public Object mean(Object... args) {
-		return run("mean", args);
+		return run(Ops.Mean.NAME, args);
 	}
 
 	@Override
 	public Object median(Object... args) {
-		return run("median", args);
+		return run(Ops.Median.NAME, args);
 	}
 
 	@Override
 	public Object min(Object... args) {
-		return run("min", args);
+		return run(Ops.Min.NAME, args);
 	}
 
 	@Override
 	public Object minmax(Object... args) {
-		return run("minmax", args);
+		return run(Ops.MinMax.NAME, args);
 	}
 
 	@Override
 	public Object multiply(Object... args) {
-		return run("multiply", args);
+		return run(Ops.Multiply.NAME, args);
 	}
 
 	@Override
 	public Object normalize(Object... args) {
-		return run("normalize", args);
+		return run(Ops.Normalize.NAME, args);
 	}
 
 	@Override
 	public Object project(Object... args) {
-		return run("project", args);
+		return run(Ops.Project.NAME, args);
 	}
 
 	@Override
 	public Object quantile(Object... args) {
-		return run("quantile", args);
+		return run(Ops.Quantile.NAME, args);
 	}
 
 	@Override
 	public Object scale(Object... args) {
-		return run("scale", args);
+		return run(Ops.Scale.NAME, args);
 	}
 
 	@Override
 	public Object size(Object... args) {
-		return run("size", args);
+		return run(Ops.Size.NAME, args);
 	}
 
 	@Override
 	public Object slicewise(Object... args) {
-		return run("slicewise", args);
+		return run(Ops.Slicewise.NAME, args);
 	}
 
 	@Override
 	public Object stddev(Object... args) {
-		return run("stddev", args);
+		return run(Ops.StdDeviation.NAME, args);
 	}
 
 	@Override
 	public Object subtract(Object... args) {
-		return run("subtract", args);
+		return run(Ops.Subtract.NAME, args);
 	}
 
 	@Override
 	public Object sum(Object... args) {
-		return run("sum", args);
+		return run(Ops.Sum.NAME, args);
 	}
 
 	@Override
 	public Object threshold(Object... args) {
-		return run("threshold", args);
+		return run(Ops.Threshold.NAME, args);
 	}
 
 	@Override
 	public Object variance(Object... args) {
-		return run("variance", args);
+		return run(Ops.Variance.NAME, args);
 	}
 
 	// -- SingletonService methods --

--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -301,11 +301,6 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	}
 
 	@Override
-	public Object otsu(Object... args) {
-		return run("otsu", args);
-	}
-
-	@Override
 	public Object project(Object... args) {
 		return run("project", args);
 	}
@@ -323,11 +318,6 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	@Override
 	public Object size(Object... args) {
 		return run("size", args);
-	}
-
-	@Override
-	public Object slicemapper(Object... args) {
-		return run("slicemapper", args);
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -206,8 +206,8 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	}
 
 	@Override
-	public Object createImg(Object... args) {
-		return run("createImg", args);
+	public Object createimg(Object... args) {
+		return run("createimg", args);
 	}
 
 	@Override
@@ -378,7 +378,7 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	@Deprecated
 	@Override
 	public Object create(Object... args) {
-		return run("createImg", args);
+		return createimg(args);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -240,9 +240,6 @@ public interface OpService extends PTService<Op>, ImageJService {
 	/** Executes the "normalize" operation on the given arguments. */
 	Object normalize(Object... args);
 
-	/** Executes the "otsu" operation on the given arguments. */
-	Object otsu(Object... args);
-
 	/** Executes the "project" operation on the given arguments. */
 	Object project(Object... args);
 
@@ -254,9 +251,6 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	/** Executes the "size" operation on the given arguments. */
 	Object size(Object... args);
-
-	/** Executes the "slicemapper" operation on the given arguments. */
-	Object slicemapper(Object... args);
 
 	/** Executes the "slicewise" operation on the given arguments. */
 	Object slicewise(Object... args);

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -183,8 +183,8 @@ public interface OpService extends PTService<Op>, ImageJService {
 	/** Executes the "convolve" operation on the given arguments. */
 	Object convolve(Object... args);
 
-	/** Executes the "createImg" operation on the given arguments. */
-	Object createImg(Object... args);
+	/** Executes the "createimg" operation on the given arguments. */
+	Object createimg(Object... args);
 
 	/** Executes the "crop" operation on the given arguments. */
 	Object crop(Object... args);
@@ -272,7 +272,7 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	// -- Deprecated methods --
 
-	/** @deprecated Use {@link #createImg} instead. */
+	/** @deprecated Use {@link #createimg} instead. */
 	@Deprecated
 	Object create(Object... args);
 

--- a/src/main/java/net/imagej/ops/create/CreateImgSimple.java
+++ b/src/main/java/net/imagej/ops/create/CreateImgSimple.java
@@ -1,0 +1,57 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.create;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = Op.class, name = Ops.CreateImg.NAME)
+public class CreateImgSimple implements Ops.CreateImg
+{
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Img<DoubleType> output;
+
+	@Parameter
+	private long[] dims;
+
+	@Override
+	public void run() {
+		output = ArrayImgs.doubles(dims);
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -8,6 +8,7 @@ ops = ```
   {name: convolve,    iface: Convolve},
   {name: createimg,   iface: CreateImg},
   {name: crop,        iface: Crop,           aliases: "slice"},
+  {name: divide,      iface: Divide},
   {name: equation,    iface: Equation},
   {name: gauss,       iface: Gauss,          aliases: "smooth"},
   {name: histogram,   iface: Histogram},
@@ -22,6 +23,7 @@ ops = ```
   {name: median,      iface: Median},
   {name: min,         iface: Min},
   {name: minmax,      iface: MinMax},
+  {name: multiply,    iface: Multiply},
   {name: normalize,   iface: Normalize,      aliases: "norm"},
   {name: project,     iface: Project},
   {name: quantile,    iface: Quantile},
@@ -29,6 +31,7 @@ ops = ```
   {name: size,        iface: Size},
   {name: slicewise,   iface: Slicewise},
   {name: stddev,      iface: StdDeviation},
+  {name: subtract,    iface: Subtract},
   {name: sum,         iface: Sum},
   {name: threshold,   iface: Threshold},
   {name: variance,    iface: Variance}

--- a/src/test/java/net/imagej/ops/ReadmeExampleTest.java
+++ b/src/test/java/net/imagej/ops/ReadmeExampleTest.java
@@ -1,0 +1,115 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.plugin.Plugin;
+import org.scijava.script.ScriptModule;
+import org.scijava.script.ScriptService;
+import org.scijava.service.AbstractService;
+import org.scijava.service.Service;
+import org.scijava.util.FileUtils;
+
+/**
+ * A test to ensure that the example in the <code>README.md</code> file works.
+ * 
+ * @author Johannes Schindelin
+ */
+public class ReadmeExampleTest {
+
+	@Test
+	public void testReadmesExample() throws Exception {
+		// extract the example script
+		final File readme = new File("README.md");
+		final String contents = new String(FileUtils.readFile(readme), "UTF-8");
+		final String telltale = "```python\n";
+		final int begin = contents.indexOf(telltale) + telltale.length();
+		assertTrue(begin > telltale.length());
+		assertTrue(contents.indexOf(telltale, begin) < 0);
+		final int end = contents.indexOf("```\n", begin);
+		assertTrue(end > 0);
+		final String snippet = contents.substring(begin, end);
+System.err.println(snippet);
+
+		final Context context = new Context();
+		final ScriptService script = context.getService(ScriptService.class);
+
+		// create mock ImageJ gateway
+		script.addAlias("ImageJ", Mock.class);
+		final ScriptModule result = script.run("op-example.py", snippet, true).get();
+		assertNotNull(result);
+		result.run();
+
+		final Mock ij = context.getService(Mock.class);
+		assertEquals(3, ij.images.size());
+		assertEquals(11.906, ij.getPixel("sinusoid", 50, 50), 1e-3);
+		assertEquals(100, ij.getPixel("gradient", 50, 50), 1e-3);
+		assertEquals(111.906, ij.getPixel("composite", 50, 50), 1e-3);
+	}
+
+	@Plugin(type = Service.class)
+	public static class Mock extends AbstractService {
+		protected final Map<String, Img<DoubleType>> images =
+				new HashMap<String, Img<DoubleType>>();
+
+		public OpService op() {
+			return getContext().getService(OpService.class);
+		}
+
+		public Object ui() {
+			return this;
+		}
+
+		public void show(final String name, final Img<DoubleType> img) {
+			images.put(name, img);
+		}
+
+		public double getPixel(final String imageName, int x, int y) {
+			final Img<DoubleType> img = images.get(imageName);
+			final RandomAccess<DoubleType> access = img.randomAccess();
+			access.setPosition(new int[] { x, y });
+			return access.get().get();
+		}
+	}
+}


### PR DESCRIPTION
When running `UsingOps`, the user is greeted thusly:

```
[INFO] Found 199 ops
[INFO] Available operations:
	[111.0] (net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.real.DoubleType, net.imglib2.img.basictypeaccess.array.DoubleArray> image) = net.imagej.ops.arithmetic.add.parallel.AddConstantToArrayDoubleImageP(net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.real.DoubleType, net.imglib2.img.basictypeaccess.array.DoubleArray> image, byte value)
	[110.0] (net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.integer.ByteType, net.imglib2.img.basictypeaccess.array.ByteArray> image) = net.imagej.ops.arithmetic.add.parallel.AddConstantToArrayByteImageP(net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.integer.ByteType, net.imglib2.img.basictypeaccess.array.ByteArray> image, byte value)
	[101.0] (net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.real.DoubleType, net.imglib2.img.basictypeaccess.array.DoubleArray> image) = net.imagej.ops.arithmetic.add.AddConstantToArrayDoubleImage(net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.real.DoubleType, net.imglib2.img.basictypeaccess.array.DoubleArray> image, double value)
	[100.0] (net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.integer.ByteType, net.imglib2.img.basictypeaccess.array.ByteArray> image) = net.imagej.ops.arithmetic.add.AddConstantToArrayByteImage(net.imglib2.img.array.ArrayImg<net.imglib2.type.numeric.integer.ByteType, net.imglib2.img.basictypeaccess.array.ByteArray> image, byte value)
	[100.0] (java.lang.Object result) = net.imagej.ops.onthefly.ArithmeticOp$AddOp(java.lang.Object result, java.lang.Object a, java.lang.Object b)
	[0.6] (double a) = net.imagej.ops.arithmetic.add.AddConstantToDouble(double a, double b)
	[0.5] (long a) = net.imagej.ops.arithmetic.add.AddConstantToLong(long a, long b)
	[0.4] (float a) = net.imagej.ops.arithmetic.add.AddConstantToFloat(float a, float b)
	[0.3] (int a) = net.imagej.ops.arithmetic.add.AddConstantToInteger(int a, int b)
	[0.2] (short a) = net.imagej.ops.arithmetic.add.AddConstantToShort(short a, short b)
	[0.1] (byte a) = net.imagej.ops.arithmetic.add.AddConstantToByte(byte a, byte b)
	[0.0] (net.imglib2.IterableRealInterval<capture of ?> image) = net.imagej.ops.arithmetic.add.AddConstantToImageInPlace(net.imglib2.IterableRealInterval<capture of ?> image, capture of ? value)
	[0.0] (net.imglib2.IterableInterval<capture of ?> a) = net.imagej.ops.arithmetic.add.AddRandomAccessibleIntervalToIterableInterval(net.imglib2.IterableInterval<capture of ?> a, net.imglib2.RandomAccessibleInterval<capture of ?> b)
	[0.0] (net.imglib2.img.planar.PlanarImg<net.imglib2.type.numeric.real.DoubleType, net.imglib2.img.basictypeaccess.array.DoubleArray> image) = net.imagej.ops.arithmetic.add.AddConstantToPlanarDoubleImage(net.imglib2.img.planar.PlanarImg<net.imglib2.type.numeric.real.DoubleType, net.imglib2.img.basictypeaccess.array.DoubleArray> image, double value)
	[-100.0] (capture of ? out?) = net.imagej.ops.arithmetic.add.AddConstantToNumericType(capture of ? out?, capture of ? in, capture of ? value)
	[-10000.0] (net.imglib2.RandomAccessibleInterval<capture of ?> out) = net.imagej.ops.arithmetic.add.AddConstantToImageFunctional(net.imglib2.RandomAccessibleInterval<capture of ?> out, net.imglib2.IterableInterval<capture of ?> in, capture of ? value)
[INFO] What is 2 + 5? 7.0
Exception in thread "main" java.lang.IllegalArgumentException: No candidate 'createImg' ops
	at net.imagej.ops.DefaultOpMatchingService.findModule(DefaultOpMatchingService.java:93)
	at net.imagej.ops.DefaultOpService.module(DefaultOpService.java:110)
	at net.imagej.ops.DefaultOpService.run(DefaultOpService.java:77)
	at net.imagej.ops.DefaultOpService.create(DefaultOpService.java:391)
	at UsingOps.main(UsingOps.java:33)
```

Maybe this should be tested as part of a unit test, what with the `README` suggesting to use `createImg` and all...