### PR TITLE
Make the `mvn test` quicker

### DIFF
--- a/src/main/groovy/generate.groovy
+++ b/src/main/groovy/generate.groovy
@@ -31,6 +31,12 @@
 templateDirectory = project.properties['templateDirectory']
 outputDirectory = project.properties['outputDirectory']
 
+/* Gets the last modified timestap for the given file. */
+def timestamp(dir, file) {
+	if (file == null) return Long.MAX_VALUE;
+	return new java.io.File(dir, file).lastModified();
+}
+
 /* Processes a template using Apache Velocity. */
 def processTemplate(engine, context, templateFile, outFilename) {
 	if (outFilename == null) return; // nothing to do
@@ -208,8 +214,8 @@ def translate(templateSubdirectory, templateFile, translationsFile) {
 
 	// avoid rewriting unchanged code to avoid recompilation
 	def mtime = java.lang.Math.max(
-		new java.io.File(templateSubdirectory, translationsFile).lastModified(),
-		new java.io.File(templateSubdirectory, templateFile).lastModified());
+		timestamp(templateSubdirectory, translationsFile),
+		timestamp(templateSubdirectory, templateFile));
 
 	for (;;) {
 		// read the line
@@ -219,7 +225,7 @@ def translate(templateSubdirectory, templateFile, translationsFile) {
 		// check if the line starts a new section
 		if (line.startsWith("[") && line.endsWith("]")) {
 			// write out the previous file
-			if (outputFilename != null && mtime >= new java.io.File(outputDirectory, outputFilename).lastModified()) {
+			if (mtime >= timestamp(outputDirectory, outputFilename)) {
 				processTemplate(engine, context, templateFile, outputFilename);
 			}
 
@@ -272,7 +278,7 @@ def translate(templateSubdirectory, templateFile, translationsFile) {
 	reader.close();
 
 	// process the template
-	if (outputFilename != null && mtime >= new java.io.File(outputDirectory, outputFilename).lastModified()) {
+	if (mtime >= timestamp(outputDirectory, outputFilename)) {
 		processTemplate(engine, context, templateFile, outputFilename);
 	}
 }

--- a/src/main/groovy/generate.groovy
+++ b/src/main/groovy/generate.groovy
@@ -205,6 +205,12 @@ def translate(templateSubdirectory, templateFile, translationsFile) {
 	// read translation lines
 	context = outputFilename = null;
 	reader = new java.io.BufferedReader(new java.io.FileReader("$templateSubdirectory/$translationsFile"));
+
+	// avoid rewriting unchanged code to avoid recompilation
+	def mtime = java.lang.Math.max(
+		new java.io.File(templateSubdirectory, translationsFile).lastModified(),
+		new java.io.File(templateSubdirectory, templateFile).lastModified());
+
 	for (;;) {
 		// read the line
 		line = reader.readLine();
@@ -213,7 +219,9 @@ def translate(templateSubdirectory, templateFile, translationsFile) {
 		// check if the line starts a new section
 		if (line.startsWith("[") && line.endsWith("]")) {
 			// write out the previous file
-			processTemplate(engine, context, templateFile, outputFilename);
+			if (outputFilename != null && mtime >= new java.io.File(outputDirectory, outputFilename).lastModified()) {
+				processTemplate(engine, context, templateFile, outputFilename);
+			}
 
 			// start a new file
 			outputFilename = line.substring(1, line.length() - 1);
@@ -264,7 +272,9 @@ def translate(templateSubdirectory, templateFile, translationsFile) {
 	reader.close();
 
 	// process the template
-	processTemplate(engine, context, templateFile, outputFilename);
+	if (outputFilename != null && mtime >= new java.io.File(outputDirectory, outputFilename).lastModified()) {
+		processTemplate(engine, context, templateFile, outputFilename);
+	}
 }
 
 /* Recursively translates all templates in the given directory. */

--- a/src/test/java/net/imagej/ops/benchmark/AbstractOpBenchmark.java
+++ b/src/test/java/net/imagej/ops/benchmark/AbstractOpBenchmark.java
@@ -30,14 +30,23 @@
 
 package net.imagej.ops.benchmark;
 
+import static org.junit.Assume.assumeTrue;
 import net.imagej.ops.AbstractOpTest;
 
+import org.junit.Before;
 import org.scijava.module.Module;
 
 /**
  * @author Christian Dietz
  */
 public class AbstractOpBenchmark extends AbstractOpTest {
+
+	private boolean benchmarkTestsEnabled = "enabled".equals(System.getProperty("imagej.ops.benchmark.tests"));
+
+	@Before
+	public void skipBenchmarksByDefault() {
+		assumeTrue(benchmarkTestsEnabled);
+	}
 
 	public long bestOf(final Runnable runnable, final int n) {
 		long best = Long.MAX_VALUE;


### PR DESCRIPTION
In particular with a highly active developer community such as ImageJ OPS', it is highly desirable to make it possible to build and test the code as quick as possible.

To this end, be cleverer with the auto-generation of the code and also skip the benchmark tests by default.