### PR TITLE
Start implementing an expression parser

### DIFF
--- a/src/main/java/net/imagej/oops/Constant.java
+++ b/src/main/java/net/imagej/oops/Constant.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.oops;
+
+import java.util.Map;
+
+/**
+ * An {@link Expression} representing a constant.
+ *
+ * @author Johannes Schindelin
+ */
+public class Constant implements Expression {
+
+	private final Object value;
+
+	public Constant(final Object value) {
+		this.value = value;
+	}
+
+	@Override
+	public String[] getVariableNames() {
+		return new String[0];
+	}
+
+	@Override
+	public void bind(final Map<String, Object> args) {
+		// nothing to do; please move along
+	}
+
+	@Override
+	public Object eval() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return "" + value;
+	}
+}

--- a/src/main/java/net/imagej/oops/Expression.java
+++ b/src/main/java/net/imagej/oops/Expression.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.oops;
+
+import java.util.Map;
+
+/**
+ * Interface for parsed expression.
+ * <p>
+ * The common flow for parsed expressions is to bind variables and then evaluate
+ * the expression. To make it easier to use, every expression is required to be
+ * able to provide the names of the variables to bind before evaluating the
+ * expression.
+ * </p>
+ * 
+ * @author Johannes Schindelin
+ */
+public interface Expression {
+
+	/**
+	 * Obtain a list of the variable names in use by this expression.
+	 * 
+	 * @return the list of variable names, in order of use
+	 */
+	String[] getVariableNames();
+
+	/**
+	 * Bind values for the variables.
+	 * 
+	 * @param args a map of the variables' values
+	 */
+	void bind(Map<String, Object> args);
+
+	/**
+	 * Evaluate the expression.
+	 * 
+	 * @return the result of the expression with the most recently bound variable
+	 *         values
+	 */
+	Object eval();
+
+}

--- a/src/main/java/net/imagej/oops/ExpressionParser.java
+++ b/src/main/java/net/imagej/oops/ExpressionParser.java
@@ -1,0 +1,191 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.oops;
+
+import static java.lang.Character.isDigit;
+import static java.lang.Character.isJavaIdentifierPart;
+import static java.lang.Character.isWhitespace;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.MathOps.Add;
+import net.imagej.ops.MathOps.Divide;
+import net.imagej.ops.MathOps.Multiply;
+import net.imagej.ops.MathOps.Subtract;
+import net.imagej.ops.OpService;
+
+/**
+ * A parser accepting an expression as a {@link String} and returning an
+ * {@link Expression} ready to be bound and evaluated.
+ *
+ * @author Johannes Schindelin
+ */
+public class ExpressionParser {
+
+	private final OpService op;
+	private char[] array;
+	private int index;
+
+	public ExpressionParser(final OpService op) {
+		this.op = op;
+	}
+
+	public synchronized Expression parse(final String expression) {
+		array = expression.toCharArray();
+		if (array.length == 0) {
+			throw new IllegalArgumentException("Empty expression");
+		}
+		index = 0;
+		final Expression result = parseArithmetic();
+		if (index != array.length) {
+			throw new IllegalArgumentException("Invalid expression, ends in '" +
+				new String(array, index, array.length - index));
+		}
+		return result;
+	}
+
+	private Expression parseArithmetic() {
+		Expression expr = parseOne();
+		while (index < array.length) {
+			skipWhitespace();
+
+			final char c = array[index++];
+
+			if (c == '+' || c == '-') {
+				final List<Expression> args = new ArrayList<Expression>();
+				args.add(expr);
+				args.add(parseArithmetic());
+				return new OpExpression(op, c == '+' ? Add.NAME : Subtract.NAME,
+					args);
+			}
+			if (c == '*' || c == '/') {
+				final List<Expression> args = new ArrayList<Expression>();
+				args.add(expr);
+				args.add(parseOne());
+				expr =
+					new OpExpression(op, c == '*' ? Multiply.NAME : Divide.NAME, args);
+				continue;
+			}
+			index--;
+			break;
+		}
+		return expr;
+	}
+
+	private Expression parseOne() {
+		skipWhitespace();
+
+		char c = array[index++];
+
+		final int start = index - 1;
+
+		if (c == '(') {
+			final Expression expr = parseArithmetic();
+			if (index >= array.length || array[index++] != ')') {
+				throw new IllegalArgumentException("Incomplete expression: " +
+					new String(array, start, index - start));
+			}
+			return expr;
+		}
+
+		if (isDigit(c)) {
+			boolean dot = false;
+			while (index < array.length) {
+				c = array[index];
+				if (c == '.') {
+					if (dot) {
+						throw new IllegalArgumentException("Invalid number: " +
+							new String(array, start, index - start));
+					}
+					dot = true;
+					continue;
+				}
+				if (!isDigit(c)) {
+					break;
+				}
+				index++;
+			}
+			final String value = new String(array, start, index - start);
+			if (dot) {
+				return new Constant(Double.parseDouble(value));
+			}
+			return new Constant(Long.parseLong(value));
+		}
+
+		if (isJavaIdentifierPart(c)) {
+			while (index < array.length) {
+				if (!isJavaIdentifierPart(array[index])) {
+					break;
+				}
+				index++;
+			}
+			final String identifier = new String(array, start, index - start);
+			skipWhitespace();
+			if (index >= array.length || array[index] != '(') {
+				return new Variable(identifier);
+			}
+
+			if (++index >= array.length) {
+				throw new IllegalArgumentException("Unterminated op: " +
+					new String(array, start, index - start));
+			}
+			final List<Expression> args = new ArrayList<Expression>();
+			for (;;) {
+				final int startArg = index;
+				args.add(parseOne());
+				skipWhitespace();
+				if (index >= array.length) {
+					throw new IllegalArgumentException("Unterminated op: " +
+						new String(array, start, index - start));
+				}
+				c = array[index++];
+				if (c == ')') {
+					return new OpExpression(op, identifier, args);
+				}
+				if (c != ',') {
+					throw new IllegalArgumentException("Unrecognized arg: " +
+						new String(array, startArg, index - startArg));
+				}
+			}
+		}
+
+		throw new IllegalArgumentException("Invalid identifier/constant: " +
+			new String(array, index, array.length - index));
+	}
+
+	private void skipWhitespace() {
+		while (index < array.length && isWhitespace(array[index])) {
+			index++;
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/oops/OOps.java
+++ b/src/main/java/net/imagej/oops/OOps.java
@@ -46,6 +46,27 @@ import org.scijava.script.ScriptService;
  */
 public class OOps {
 
+	private static OpService op;
+
+	private synchronized static OpService op() {
+		if (op == null) {
+			op = new Context(OpService.class, ScriptService.class).getService(OpService.class);
+		}
+		return op;
+	}
+
+	/**
+	 * Parse and evaluate the given expression using an implicit {@link OpService}.
+	 * 
+	 * @param expression the expression to evaluate
+	 * @param args the variables on which to evaluate the expression
+	 * @return the result of the evaluated expression
+	 */
+	public static Object eval(final String expression, final Object... args)
+	{
+		return eval(op(), expression, args);
+	}
+
 	/**
 	 * Parse and evaluate the given expression using the specified {@link OpService}.
 	 * 

--- a/src/main/java/net/imagej/oops/OOps.java
+++ b/src/main/java/net/imagej/oops/OOps.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.oops;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
+
+import org.scijava.Context;
+import org.scijava.script.ScriptService;
+
+/**
+ * Convenience functions for working with optimized {@link Op}s.
+ *
+ * @author Johannes Schindelin
+ */
+public class OOps {
+
+	/**
+	 * Parse and evaluate the given expression using the specified {@link OpService}.
+	 * 
+	 * @param op the {@link OpService}
+	 * @param expression the expression to evaluate
+	 * @param args the variables on which to evaluate the expression
+	 * @return the result of the evaluated expression
+	 */
+	public static Object eval(final OpService op, final String expression,
+		final Object... args)
+	{
+		final Expression expr = parse(op, expression);
+		final String[] variableNames = expr.getVariableNames();
+		if (variableNames.length != args.length) {
+			throw new IllegalArgumentException("Expected " + variableNames.length +
+				" variables but got " + args.length);
+		}
+		final Map<String, Object> map =
+			new HashMap<String, Object>(variableNames.length);
+		for (int i = 0; i < args.length; i++) {
+			map.put(variableNames[i], args[i]);
+		}
+		expr.bind(map);
+		return expr.eval();
+	}
+
+	private static Expression parse(final OpService op, final String expression) {
+		return new ExpressionParser(op).parse(expression);
+	}
+
+}

--- a/src/main/java/net/imagej/oops/OpExpression.java
+++ b/src/main/java/net/imagej/oops/OpExpression.java
@@ -1,0 +1,108 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.oops;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
+
+/**
+ * An {@link Expression} representing an {@link Op}.
+ *
+ * @author Johannes Schindelin
+ */
+public class OpExpression implements Expression {
+
+	private final OpService op;
+	private final String identifier;
+	private final String[] variableNames;
+	private final List<Expression> args;
+	private final Object[] evaluated;
+
+	public OpExpression(final OpService op, final String identifier,
+		final List<Expression> args)
+	{
+		this.op = op;
+		this.identifier = identifier;
+		this.args = args;
+		evaluated = new Object[args.size()];
+
+		if (evaluated.length == 0) {
+			variableNames = new String[0];
+		}
+		else {
+			final Set<String> names = new LinkedHashSet<String>();
+			for (final Expression expr : args) {
+				for (final String name : expr.getVariableNames()) {
+					names.add(name);
+				}
+			}
+			variableNames = names.toArray(new String[names.size()]);
+		}
+	}
+
+	@Override
+	public String[] getVariableNames() {
+		return variableNames;
+	}
+
+	@Override
+	public void bind(final Map<String, Object> args) {
+		for (final Expression expr : this.args) {
+			expr.bind(args);
+		}
+	}
+
+	@Override
+	public Object eval() {
+		for (int i = 0; i < evaluated.length; i++) {
+			evaluated[i] = args.get(i).eval();
+		}
+		return op.run(identifier, evaluated);
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder builder = new StringBuilder();
+		builder.append(identifier).append('(');
+		String separator = "";
+		for (final Expression expr : args) {
+			builder.append(separator).append(expr);
+			separator = ", ";
+		}
+		builder.append(')');
+		return builder.toString();
+	}
+}

--- a/src/main/java/net/imagej/oops/Variable.java
+++ b/src/main/java/net/imagej/oops/Variable.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.oops;
+
+import java.util.Map;
+
+/**
+ * An {@link Expression} representing a single variable.
+ *
+ * @author Johannes Schindelin
+ */
+public class Variable implements Expression {
+
+	private final String[] variableNames;
+	private Object value;
+
+	public Variable(final String identifier) {
+		this.variableNames = new String[] { identifier };
+	}
+
+	@Override
+	public String[] getVariableNames() {
+		return variableNames;
+	}
+
+	@Override
+	public void bind(final Map<String, Object> args) {
+		value = args.get(variableNames[0]);
+	}
+
+	@Override
+	public Object eval() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return "<" + variableNames[0] + ">";
+	}
+}


### PR DESCRIPTION
Please do not merge this just yet.

A couple of things are left to do, still:
- [ ] ensure that  `"a+b"` does not modify `a` (the 2-parameter "math.add" op modifies the first parameter if it is an image; I think that is fine, but we should teach the expression parser to generate a temporary image and use the 3-parameter op)
- [x] add more operators and use the [Shunting yard algorithm](https://en.wikipedia.org/wiki/Shunting-yard_algorithm) to handle operator priorities (pointed out by @ctrueden)

A few more things need to be done, but they can be done in different Pull Requests (and by people other than myself :grinning:): optimize the temporary variable usage (i.e. reuse the temporary image in "a+b*c"), and add a way to generate new ops based on entire expression (sub-)trees using Javassist (one idea is to add a hook to the `ExpressionParser.bind(map)` method that reasons over arithmetic operations by inspecting `OpExpression`s: when the op name is e.g. "math.add" and the two parameters are either a `Variable` of type `PlanarImg` or `ArrayImg` with a primitive backing store, or a to-be-introduced `JavassistedOpExpression`, generate a new `JavassistedOpExpression` based on those parameters and execute that in `OpExpression#eval()` instead.

@tinevez the idea for this Pull Request is based heavily on your Image Expression Parser, thank you so much for that!

Even if this developer was not aware of #100, this Pull Request seems to address it!