### PR TITLE
Decon fixups

### DIFF
--- a/src/main/java/net/imagej/ops/convolve/ConvolveFFTImg.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveFFTImg.java
@@ -45,32 +45,34 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 
 /**
- * Convolve op for (@link Img) 
+ * Convolve op for (@link Img)
  * 
  * @author bnorthan
- *
  * @param <I>
  * @param <O>
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Op.class, name = Ops.Convolve.NAME, priority = Priority.VERY_HIGH_PRIORITY)
+@Plugin(type = Op.class, name = Ops.Convolve.NAME,
+	priority = Priority.VERY_HIGH_PRIORITY)
 public class ConvolveFFTImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends AbstractFFTFilterImg<I, O, K, C> implements Contingent {
+	extends AbstractFFTFilterImg<I, O, K, C> implements Contingent
+{
 
 	/**
 	 * run the filter (ConvolveFFTRAI) on the rais
 	 */
 	@Override
 	public void runFilter(RandomAccessibleInterval<I> raiExtendedInput,
-			RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
-			Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval) {
+		RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
+		Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval)
+	{
 
-		ops.run(ConvolveFFTRAI.class, raiExtendedInput, raiExtendedKernel,
-				fftImg, fftKernel, output);
+		ops.run(ConvolveFFTRAI.class, raiExtendedInput, raiExtendedKernel, fftImg,
+			fftKernel, output);
 
 	}
-	
+
 	@Override
 	public boolean conforms() {
 		// TODO: only conforms if the kernel is sufficiently large (else the

--- a/src/main/java/net/imagej/ops/convolve/ConvolveFFTRAI.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveFFTRAI.java
@@ -46,31 +46,30 @@ import net.imagej.ops.fft.filter.LinearFFTFilterRAI;
  * Convolve op for (@link RandomAccessibleInterval)
  * 
  * @author bnorthan
- *
  * @param <I>
  * @param <O>
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Op.class, name = Ops.Convolve.NAME, priority=Priority.HIGH_PRIORITY)
+@Plugin(type = Op.class, name = Ops.Convolve.NAME,
+	priority = Priority.HIGH_PRIORITY)
 public class ConvolveFFTRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends LinearFFTFilterRAI<I, O, K, C> {
-	
+	extends LinearFFTFilterRAI<I, O, K, C>
+{
+
 	/**
-	 * Perform convolution by multiplying the FFTs in the frequency domain
-	 * 
-	 * TODO use an op here??
+	 * Perform convolution by multiplying the FFTs in the frequency domain TODO
+	 * use an op here??
 	 */
 	protected void frequencyOperation(Img<C> a, Img<C> b) {
 		final Cursor<C> cursorA = a.cursor();
 		final Cursor<C> cursorB = b.cursor();
-		
-		while ( cursorA.hasNext() )
-		{
+
+		while (cursorA.hasNext()) {
 			cursorA.fwd();
 			cursorB.fwd();
-		
-			cursorA.get().mul( cursorB.get() );
+
+			cursorA.get().mul(cursorB.get());
 		}
 	}
 }

--- a/src/main/java/net/imagej/ops/convolve/CorrelateFFTImg.java
+++ b/src/main/java/net/imagej/ops/convolve/CorrelateFFTImg.java
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.convolve;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops;
+import net.imagej.ops.fft.filter.AbstractFFTFilterImg;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
+
+/**
+ * Correlate op for (@link Img) 
+ * 
+ * @author bnorthan
+ *
+ * @param <I>
+ * @param <O>
+ * @param <K>
+ * @param <C>
+ */
+@Plugin(type = Op.class, name = Ops.Correlate.NAME, priority = Priority.VERY_HIGH_PRIORITY)
+public class CorrelateFFTImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		extends AbstractFFTFilterImg<I, O, K, C> implements Contingent {
+
+	/**
+	 * run the filter (CorrelateFFTRAI) on the rais
+	 */
+	@Override
+	public void runFilter(RandomAccessibleInterval<I> raiExtendedInput,
+			RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
+			Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval) {
+
+		ops.run(CorrelateFFTRAI.class, raiExtendedInput, raiExtendedKernel,
+				fftImg, fftKernel, output);
+
+	}
+	
+	@Override
+	public boolean conforms() {
+		// TODO: only conforms if the kernel is sufficiently large (else the
+		// naive approach should be used) -> what is a good heuristic??
+		return Intervals.numElements(kernel) > 9;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/convolve/CorrelateFFTRAI.java
+++ b/src/main/java/net/imagej/ops/convolve/CorrelateFFTRAI.java
@@ -44,7 +44,6 @@ import net.imagej.ops.fft.filter.LinearFFTFilterRAI;
  * Correlate op for (@link RandomAccessibleInterval)
  * 
  * @author bnorthan
- * 
  * @param <I>
  * @param <O>
  * @param <K>
@@ -52,13 +51,12 @@ import net.imagej.ops.fft.filter.LinearFFTFilterRAI;
  */
 @Plugin(type = Op.class)
 public class CorrelateFFTRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends LinearFFTFilterRAI<I, O, K, C> {
+	extends LinearFFTFilterRAI<I, O, K, C>
+{
 
 	/**
 	 * Perform correlation by conjugate multiplying the FFTs in the frequency
-	 * domain
-	 * 
-	 * TODO use an op here??
+	 * domain TODO use an op here??
 	 */
 	protected void frequencyOperation(Img<C> a, Img<C> b) {
 		final Cursor<C> cursorA = a.cursor();

--- a/src/main/java/net/imagej/ops/convolve/CorrelateFFTRAI.java
+++ b/src/main/java/net/imagej/ops/convolve/CorrelateFFTRAI.java
@@ -70,7 +70,7 @@ public class CorrelateFFTRAI<I extends RealType<I>, O extends RealType<O>, K ext
 			temp.set(cursorB.get());
 			temp.complexConjugate();
 
-			cursorA.get().mul(cursorB.get());
+			cursorA.get().mul(temp);
 		}
 	}
 }

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyImg.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyImg.java
@@ -35,7 +35,8 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import net.imagej.ops.Op;
-import net.imagej.ops.Ops;
+import net.imagej.ops.DeconvolveOps;
+
 import net.imagej.ops.fft.filter.AbstractFFTFilterImg;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
@@ -52,7 +53,7 @@ import net.imglib2.type.numeric.RealType;
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Op.class, name = Ops.Deconvolve.NAME,
+@Plugin(type = Op.class, name = DeconvolveOps.RichardsonLucy.NAME,
 	priority = Priority.HIGH_PRIORITY)
 public class RichardsonLucyImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends AbstractFFTFilterImg<I, O, K, C>

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyImg.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyImg.java
@@ -47,20 +47,21 @@ import net.imglib2.type.numeric.RealType;
  * Richardson Lucy op that operates on (@link Img)
  * 
  * @author bnorthan
- *
  * @param <I>
  * @param <O>
  * @param <K>
- * @param <C> 
+ * @param <C>
  */
-@Plugin(type = Op.class, name = Ops.Deconvolve.NAME, priority = Priority.HIGH_PRIORITY)
+@Plugin(type = Op.class, name = Ops.Deconvolve.NAME,
+	priority = Priority.HIGH_PRIORITY)
 public class RichardsonLucyImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends AbstractFFTFilterImg<I, O, K, C> {
-	
+	extends AbstractFFTFilterImg<I, O, K, C>
+{
+
 	/**
 	 * max number of iterations
 	 */
-	@Parameter 
+	@Parameter
 	int maxIterations;
 
 	/**
@@ -68,12 +69,13 @@ public class RichardsonLucyImg<I extends RealType<I>, O extends RealType<O>, K e
 	 */
 	@Override
 	public void runFilter(RandomAccessibleInterval<I> raiExtendedInput,
-			RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
-			Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval) {
+		RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
+		Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval)
+	{
 
 		ops.run(RichardsonLucyRAI.class, raiExtendedInput, raiExtendedKernel,
-				fftImg, fftKernel, output, true, true, maxIterations,
-				imgConvolutionInterval, output.factory());
+			fftImg, fftKernel, output, true, true, maxIterations,
+			imgConvolutionInterval, output.factory());
 
 	}
 }

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
@@ -67,22 +67,21 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	@Override
 	protected void performIteration() {
 
-		// 1. Reblurred will have allready been created in previous iteration
+		// 1. Create Reblurred (this step will have already been done from the
+		// previous iteration in order to calculate error stats)
 
 		// 2. divide observed image by reblurred
 		inPlaceDivide(raiExtendedReblurred, raiExtendedInput);
 
 		// 3. correlate psf with the output of step 2.
 		ops.run(CorrelateFFTRAI.class, raiExtendedReblurred, null, fftInput,
-			fftKernel, reblurred, true, false);
+			fftKernel, raiExtendedReblurred, true, false);
 
 		// compute estimate -
 		// for standard RL this step will multiply output of correlation step
 		// and current estimate
 		// (Note: ComputeEstimate can be overridden to achieve regularization)
 		ComputeEstimate();
-
-		inPlaceMultiply(output, reblurred);
 
 		// TODO
 		// normalize for non-circulant deconvolution
@@ -134,7 +133,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	}
 
 	public void ComputeEstimate() {
-		inPlaceMultiply(output, reblurred);
+		inPlaceMultiply(raiExtendedEstimate, raiExtendedReblurred);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
@@ -89,7 +89,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	}
 
 	// TODO: replace this function with divide op
-	void inPlaceDivide(RandomAccessibleInterval<O> denominatorOutput,
+	protected void inPlaceDivide(RandomAccessibleInterval<O> denominatorOutput,
 		RandomAccessibleInterval<I> numerator)
 	{
 
@@ -117,7 +117,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	}
 
 	// TODO replace with op
-	void inPlaceMultiply(RandomAccessibleInterval<O> inputOutput,
+	protected void inPlaceMultiply(RandomAccessibleInterval<O> inputOutput,
 		RandomAccessibleInterval<O> input)
 	{
 

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
@@ -48,15 +48,16 @@ import net.imagej.ops.fft.filter.IterativeFFTFilterRAI;
  * Richardson Lucy op that operates on (@link RandomAccessibleInterval)
  * 
  * @author bnorthan
- * 
  * @param <I>
  * @param <O>
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Op.class, name = Ops.Deconvolve.NAME, priority = Priority.HIGH_PRIORITY)
+@Plugin(type = Op.class, name = Ops.Deconvolve.NAME,
+	priority = Priority.HIGH_PRIORITY)
 public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends IterativeFFTFilterRAI<I, O, K, C> {
+	extends IterativeFFTFilterRAI<I, O, K, C>
+{
 
 	/**
 	 * performs one iteration of the Richardson Lucy Algorithm (Lucy, L. B.
@@ -73,7 +74,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 
 		// 3. correlate psf with the output of step 2.
 		ops.run(CorrelateFFTRAI.class, raiExtendedReblurred, null, fftInput,
-				fftKernel, reblurred, true, false);
+			fftKernel, reblurred, true, false);
 
 		// compute estimate -
 		// for standard RL this step will multiply output of correlation step
@@ -82,7 +83,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 		ComputeEstimate();
 
 		inPlaceMultiply(output, reblurred);
-		
+
 		// TODO
 		// normalize for non-circulant deconvolution
 
@@ -90,10 +91,11 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 
 	// TODO: replace this function with divide op
 	void inPlaceDivide(RandomAccessibleInterval<O> denominatorOutput,
-			RandomAccessibleInterval<I> numerator) {
+		RandomAccessibleInterval<I> numerator)
+	{
 
-		final Cursor<O> cursorDenominatorOutput = Views.iterable(
-				denominatorOutput).cursor();
+		final Cursor<O> cursorDenominatorOutput =
+			Views.iterable(denominatorOutput).cursor();
 		final Cursor<I> cursorNumerator = Views.iterable(numerator).cursor();
 
 		while (cursorDenominatorOutput.hasNext()) {
@@ -106,7 +108,8 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 
 			if (div > 0) {
 				res = num / div;
-			} else {
+			}
+			else {
 				res = 0;
 			}
 
@@ -116,10 +119,10 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 
 	// TODO replace with op
 	void inPlaceMultiply(RandomAccessibleInterval<O> inputOutput,
-			RandomAccessibleInterval<O> input) {
+		RandomAccessibleInterval<O> input)
+	{
 
-		final Cursor<O> cursorInputOutput = Views.iterable(inputOutput)
-				.cursor();
+		final Cursor<O> cursorInputOutput = Views.iterable(inputOutput).cursor();
 		final Cursor<O> cursorInput = Views.iterable(input).cursor();
 
 		while (cursorInputOutput.hasNext()) {

--- a/src/main/java/net/imagej/ops/fft/AbstractFFTIterable.java
+++ b/src/main/java/net/imagej/ops/fft/AbstractFFTIterable.java
@@ -37,14 +37,14 @@ import org.scijava.plugin.Parameter;
 
 /**
  * Abstract superclass for forward fft implementations.
- *
+ * 
  * @author Brian Northan
  */
 public abstract class AbstractFFTIterable<C, T, I extends Iterable<C>, O extends Iterable<T>>
-	extends AbstractOutputFunction<I, O> 
+	extends AbstractOutputFunction<I, O>
 {
 
 	@Parameter
 	protected OpService ops;
-	
+
 }

--- a/src/main/java/net/imagej/ops/fft/AbstractIFFTIterable.java
+++ b/src/main/java/net/imagej/ops/fft/AbstractIFFTIterable.java
@@ -37,14 +37,14 @@ import org.scijava.plugin.Parameter;
 
 /**
  * Abstract superclass for inverse fft implementations.
- *
+ * 
  * @author Brian Northan
  */
 public abstract class AbstractIFFTIterable<T, C, I extends Iterable<T>, O extends Iterable<C>>
-	extends AbstractStrictFunction<I, O> 
+	extends AbstractStrictFunction<I, O>
 {
 
 	@Parameter
 	protected OpService ops;
-	
+
 }

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterImg.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterImg.java
@@ -166,7 +166,8 @@ public abstract class AbstractFFTFilterImg<I extends RealType<I>, O extends Real
 	}
 
 	/**
-	 * This function is called after the rais and ffts are set up and implements a frequency filter.  
+	 * This function is called after the rais and ffts are set up and implements a
+	 * frequency filter.
 	 * 
 	 * @param raiExtendedInput
 	 * @param raiExtendedKernel

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterRAI.java
@@ -43,14 +43,14 @@ import net.imglib2.type.numeric.RealType;
  * Abstract class for FFT based filters that operate on RAI
  * 
  * @author bnorthan
- * 
  * @param <I>
  * @param <O>
  * @param <K>
  * @param <C>
  */
 public abstract class AbstractFFTFilterRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		implements Op {
+	implements Op
+{
 
 	@Parameter
 	protected OpService ops;
@@ -69,15 +69,15 @@ public abstract class AbstractFFTFilterRAI<I extends RealType<I>, O extends Real
 	protected RandomAccessibleInterval<K> raiExtendedKernel;
 
 	/**
-	 * Img to be used to store FFTs for input. Size of fftInput must correspond
-	 * to the fft size of raiExtendedInput
+	 * Img to be used to store FFTs for input. Size of fftInput must correspond to
+	 * the fft size of raiExtendedInput
 	 */
 	@Parameter(required = false)
 	protected Img<C> fftInput;
 
 	/**
-	 * Img to be used to store FFTs for kernel. Size of fftKernel must
-	 * correspond to the fft size of raiExtendedKernel
+	 * Img to be used to store FFTs for kernel. Size of fftKernel must correspond
+	 * to the fft size of raiExtendedKernel
 	 */
 	@Parameter(required = false)
 	protected Img<C> fftKernel;

--- a/src/main/java/net/imagej/ops/fft/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/IterativeFFTFilterRAI.java
@@ -51,27 +51,27 @@ import net.imglib2.view.Views;
  * Abstract class for iterative FFT filters that perform on RAI
  * 
  * @author bnorthan
- *
  * @param <I>
  * @param <O>
  * @param <K>
  * @param <C>
  */
 public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends AbstractFFTFilterRAI<I, O, K, C> {
+	extends AbstractFFTFilterRAI<I, O, K, C>
+{
 
 	@Parameter
 	protected OpService ops;
-	
+
 	/**
 	 * Max number of iterations to perform
 	 */
-	@Parameter 
+	@Parameter
 	protected int maxIterations;
-	
+
 	@Parameter
 	protected Interval imgConvolutionInterval;
-	
+
 	@Parameter
 	protected ImgFactory<O> imgFactory;
 
@@ -83,9 +83,8 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 	protected RandomAccessibleInterval<O> raiExtendedEstimate;
 
 	protected Img<C> fftRoving;
-	
+
 	protected Img<O> reblurred;
-	
 
 	@Override
 	public void run() {
@@ -101,26 +100,27 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 	 */
 	protected void initialize() {
 
-		// if no output out of bounds factory exists create it 
+		// if no output out of bounds factory exists create it
 		if (obfOutput == null) {
-			obfOutput = new OutOfBoundsConstantValueFactory<O, RandomAccessibleInterval<O>>(
+			obfOutput =
+				new OutOfBoundsConstantValueFactory<O, RandomAccessibleInterval<O>>(
 					Util.getTypeFromInterval(output).createVariable());
 		}
-		
 
-		Type<O> outType=Util.getTypeFromInterval(output);
-		
+		Type<O> outType = Util.getTypeFromInterval(output);
+
 		// create image for the reblurred
-		reblurred=imgFactory.create(output, outType.createVariable());
+		reblurred = imgFactory.create(output, outType.createVariable());
 
-		// TODO: review this step 
+		// TODO: review this step
 		// extend the output and use it as a buffer to store the estimate
-		raiExtendedEstimate = Views.interval(Views.extend(output, obfOutput),
-				imgConvolutionInterval);
+		raiExtendedEstimate =
+			Views.interval(Views.extend(output, obfOutput), imgConvolutionInterval);
 
 		// assemble the extended view of the reblurred
-		raiExtendedReblurred = Views.interval(Views.extend(reblurred, obfOutput),
-				imgConvolutionInterval);
+		raiExtendedReblurred =
+			Views
+				.interval(Views.extend(reblurred, obfOutput), imgConvolutionInterval);
 
 		// perform fft of input
 		ops.run("fft", fftInput, raiExtendedInput);
@@ -137,9 +137,9 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 			c.fwd();
 			c.get().setReal(1.0f);
 		}
-		
+
 		createReblurred();
-		
+
 		// TODO: code for edge handling scheme
 	}
 
@@ -149,11 +149,11 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 			createReblurred();
 		}
 	}
-	
+
 	protected void createReblurred() {
 		// perform convolution -- kernel FFT should allready exist
-		ops.run(ConvolveFFTRAI.class, raiExtendedEstimate, null,
-				fftInput, fftKernel, reblurred, true, false);
+		ops.run(ConvolveFFTRAI.class, raiExtendedEstimate, null, fftInput,
+			fftKernel, reblurred, true, false);
 	}
 
 	abstract protected void performIteration();

--- a/src/main/java/net/imagej/ops/fft/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/IterativeFFTFilterRAI.java
@@ -130,12 +130,14 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 		// set first guess of estimate
 		// TODO: implement logic for various first guesses.
-		// for now just set to constant value
+		// for now just set to original image
 		Cursor<O> c = Views.iterable(raiExtendedEstimate).cursor();
+		Cursor<I> cIn = Views.iterable(raiExtendedInput).cursor();
 
 		while (c.hasNext()) {
 			c.fwd();
-			c.get().setReal(1.0f);
+			cIn.fwd();
+			c.get().setReal(cIn.get().getRealFloat());
 		}
 
 		createReblurred();
@@ -152,8 +154,8 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 	protected void createReblurred() {
 		// perform convolution -- kernel FFT should allready exist
-		ops.run(ConvolveFFTRAI.class, raiExtendedEstimate, null, fftInput,
-			fftKernel, reblurred, true, false);
+		ops.run(ConvolveFFTRAI.class, raiExtendedEstimate, null,
+				fftInput, fftKernel, raiExtendedReblurred, true, false);
 	}
 
 	abstract protected void performIteration();

--- a/src/main/java/net/imagej/ops/fft/image/AbstractFFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/AbstractFFTImg.java
@@ -45,7 +45,8 @@ import net.imglib2.outofbounds.OutOfBoundsFactory;
  * @author Brian Northan
  */
 public abstract class AbstractFFTImg<T, I extends Img<T>, C, O extends Img<C>>
-		extends AbstractFFTIterable<T, C, I, O> implements FFT {
+	extends AbstractFFTIterable<T, C, I, O> implements FFT
+{
 
 	/**
 	 * size of border to apply in each dimension
@@ -93,7 +94,8 @@ public abstract class AbstractFFTImg<T, I extends Img<T>, C, O extends Img<C>>
 
 		if (fast) {
 			computeFFTFastSize(inputSize);
-		} else {
+		}
+		else {
 			computeFFTSmallSize(inputSize);
 		}
 

--- a/src/main/java/net/imagej/ops/fft/image/AbstractIFFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/AbstractIFFTImg.java
@@ -36,7 +36,7 @@ import net.imglib2.img.Img;
 
 /**
  * Abstract superclass for inverse fft implementations that operate on Img<C>.
- *
+ * 
  * @author Brian Northan
  */
 public abstract class AbstractIFFTImg<C, I extends Img<C>, T, O extends Img<T>>

--- a/src/main/java/net/imagej/ops/fft/image/FFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/FFTImg.java
@@ -51,7 +51,8 @@ import net.imagej.ops.fft.size.ComputeFFTSize;
  */
 @Plugin(type = FFT.class, name = FFT.NAME, priority = Priority.HIGH_PRIORITY)
 public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
-		AbstractFFTImg<T, I, ComplexFloatType, Img<ComplexFloatType>> {
+	AbstractFFTImg<T, I, ComplexFloatType, Img<ComplexFloatType>>
+{
 
 	@Override
 	protected void computeFFTFastSize(long[] inputSize) {
@@ -59,8 +60,7 @@ public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
 		paddedSize = new long[inputSize.length];
 		fftSize = new long[inputSize.length];
 
-		ops.run(ComputeFFTSize.class, inputSize, paddedSize, fftSize, true,
-				true);
+		ops.run(ComputeFFTSize.class, inputSize, paddedSize, fftSize, true, true);
 
 	}
 
@@ -70,18 +70,18 @@ public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
 		paddedSize = new long[inputSize.length];
 		fftSize = new long[inputSize.length];
 
-		ops.run(ComputeFFTSize.class, inputSize, paddedSize, fftSize, true,
-				false);
+		ops.run(ComputeFFTSize.class, inputSize, paddedSize, fftSize, true, false);
 
 	}
 
 	@Override
 	protected Img<ComplexFloatType> createFFTImg(ImgFactory<T> factory,
-			long[] size) {
+		long[] size)
+	{
 
 		try {
 			return factory.imgFactory(new ComplexFloatType()).create(size,
-					new ComplexFloatType());
+				new ComplexFloatType());
 		}
 		// TODO: error handling?
 		catch (IncompatibleTypeException e) {
@@ -90,8 +90,9 @@ public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
 	}
 
 	@Override
-	public Img<ComplexFloatType> safeCompute(I input,
-			Img<ComplexFloatType> output) {
+	public Img<ComplexFloatType>
+		safeCompute(I input, Img<ComplexFloatType> output)
+	{
 
 		ops.run(FFTRAI.class, output, input, obf, paddedSize);
 

--- a/src/main/java/net/imagej/ops/fft/image/IFFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/IFFTImg.java
@@ -47,14 +47,13 @@ import net.imglib2.type.numeric.complex.ComplexFloatType;
  * Inverse FFT op implemented by wrapping FFTMethods.
  * 
  * @author Brian Northan
- * 
  * @param <T>
  * @param <I>
  */
 @Plugin(type = IFFT.class, name = IFFT.NAME, priority = Priority.HIGH_PRIORITY)
-public class IFFTImg<T extends RealType<T>, O extends Img<T>>
-		extends
-		AbstractIFFTImg<ComplexFloatType, Img<ComplexFloatType>, T, O> {
+public class IFFTImg<T extends RealType<T>, O extends Img<T>> extends
+	AbstractIFFTImg<ComplexFloatType, Img<ComplexFloatType>, T, O>
+{
 
 	@Override
 	public O compute(Img<ComplexFloatType> input, O output) {

--- a/src/main/java/net/imagej/ops/fft/methods/FFTRAI.java
+++ b/src/main/java/net/imagej/ops/fft/methods/FFTRAI.java
@@ -52,18 +52,17 @@ import net.imglib2.view.Views;
 import net.imglib2.algorithm.fft2.FFTMethods;
 
 /**
- * 
  * Forward FFT that operates on an RAI and wraps FFTMethods.
  * 
  * @author Brian Northan
- * 
  * @param <T>
  * @param <C>
  */
 @Plugin(type = FFT.class, name = FFT.NAME, priority = Priority.HIGH_PRIORITY)
 public class FFTRAI<T extends RealType<T>, C extends ComplexType<C>>
-		extends
-		AbstractStrictFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<C>> {
+	extends
+	AbstractStrictFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<C>>
+{
 
 	/**
 	 * generates the out of bounds strategy for the extended area
@@ -74,9 +73,9 @@ public class FFTRAI<T extends RealType<T>, C extends ComplexType<C>>
 	@Parameter(required = false)
 	protected long[] paddedSize;
 
-	public RandomAccessibleInterval<C> compute(
-			RandomAccessibleInterval<T> input,
-			RandomAccessibleInterval<C> output) {
+	public RandomAccessibleInterval<C> compute(RandomAccessibleInterval<T> input,
+		RandomAccessibleInterval<C> output)
+	{
 
 		RandomAccessibleInterval<T> inputRAI;
 
@@ -93,23 +92,25 @@ public class FFTRAI<T extends RealType<T>, C extends ComplexType<C>>
 		if (!FFTMethods.dimensionsEqual(input, paddedSize)) {
 
 			if (obf == null) {
-				obf = new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(
+				obf =
+					new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(
 						Util.getTypeFromInterval(input).createVariable());
 			}
 
-			Interval inputInterval = FFTMethods.paddingIntervalCentered(input,
-					FinalDimensions.wrap(paddedSize));
+			Interval inputInterval =
+				FFTMethods.paddingIntervalCentered(input, FinalDimensions
+					.wrap(paddedSize));
 
 			inputRAI = Views.interval(Views.extend(input, obf), inputInterval);
 
-		} else {
+		}
+		else {
 			inputRAI = input;
 		}
 
 		// TODO: proper use of Executor service
 		final int numThreads = Runtime.getRuntime().availableProcessors();
-		final ExecutorService service = Executors
-				.newFixedThreadPool(numThreads);
+		final ExecutorService service = Executors.newFixedThreadPool(numThreads);
 
 		FFTMethods.realToComplex(inputRAI, output, 0, false, service);
 

--- a/src/main/java/net/imagej/ops/fft/methods/IFFTRAI.java
+++ b/src/main/java/net/imagej/ops/fft/methods/IFFTRAI.java
@@ -43,11 +43,9 @@ import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
 
 /**
- * 
  * Inverse fft that operates on an RAI and wraps FFTMethods.
  * 
  * @author Brian Northan
- *
  * @param <C>
  * @param <T>
  */
@@ -56,22 +54,20 @@ public class IFFTRAI<C extends ComplexType<C>, T extends RealType<T>>
 	extends
 	AbstractStrictFunction<RandomAccessibleInterval<C>, RandomAccessibleInterval<T>>
 {
-	
+
 	public RandomAccessibleInterval<T> compute(RandomAccessibleInterval<C> input,
 		RandomAccessibleInterval<T> output)
 	{
 		// TODO: proper use of Executor service
 		final int numThreads = Runtime.getRuntime().availableProcessors();
-		final ExecutorService service =
-			Executors.newFixedThreadPool(numThreads);
-		
+		final ExecutorService service = Executors.newFixedThreadPool(numThreads);
+
 		for (int d = input.numDimensions() - 1; d > 0; d--)
 			FFTMethods.complexToComplex(input, d, false, true, service);
-	
+
 		FFTMethods.complexToReal(input, output, FFTMethods
-					.unpaddingIntervalCentered(input, output), 0, true,
-					service);
-		
+			.unpaddingIntervalCentered(input, output), 0, true, service);
+
 		return output;
 	}
 }

--- a/src/main/java/net/imagej/ops/fft/size/ComputeFFTSize.java
+++ b/src/main/java/net/imagej/ops/fft/size/ComputeFFTSize.java
@@ -50,25 +50,21 @@ public class ComputeFFTSize extends AbstractFFTSize {
 
 		if (fast && forward) {
 
-			FFTMethods
-				.dimensionsRealToComplexFast(dim, paddedSize, fftSize);
+			FFTMethods.dimensionsRealToComplexFast(dim, paddedSize, fftSize);
 
 		}
 		else if (!fast && forward) {
-			FFTMethods.dimensionsRealToComplexSmall(dim, paddedSize,
-				fftSize);
+			FFTMethods.dimensionsRealToComplexSmall(dim, paddedSize, fftSize);
 
 		}
 		if (fast && !forward) {
 
-			FFTMethods
-				.dimensionsComplexToRealFast(dim, paddedSize, fftSize);
+			FFTMethods.dimensionsComplexToRealFast(dim, paddedSize, fftSize);
 
 		}
 		else if (!fast && !forward) {
 
-			FFTMethods.dimensionsComplexToRealSmall(dim, paddedSize,
-				fftSize);
+			FFTMethods.dimensionsComplexToRealSmall(dim, paddedSize, fftSize);
 
 		}
 	}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -7,6 +7,7 @@ ops = ```
 	[name: "chunker",     iface: "Chunker"],
 	[name: "convert",     iface: "Convert"],
 	[name: "convolve",    iface: "Convolve"],
+	[name: "correlate",    iface: "Correlate"],
 	[name: "createimg",   iface: "CreateImg"],
 	[name: "crop",        iface: "Crop",           aliases: ["slice"]],
 	[name: "deconvolve",  iface: "Deconvolve"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -165,3 +165,13 @@ ops = ```
 	[name: "yen",           iface: "Yen"]
 ]
 ```
+
+[DeconvolveOps.java]
+className = "DeconvolveOps"
+namespace = "deconvolve"
+authors = ["Brian Northan"]
+ops = ```
+[
+	[name: "richardsonlucy",         iface: "RichardsonLucy"]
+]
+```

--- a/src/test/java/net/imagej/ops/convolve/ConvolveTest.java
+++ b/src/test/java/net/imagej/ops/convolve/ConvolveTest.java
@@ -31,18 +31,13 @@
 package net.imagej.ops.convolve;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import net.imagej.ops.AbstractOpTest;
-import net.imagej.ops.AbstractOutputFunction;
-import net.imagej.ops.Op;
-import net.imagej.ops.fft.filter.AbstractFFTFilterImg;
 import net.imagej.ops.fft.filter.CreateFFTFilterMemory;
 import net.imglib2.Point;
 import net.imglib2.algorithm.region.hypersphere.HyperSphere;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.type.numeric.integer.ShortType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
 
@@ -57,12 +52,13 @@ public class ConvolveTest extends AbstractOpTest {
 	@Test
 	public void testConvolveMethodSelection() {
 
-		final Img<ByteType> in = new ArrayImgFactory<ByteType>().create(
-				new int[] { 20, 20 }, new ByteType());
+		final Img<ByteType> in =
+			new ArrayImgFactory<ByteType>().create(new int[] { 20, 20 },
+				new ByteType());
 		final Img<ByteType> out = in.copy();
 
 		// TODO: rework method selection based on new convolve classes
-		
+
 		// testing for a small kernel
 		/*Img<ByteType> kernel = new ArrayImgFactory<ByteType>().create(
 				new int[] { 3, 3 }, new ByteType());
@@ -77,23 +73,22 @@ public class ConvolveTest extends AbstractOpTest {
 
 	}
 
-
 	@Test
 	public void testConvolve() {
 
 		int[] size = new int[] { 225, 167 };
 		int[] kernelSize = new int[] { 27, 39 };
-		
-		long[] borderSize = new long[] {10, 10};
+
+		long[] borderSize = new long[] { 10, 10 };
 
 		// create an input with a small sphere at the center
-		Img<FloatType> in = new ArrayImgFactory<FloatType>().create(size,
-				new FloatType());
+		Img<FloatType> in =
+			new ArrayImgFactory<FloatType>().create(size, new FloatType());
 		placeSphereInCenter(in);
 
 		// create a kernel with a small sphere in the center
-		Img<FloatType> kernel = new ArrayImgFactory<FloatType>().create(
-				kernelSize, new FloatType());
+		Img<FloatType> kernel =
+			new ArrayImgFactory<FloatType>().create(kernelSize, new FloatType());
 		placeSphereInCenter(kernel);
 
 		// create variables to hold the image sums
@@ -108,30 +103,30 @@ public class ConvolveTest extends AbstractOpTest {
 		ops.run("sum", kernelSum, kernel);
 
 		// convolve and calculate the sum of output
-		Img<FloatType> out = (Img<FloatType>) ops.run("convolve", null, in, kernel, borderSize);
+		Img<FloatType> out =
+			(Img<FloatType>) ops.run("convolve", null, in, kernel, borderSize);
 
 		// create an output for the next test
-		Img<FloatType> out2 = new ArrayImgFactory<FloatType>().create(size,
-				new FloatType());
+		Img<FloatType> out2 =
+			new ArrayImgFactory<FloatType>().create(size, new FloatType());
 
 		// create an output for the next test
-		Img<FloatType> out3 = new ArrayImgFactory<FloatType>().create(size,
-				new FloatType());
+		Img<FloatType> out3 =
+			new ArrayImgFactory<FloatType>().create(size, new FloatType());
 
 		// this time create reusable fft memory first
-		CreateFFTFilterMemory<FloatType, FloatType, FloatType, ComplexFloatType> createMemory = ops
-				.op(CreateFFTFilterMemory.class, in, kernel);
+		CreateFFTFilterMemory<FloatType, FloatType, FloatType, ComplexFloatType> createMemory =
+			ops.op(CreateFFTFilterMemory.class, in, kernel);
 
 		createMemory.run();
 
 		// run convolve using the rai version with the memory created above
 		ops.run(ConvolveFFTRAI.class, createMemory.getRAIExtendedInput(),
-				createMemory.getRAIExtendedKernel(), createMemory.getFFTImg(),
-				createMemory.getFFTKernel(), out2);
+			createMemory.getRAIExtendedKernel(), createMemory.getFFTImg(),
+			createMemory.getFFTKernel(), out2);
 
 		ops.run(ConvolveFFTRAI.class, createMemory.getRAIExtendedInput(), null,
-				createMemory.getFFTImg(), createMemory.getFFTKernel(), out3,
-				true, false);
+			createMemory.getFFTImg(), createMemory.getFFTKernel(), out3, true, false);
 
 		ops.run("sum", outSum, out);
 		ops.run("sum", outSum2, out2);
@@ -142,10 +137,10 @@ public class ConvolveTest extends AbstractOpTest {
 		assertEquals(inSum, outSum);
 		assertEquals(inSum, outSum2);
 		assertEquals(inSum, outSum3);
-		
+
 		System.out.println(out.dimension(0));
 		System.out.println(out2.dimension(0));
-	
+
 	}
 
 	// utility to place a small sphere at the center of the image
@@ -156,8 +151,8 @@ public class ConvolveTest extends AbstractOpTest {
 		for (int d = 0; d < img.numDimensions(); d++)
 			center.setPosition(img.dimension(d) / 2, d);
 
-		HyperSphere<FloatType> hyperSphere = new HyperSphere<FloatType>(img,
-				center, 2);
+		HyperSphere<FloatType> hyperSphere =
+			new HyperSphere<FloatType>(img, center, 2);
 
 		for (final FloatType value : hyperSphere) {
 			value.setReal(1);

--- a/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
+++ b/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
@@ -64,7 +64,8 @@ public class DeconvolveTest extends AbstractOpTest {
 		Img<FloatType> convolved = (Img<FloatType>) ops.run("convolve", in, kernel);
 
 		Img<FloatType> deconvolved2 =
-			(Img<FloatType>) ops.run("deconvolve", convolved, kernel, 10);
+			(Img<FloatType>) ops.run("deconvolve.richardsonlucy", convolved, kernel,
+				10);
 
 	}
 

--- a/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
+++ b/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
@@ -51,21 +51,20 @@ public class DeconvolveTest extends AbstractOpTest {
 		int[] kernelSize = new int[] { 27, 39 };
 
 		// create an input with a small sphere at the center
-		Img<FloatType> in = new ArrayImgFactory<FloatType>().create(size,
-				new FloatType());
+		Img<FloatType> in =
+			new ArrayImgFactory<FloatType>().create(size, new FloatType());
 		placeSphereInCenter(in);
 
 		// create a kernel with a small sphere in the center
-		Img<FloatType> kernel = new ArrayImgFactory<FloatType>().create(
-				kernelSize, new FloatType());
+		Img<FloatType> kernel =
+			new ArrayImgFactory<FloatType>().create(kernelSize, new FloatType());
 		placeSphereInCenter(kernel);
 
 		// convolve and calculate the sum of output
-		Img<FloatType> convolved = (Img<FloatType>) ops.run("convolve", in,
-				kernel);
-		
-		Img<FloatType> deconvolved2 = (Img<FloatType>) ops.run("deconvolve",
-				convolved, kernel,10);
+		Img<FloatType> convolved = (Img<FloatType>) ops.run("convolve", in, kernel);
+
+		Img<FloatType> deconvolved2 =
+			(Img<FloatType>) ops.run("deconvolve", convolved, kernel, 10);
 
 	}
 
@@ -77,8 +76,8 @@ public class DeconvolveTest extends AbstractOpTest {
 		for (int d = 0; d < img.numDimensions(); d++)
 			center.setPosition(img.dimension(d) / 2, d);
 
-		HyperSphere<FloatType> hyperSphere = new HyperSphere<FloatType>(img,
-				center, 2);
+		HyperSphere<FloatType> hyperSphere =
+			new HyperSphere<FloatType>(img, center, 2);
 
 		for (final FloatType value : hyperSphere) {
 			value.setReal(1);


### PR DESCRIPTION
This pull request contains several format fixes, bug fixes and minor adjustments.   I can merge it myself but I will wait a couple of days in case anyone has any concerns or suggestions.  The only "non-decon/fft-related" file I changed was Ops.list.  (I can put the format fix in a separate pull request if necessary  The individual commits should be readable.)  

- fixed formatting on several files
- added a correlation op
- changed default first guess for RichardsonLucy algorithm to be consistent with DeconvolutionLab (todo: make first guess type a parameter)
- added a 'deconvolution' namespace in Ops.list

