### PR TITLE
Improve varargs matching

### DIFF
--- a/src/main/java/net/imagej/ops/OpRef.java
+++ b/src/main/java/net/imagej/ops/OpRef.java
@@ -105,6 +105,11 @@ public class OpRef<OP extends Op> {
 		return args;
 	}
 
+	/** Sets the op's arguments. */
+	public void setArgs(final Object[] args) {
+		this.args = args;
+	}
+
 	/** Gets a label identifying the op's scope (i.e., its type or name). */
 	public String getLabel() {
 		if (type != null) return type.getName();

--- a/src/test/java/net/imagej/ops/create/CreateImgTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgTest.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.create;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.OpService;
+import net.imglib2.img.Img;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link Img} creation.
+ *
+ * @author Mark Hiner
+ */
+public class CreateImgTest extends AbstractOpTest {
+
+	/**
+	 * Test {@link OpService#createimg(Object...)} by passing raw ints
+	 */
+	@Test
+	public void testCreateVarargs() {
+		final int width = 50;
+		final int height = 100;
+
+		Object o = ops.createimg(width, height);
+
+		assertTrue(o instanceof Img);
+
+		Img img = (Img) o;
+
+		assertEquals(width, img.dimension(0));
+		assertEquals(height, img.dimension(1));
+	}
+
+	/**
+	 * Test {@link OpService#createimg(Object...)} by passing an array of ints
+	 */
+	@Test
+	public void testCreate() {
+		int[] dims = {100, 50};
+
+		Object o = ops.createimg(dims);
+
+		assertTrue(o instanceof Img);
+
+		Img img = (Img) o;
+
+		assertEquals(dims[0], img.dimension(0));
+		assertEquals(dims[1], img.dimension(1));
+	}
+
+}


### PR DESCRIPTION
Add logic to handle the case where varargs may be split out into individual arguments, instead of aggregated in an array.