### PR TITLE
Naive convolution

### DIFF
--- a/src/main/java/net/imagej/ops/convolve/ConvolveFFTImg.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveFFTImg.java
@@ -54,7 +54,7 @@ import net.imglib2.util.Intervals;
  * @param <C>
  */
 @Plugin(type = Op.class, name = Ops.Convolve.NAME,
-	priority = Priority.VERY_HIGH_PRIORITY)
+	priority = Priority.HIGH_PRIORITY)
 public class ConvolveFFTImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends AbstractFFTFilterImg<I, O, K, C> implements Contingent
 {

--- a/src/main/java/net/imagej/ops/convolve/ConvolveFFTRAI.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveFFTRAI.java
@@ -52,7 +52,7 @@ import net.imagej.ops.fft.filter.LinearFFTFilterRAI;
  * @param <C>
  */
 @Plugin(type = Op.class, name = Ops.Convolve.NAME,
-	priority = Priority.HIGH_PRIORITY)
+	priority = Priority.LOW_PRIORITY)
 public class ConvolveFFTRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends LinearFFTFilterRAI<I, O, K, C>
 {

--- a/src/main/java/net/imagej/ops/convolve/ConvolveNaiveImg.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveNaiveImg.java
@@ -1,0 +1,95 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.convolve;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops;
+import net.imagej.ops.fft.filter.AbstractFilterImg;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Convolves an image naively (no FFTs).
+ */
+@Plugin(type = Op.class, name = Ops.Convolve.NAME,
+	priority = Priority.HIGH_PRIORITY)
+public class ConvolveNaiveImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
+	extends AbstractFilterImg<I, O, K> implements Contingent, Ops.Convolve
+{
+
+	protected Img<O> safeCompute(Img<I> img, Img<O> out) {
+
+		if (obfInput == null) {
+			obfInput =
+				new OutOfBoundsConstantValueFactory<I, RandomAccessibleInterval<I>>(
+					Util.getTypeFromInterval(img).createVariable());
+		}
+
+		if ((obfKernel == null) && (kernel != null)) {
+			obfKernel =
+				new OutOfBoundsConstantValueFactory<K, RandomAccessibleInterval<K>>(
+					Util.getTypeFromInterval(kernel).createVariable());
+		}
+
+		// extend the input
+		RandomAccessibleInterval<I> extendedIn =
+			Views.interval(Views.extend(img, obfInput), img);
+
+		OutOfBoundsFactory<O, RandomAccessibleInterval<O>> obfOutput =
+			new OutOfBoundsConstantValueFactory<O, RandomAccessibleInterval<O>>(Util
+				.getTypeFromInterval(out).createVariable());
+
+		// extend the output
+		RandomAccessibleInterval<O> extendedOut =
+			Views.interval(Views.extend(out, obfOutput), out);
+
+		ops.run(ConvolveNaive.class, extendedOut, extendedIn, kernel);
+
+		return out;
+	}
+
+	@Override
+	public boolean conforms() {
+		// conforms only if the kernel is sufficiently small
+		return Intervals.numElements(kernel) <= 9;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterImg.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterImg.java
@@ -32,19 +32,12 @@ package net.imagej.ops.fft.filter;
 
 import org.scijava.plugin.Parameter;
 
-import net.imagej.ops.AbstractOutputFunction;
-import net.imagej.ops.OpService;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
-import net.imglib2.img.planar.PlanarImgFactory;
-import net.imglib2.outofbounds.OutOfBoundsFactory;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Util;
 
 /**
  * Abstract class for FFT based filters that operate on Img.
@@ -56,47 +49,8 @@ import net.imglib2.util.Util;
  * @param <C>
  */
 public abstract class AbstractFFTFilterImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-	extends AbstractOutputFunction<Img<I>, Img<O>>
+	extends AbstractFilterImg<I, O, K>
 {
-
-	@Parameter
-	protected OpService ops;
-
-	/**
-	 * the kernel (psf)
-	 */
-	@Parameter
-	protected RandomAccessibleInterval<K> kernel;
-
-	/**
-	 * Border size in each dimensions. If null default border size will be added.
-	 */
-	@Parameter(required = false)
-	protected long[] borderSize = null;
-
-	/**
-	 * generates the out of bounds strategy for the extended area of the input
-	 */
-	@Parameter(required = false)
-	protected OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput;
-
-	/**
-	 * generates the out of bounds strategy for the extended area of the kernel
-	 */
-	@Parameter(required = false)
-	protected OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel;
-
-	/**
-	 * The output type. If null default output type will be used.
-	 */
-	@Parameter(required = false)
-	protected Type<O> outType;
-
-	/**
-	 * Factory to create output Img
-	 */
-	@Parameter(required = false)
-	protected ImgFactory<O> outFactory;
 
 	/**
 	 * FFT type
@@ -109,40 +63,6 @@ public abstract class AbstractFFTFilterImg<I extends RealType<I>, O extends Real
 	 */
 	@Parameter(required = false)
 	protected ImgFactory<C> fftFactory;
-
-	/**
-	 * Create the output using the outFactory and outType if they exist. If these
-	 * are null use a default factory and type
-	 */
-	@Override
-	public Img<O> createOutput(Img<I> input) {
-
-		// if the outType is null
-		if (outType == null) {
-
-			// if the input type and kernel type are the same use this type
-			if (input.firstElement().getClass() == Util.getTypeFromInterval(kernel)
-				.getClass())
-			{
-				Object temp = input.firstElement().createVariable();
-				outType = (Type<O>) temp;
-
-			}
-			// otherwise default to float
-			else {
-				Object temp = new FloatType();
-				outType = (Type<O>) temp;
-			}
-		}
-
-		// if the outFactory is null use a PlanarImgFactory to create the output
-		if (outFactory == null) {
-			Object temp = new PlanarImgFactory();
-			outFactory = (ImgFactory<O>) temp;
-		}
-
-		return outFactory.create(input, outType.createVariable());
-	}
 
 	/**
 	 * 

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFilterImg.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFilterImg.java
@@ -1,0 +1,133 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.fft.filter;
+
+import org.scijava.plugin.Parameter;
+
+import net.imagej.ops.AbstractOutputFunction;
+import net.imagej.ops.OpService;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Util;
+
+/**
+ * Abstract class for filters that operate on Img.
+ * 
+ * @author bnorthan
+ * @param <I>
+ * @param <O>
+ * @param <K>
+ * @param <C>
+ */
+public abstract class AbstractFilterImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
+	extends AbstractOutputFunction<Img<I>, Img<O>>
+{
+
+	@Parameter
+	protected OpService ops;
+
+	/**
+	 * the kernel (psf)
+	 */
+	@Parameter
+	protected RandomAccessibleInterval<K> kernel;
+
+	/**
+	 * Border size in each dimensions. If null default border size will be added.
+	 */
+	@Parameter(required = false)
+	protected long[] borderSize = null;
+
+	/**
+	 * generates the out of bounds strategy for the extended area of the input
+	 */
+	@Parameter(required = false)
+	protected OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput;
+
+	/**
+	 * generates the out of bounds strategy for the extended area of the kernel
+	 */
+	@Parameter(required = false)
+	protected OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel;
+
+	/**
+	 * The output type. If null default output type will be used.
+	 */
+	@Parameter(required = false)
+	protected Type<O> outType;
+
+	/**
+	 * Factory to create output Img
+	 */
+	@Parameter(required = false)
+	protected ImgFactory<O> outFactory;
+
+	/**
+	 * Create the output using the outFactory and outType if they exist. If these
+	 * are null use a default factory and type
+	 */
+	@Override
+	public Img<O> createOutput(Img<I> input) {
+
+		// if the outType is null
+		if (outType == null) {
+
+			// if the input type and kernel type are the same use this type
+			if (input.firstElement().getClass() == Util.getTypeFromInterval(kernel)
+				.getClass())
+			{
+				Object temp = input.firstElement().createVariable();
+				outType = (Type<O>) temp;
+
+			}
+			// otherwise default to float
+			else {
+				Object temp = new FloatType();
+				outType = (Type<O>) temp;
+			}
+		}
+
+		// if the outFactory is null use a PlanarImgFactory to create the output
+		if (outFactory == null) {
+			Object temp = new PlanarImgFactory();
+			outFactory = (ImgFactory<O>) temp;
+		}
+
+		return outFactory.create(input, outType.createVariable());
+	}
+
+}


### PR DESCRIPTION
@ctrueden, @dietzc - This pull request fixes the NaiveConvolution boundary problem mentioned in #98, and also mentioned on the [imagej-dev listserv](http://imagej.net/pipermail/imagej-devel/2015-April/thread.html).  Long term it could be helpful to use a common base class for efficient neighbourhood operations.   Let me know if anything along those lines all ready exists, and I will update this.    