### PR TITLE
Private fields and parameters

### DIFF
--- a/src/main/java/net/imagej/ops/convolve/ConvolveFFTImg.java
+++ b/src/main/java/net/imagej/ops/convolve/ConvolveFFTImg.java
@@ -32,6 +32,7 @@ package net.imagej.ops.convolve;
 
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.fft.filter.AbstractFFTFilterImg;
 import net.imglib2.Interval;
@@ -42,6 +43,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 
 import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -58,6 +60,9 @@ import org.scijava.plugin.Plugin;
 public class ConvolveFFTImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends AbstractFFTFilterImg<I, O, K, C> implements Contingent
 {
+
+	@Parameter
+	private OpService ops;
 
 	/**
 	 * run the filter (ConvolveFFTRAI) on the rais
@@ -77,7 +82,7 @@ public class ConvolveFFTImg<I extends RealType<I>, O extends RealType<O>, K exte
 	public boolean conforms() {
 		// TODO: only conforms if the kernel is sufficiently large (else the
 		// naive approach should be used) -> what is a good heuristic??
-		return Intervals.numElements(kernel) > 9;
+		return Intervals.numElements(getKernel()) > 9;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/convolve/CorrelateFFTImg.java
+++ b/src/main/java/net/imagej/ops/convolve/CorrelateFFTImg.java
@@ -32,6 +32,7 @@ package net.imagej.ops.convolve;
 
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.fft.filter.AbstractFFTFilterImg;
 import net.imglib2.Interval;
@@ -42,40 +43,46 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 
 import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Correlate op for (@link Img) 
+ * Correlate op for (@link Img)
  * 
  * @author bnorthan
- *
  * @param <I>
  * @param <O>
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Op.class, name = Ops.Correlate.NAME, priority = Priority.VERY_HIGH_PRIORITY)
+@Plugin(type = Op.class, name = Ops.Correlate.NAME,
+	priority = Priority.VERY_HIGH_PRIORITY)
 public class CorrelateFFTImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		extends AbstractFFTFilterImg<I, O, K, C> implements Contingent {
+	extends AbstractFFTFilterImg<I, O, K, C> implements Contingent
+{
+
+	@Parameter
+	private OpService ops;
 
 	/**
 	 * run the filter (CorrelateFFTRAI) on the rais
 	 */
 	@Override
 	public void runFilter(RandomAccessibleInterval<I> raiExtendedInput,
-			RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
-			Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval) {
+		RandomAccessibleInterval<K> raiExtendedKernel, Img<C> fftImg,
+		Img<C> fftKernel, Img<O> output, Interval imgConvolutionInterval)
+	{
 
-		ops.run(CorrelateFFTRAI.class, raiExtendedInput, raiExtendedKernel,
-				fftImg, fftKernel, output);
+		ops.run(CorrelateFFTRAI.class, raiExtendedInput, raiExtendedKernel, fftImg,
+			fftKernel, output);
 
 	}
-	
+
 	@Override
 	public boolean conforms() {
 		// TODO: only conforms if the kernel is sufficiently large (else the
 		// naive approach should be used) -> what is a good heuristic??
-		return Intervals.numElements(kernel) > 9;
+		return Intervals.numElements(getKernel()) > 9;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyImg.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyImg.java
@@ -32,6 +32,7 @@ package net.imagej.ops.deconvolve;
 
 import net.imagej.ops.DeconvolveOps;
 import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
 import net.imagej.ops.fft.filter.AbstractFFTFilterImg;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
@@ -58,11 +59,14 @@ public class RichardsonLucyImg<I extends RealType<I>, O extends RealType<O>, K e
 	extends AbstractFFTFilterImg<I, O, K, C>
 {
 
+	@Parameter
+	private OpService ops;
+
 	/**
 	 * max number of iterations
 	 */
 	@Parameter
-	int maxIterations;
+	private int maxIterations;
 
 	/**
 	 * run RichardsonLucyRAI

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
@@ -31,6 +31,7 @@
 package net.imagej.ops.deconvolve;
 
 import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.convolve.CorrelateFFTRAI;
 import net.imagej.ops.fft.filter.IterativeFFTFilterRAI;
@@ -41,6 +42,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
 import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -58,6 +60,9 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	extends IterativeFFTFilterRAI<I, O, K, C>
 {
 
+	@Parameter
+	private OpService ops;
+
 	/**
 	 * performs one iteration of the Richardson Lucy Algorithm (Lucy, L. B.
 	 * (1974).
@@ -70,11 +75,11 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 		// previous iteration in order to calculate error stats)
 
 		// 2. divide observed image by reblurred
-		inPlaceDivide(raiExtendedReblurred, raiExtendedInput);
+		inPlaceDivide(getRaiExtendedReblurred(), getRaiExtendedInput());
 
 		// 3. correlate psf with the output of step 2.
-		ops.run(CorrelateFFTRAI.class, raiExtendedReblurred, null, fftInput,
-			fftKernel, raiExtendedReblurred, true, false);
+		ops.run(CorrelateFFTRAI.class, getRaiExtendedReblurred(), null,
+			getFFTInput(), getFFTKernel(), getRaiExtendedReblurred(), true, false);
 
 		// compute estimate -
 		// for standard RL this step will multiply output of correlation step
@@ -132,7 +137,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	}
 
 	public void ComputeEstimate() {
-		inPlaceMultiply(raiExtendedEstimate, raiExtendedReblurred);
+		inPlaceMultiply(getRaiExtendedEstimate(), getRaiExtendedReblurred());
 	}
 
 }

--- a/src/main/java/net/imagej/ops/fft/AbstractFFTIterable.java
+++ b/src/main/java/net/imagej/ops/fft/AbstractFFTIterable.java
@@ -45,6 +45,6 @@ public abstract class AbstractFFTIterable<C, T, I extends Iterable<C>, O extends
 {
 
 	@Parameter
-	protected OpService ops;
+	private OpService ops;
 
 }

--- a/src/main/java/net/imagej/ops/fft/AbstractIFFTIterable.java
+++ b/src/main/java/net/imagej/ops/fft/AbstractIFFTIterable.java
@@ -45,6 +45,6 @@ public abstract class AbstractIFFTIterable<T, C, I extends Iterable<T>, O extend
 {
 
 	@Parameter
-	protected OpService ops;
+	private OpService ops;
 
 }

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterImg.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterImg.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.fft.filter;
 
+import net.imagej.ops.OpService;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
@@ -52,17 +53,20 @@ public abstract class AbstractFFTFilterImg<I extends RealType<I>, O extends Real
 	extends AbstractFilterImg<I, O, K>
 {
 
+	@Parameter
+	private OpService ops;
+
 	/**
 	 * FFT type
 	 */
 	@Parameter(required = false)
-	protected ComplexType<C> fftType;
+	private ComplexType<C> fftType;
 
 	/**
 	 * Factory to create ffts Imgs
 	 */
 	@Parameter(required = false)
-	protected ImgFactory<C> fftFactory;
+	private ImgFactory<C> fftFactory;
 
 	/**
 	 * 
@@ -73,7 +77,7 @@ public abstract class AbstractFFTFilterImg<I extends RealType<I>, O extends Real
 		// run the op that extends the input and kernel and creates the Imgs
 		// required for the fft algorithm
 		CreateFFTFilterMemory<I, O, K, C> createMemory =
-			ops.op(CreateFFTFilterMemory.class, input, kernel, borderSize);
+			ops.op(CreateFFTFilterMemory.class, input, getKernel(), getBorderSize());
 
 		createMemory.run();
 

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterRAI.java
@@ -53,53 +53,81 @@ public abstract class AbstractFFTFilterRAI<I extends RealType<I>, O extends Real
 {
 
 	@Parameter
-	protected OpService ops;
+	private OpService ops;
 
 	/**
 	 * input rai. If extension is desired it needs to be done before passing the
 	 * rai to the op
 	 */
 	@Parameter
-	protected RandomAccessibleInterval<I> raiExtendedInput;
+	private RandomAccessibleInterval<I> raiExtendedInput;
 
 	/**
 	 * kernel rai. Needs to be the same size as the input rai
 	 */
 	@Parameter(required = false)
-	protected RandomAccessibleInterval<K> raiExtendedKernel;
+	private RandomAccessibleInterval<K> raiExtendedKernel;
 
 	/**
 	 * Img to be used to store FFTs for input. Size of fftInput must correspond to
 	 * the fft size of raiExtendedInput
 	 */
 	@Parameter(required = false)
-	protected Img<C> fftInput;
+	private Img<C> fftInput;
 
 	/**
 	 * Img to be used to store FFTs for kernel. Size of fftKernel must correspond
 	 * to the fft size of raiExtendedKernel
 	 */
 	@Parameter(required = false)
-	protected Img<C> fftKernel;
+	private Img<C> fftKernel;
 
 	/**
 	 * RAI to store output
 	 */
 	@Parameter(required = false)
-	protected RandomAccessibleInterval<O> output;
+	private RandomAccessibleInterval<O> output;
 
 	/**
 	 * Boolean indicating that the input FFT has allready been calculated (use
 	 * when re-using an input with the same kernel size)
 	 */
 	@Parameter(required = false)
-	protected boolean performInputFFT = true;
+	private boolean performInputFFT = true;
 
 	/**
 	 * Boolean indicating that the kernel FFT has allready been calculated (use
 	 * when re-using an input with the same kernel size)
 	 */
 	@Parameter(required = false)
-	protected boolean performKernelFFT = true;
+	private boolean performKernelFFT = true;
+
+	protected RandomAccessibleInterval<I> getRaiExtendedInput() {
+		return raiExtendedInput;
+	}
+
+	protected RandomAccessibleInterval<K> getRaiExtendedKernel() {
+		return raiExtendedKernel;
+	}
+
+	protected Img<C> getFFTInput() {
+		return fftInput;
+	}
+
+	protected Img<C> getFFTKernel() {
+		return fftKernel;
+	}
+
+	protected RandomAccessibleInterval<O> getOutput() {
+		return output;
+	}
+
+	protected boolean getPerformInputFFT() {
+		return performInputFFT;
+	}
+
+	protected boolean getPerformKernelFFT() {
+		return performKernelFFT;
+	}
 
 }

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFilterImg.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFilterImg.java
@@ -58,43 +58,43 @@ public abstract class AbstractFilterImg<I extends RealType<I>, O extends RealTyp
 {
 
 	@Parameter
-	protected OpService ops;
+	private OpService ops;
 
 	/**
 	 * the kernel (psf)
 	 */
 	@Parameter
-	protected RandomAccessibleInterval<K> kernel;
+	private RandomAccessibleInterval<K> kernel;
 
 	/**
 	 * Border size in each dimensions. If null default border size will be added.
 	 */
 	@Parameter(required = false)
-	protected long[] borderSize = null;
+	private long[] borderSize = null;
 
 	/**
 	 * generates the out of bounds strategy for the extended area of the input
 	 */
 	@Parameter(required = false)
-	protected OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput;
+	private OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput;
 
 	/**
 	 * generates the out of bounds strategy for the extended area of the kernel
 	 */
 	@Parameter(required = false)
-	protected OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel;
+	private OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel;
 
 	/**
 	 * The output type. If null default output type will be used.
 	 */
 	@Parameter(required = false)
-	protected Type<O> outType;
+	private Type<O> outType;
 
 	/**
 	 * Factory to create output Img
 	 */
 	@Parameter(required = false)
-	protected ImgFactory<O> outFactory;
+	private ImgFactory<O> outFactory;
 
 	/**
 	 * Create the output using the outFactory and outType if they exist. If these
@@ -128,6 +128,34 @@ public abstract class AbstractFilterImg<I extends RealType<I>, O extends RealTyp
 		}
 
 		return outFactory.create(input, outType.createVariable());
+	}
+
+	protected RandomAccessibleInterval<K> getKernel() {
+		return kernel;
+	}
+
+	protected long[] getBorderSize() {
+		return borderSize;
+	}
+
+	protected OutOfBoundsFactory<I, RandomAccessibleInterval<I>> getOBFInput() {
+		return obfInput;
+	}
+
+	protected void setOBFInput(
+		OutOfBoundsFactory<I, RandomAccessibleInterval<I>> objInput)
+	{
+		this.obfInput = objInput;
+	}
+
+	protected OutOfBoundsFactory<K, RandomAccessibleInterval<K>> getOBFKernel() {
+		return obfKernel;
+	}
+
+	protected void setOBFKernel(
+		OutOfBoundsFactory<K, RandomAccessibleInterval<K>> objInput)
+	{
+		this.obfKernel = obfKernel;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/fft/filter/CreateFFTFilterMemory.java
+++ b/src/main/java/net/imagej/ops/fft/filter/CreateFFTFilterMemory.java
@@ -68,34 +68,34 @@ public class CreateFFTFilterMemory<I extends RealType<I>, O extends RealType<O>,
 {
 
 	@Parameter
-	protected OpService ops;
+	private OpService ops;
 
 	@Parameter
-	protected RandomAccessibleInterval<I> input;
+	private RandomAccessibleInterval<I> input;
 
 	@Parameter
-	protected RandomAccessibleInterval<K> kernel;
+	private RandomAccessibleInterval<K> kernel;
 
 	@Parameter(required = false)
-	protected long[] borderSize = null;
+	private long[] borderSize = null;
 
 	/**
 	 * generates the out of bounds strategy for the extended area
 	 */
 	@Parameter(required = false)
-	protected OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput;
+	private OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput;
 
 	/**
 	 * generates the out of bounds strategy for the extended area
 	 */
 	@Parameter(required = false)
-	protected OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel;
+	private OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel;
 
 	@Parameter(required = false)
-	protected ComplexType<C> fftType;
+	private ComplexType<C> fftType;
 
 	@Parameter(required = false)
-	protected ImgFactory<C> fftFactory;
+	private ImgFactory<C> fftFactory;
 
 	Img<C> fftImg;
 

--- a/src/main/java/net/imagej/ops/fft/filter/LinearFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/LinearFFTFilterRAI.java
@@ -30,6 +30,9 @@
 
 package net.imagej.ops.fft.filter;
 
+import org.scijava.plugin.Parameter;
+
+import net.imagej.ops.OpService;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
@@ -47,26 +50,29 @@ public abstract class LinearFFTFilterRAI<I extends RealType<I>, O extends RealTy
 	extends AbstractFFTFilterRAI<I, O, K, C>
 {
 
+	@Parameter
+	private OpService ops;
+
 	@Override
 	public void run() {
 
 		// perform input FFT if needed
-		if (performInputFFT) {
-			ops.run("fft", fftInput, raiExtendedInput);
+		if (getPerformInputFFT()) {
+			ops.run("fft", getFFTInput(), getRaiExtendedInput());
 		}
 
 		// perform kernel FFT if needed
-		if (performKernelFFT) {
-			ops.run("fft", fftKernel, raiExtendedKernel);
+		if (getPerformKernelFFT()) {
+			ops.run("fft", getFFTKernel(), getRaiExtendedKernel());
 		}
 
 		// perform the operation in frequency domain (ie multiplication for
 		// convolution, complex conjugate multiplication for correlation,
 		// etc.) Wiener Filter,
-		frequencyOperation(fftInput, fftKernel);
+		frequencyOperation(getFFTInput(), getFFTKernel());
 
 		// inverse fft
-		ops.run("ifft", output, fftInput);
+		ops.run("ifft", getOutput(), getFFTInput());
 	}
 
 	// abstract function that implements an operation in frequency domain (ie

--- a/src/main/java/net/imagej/ops/fft/image/AbstractFFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/AbstractFFTImg.java
@@ -52,7 +52,7 @@ public abstract class AbstractFFTImg<T, I extends Img<T>, C, O extends Img<C>>
 	 * size of border to apply in each dimension
 	 */
 	@Parameter(required = false)
-	long[] borderSize = null;
+	private long[] borderSize = null;
 
 	/**
 	 * set to true to compute the FFT as fast as possible. The input will be
@@ -62,16 +62,13 @@ public abstract class AbstractFFTImg<T, I extends Img<T>, C, O extends Img<C>>
 	 * extended to the nearest size that is supported.
 	 */
 	@Parameter(required = false)
-	Boolean fast = true;
+	private Boolean fast = true;
 
 	/**
 	 * generates the out of bounds strategy for the extended area
 	 */
 	@Parameter(required = false)
-	protected OutOfBoundsFactory<T, RandomAccessibleInterval<T>> obf;
-
-	protected long[] paddedSize;
-	protected long[] fftSize;
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> obf;
 
 	/**
 	 * create the output based on the input. If fast=true the size is determined
@@ -99,7 +96,7 @@ public abstract class AbstractFFTImg<T, I extends Img<T>, C, O extends Img<C>>
 			computeFFTSmallSize(inputSize);
 		}
 
-		return createFFTImg(input.factory(), fftSize);
+		return createFFTImg(input.factory());
 
 	}
 
@@ -125,6 +122,11 @@ public abstract class AbstractFFTImg<T, I extends Img<T>, C, O extends Img<C>>
 	 * @param size
 	 * @return
 	 */
-	protected abstract O createFFTImg(ImgFactory<T> factory, long[] size);
+	protected abstract O createFFTImg(ImgFactory<T> factory);
+
+	protected OutOfBoundsFactory<T, RandomAccessibleInterval<T>> getOBF() {
+		return obf;
+
+	}
 
 }

--- a/src/main/java/net/imagej/ops/fft/image/FFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/FFTImg.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.fft.image;
 
+import net.imagej.ops.OpService;
 import net.imagej.ops.Ops.FFT;
 import net.imagej.ops.fft.methods.FFTRAI;
 import net.imagej.ops.fft.size.ComputeFFTSize;
@@ -40,6 +41,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
 
 import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -53,6 +55,13 @@ import org.scijava.plugin.Plugin;
 public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
 	AbstractFFTImg<T, I, ComplexFloatType, Img<ComplexFloatType>>
 {
+
+	@Parameter
+	private OpService ops;
+
+	private long[] paddedSize;
+
+	private long[] fftSize;
 
 	@Override
 	protected void computeFFTFastSize(long[] inputSize) {
@@ -75,12 +84,10 @@ public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
 	}
 
 	@Override
-	protected Img<ComplexFloatType> createFFTImg(ImgFactory<T> factory,
-		long[] size)
-	{
+	protected Img<ComplexFloatType> createFFTImg(ImgFactory<T> factory) {
 
 		try {
-			return factory.imgFactory(new ComplexFloatType()).create(size,
+			return factory.imgFactory(new ComplexFloatType()).create(fftSize,
 				new ComplexFloatType());
 		}
 		// TODO: error handling?
@@ -94,7 +101,7 @@ public class FFTImg<T extends RealType<T>, I extends Img<T>> extends
 		safeCompute(I input, Img<ComplexFloatType> output)
 	{
 
-		ops.run(FFTRAI.class, output, input, obf, paddedSize);
+		ops.run(FFTRAI.class, output, input, getOBF(), paddedSize);
 
 		return output;
 	}

--- a/src/main/java/net/imagej/ops/fft/image/IFFTImg.java
+++ b/src/main/java/net/imagej/ops/fft/image/IFFTImg.java
@@ -33,6 +33,7 @@ package net.imagej.ops.fft.image;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import net.imagej.ops.OpService;
 import net.imagej.ops.Ops.IFFT;
 import net.imagej.ops.fft.methods.IFFTRAI;
 import net.imglib2.img.Img;
@@ -40,6 +41,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
 
 import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -53,6 +55,9 @@ import org.scijava.plugin.Plugin;
 public class IFFTImg<T extends RealType<T>, O extends Img<T>> extends
 	AbstractIFFTImg<ComplexFloatType, Img<ComplexFloatType>, T, O>
 {
+
+	@Parameter
+	private OpService ops;
 
 	@Override
 	public O compute(Img<ComplexFloatType> input, O output) {

--- a/src/main/java/net/imagej/ops/fft/methods/FFTRAI.java
+++ b/src/main/java/net/imagej/ops/fft/methods/FFTRAI.java
@@ -67,10 +67,10 @@ public class FFTRAI<T extends RealType<T>, C extends ComplexType<C>>
 	 * generates the out of bounds strategy for the extended area
 	 */
 	@Parameter(required = false)
-	protected OutOfBoundsFactory<T, RandomAccessibleInterval<T>> obf;
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> obf;
 
 	@Parameter(required = false)
-	protected long[] paddedSize;
+	private long[] paddedSize;
 
 	@Override
 	public RandomAccessibleInterval<C> compute(RandomAccessibleInterval<T> input,


### PR DESCRIPTION
Changed fields and parameters, in all FFT-related classes, to be
private. Added getters and setters where needed.  Changed subclasses to
use getters/setters to access/set fields.