### PR TITLE
Introducing easier readable naming schema

### DIFF
--- a/src/main/java/net/imagej/ops/convert/ConvertIterableInterval.java
+++ b/src/main/java/net/imagej/ops/convert/ConvertIterableInterval.java
@@ -28,24 +28,42 @@
  * #L%
  */
 
-package net.imagej.ops.map;
+package net.imagej.ops.convert;
 
+import net.imagej.ops.AbstractStrictFunction;
 import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imglib2.IterableInterval;
-import net.imglib2.converter.read.ConvertedIterableInterval;
-import net.imglib2.type.Type;
+import net.imglib2.type.numeric.RealType;
 
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin(type = Op.class, name = Ops.Map.NAME)
-public class MapII2View<A, B extends Type<B>> extends
-	MapView<A, B, IterableInterval<A>, IterableInterval<B>>
+/**
+ * @author Martin Horn
+ */
+@Plugin(type = Op.class, name = Ops.Convert.NAME)
+public class ConvertIterableInterval<I extends RealType<I>, O extends RealType<O>> extends
+	AbstractStrictFunction<IterableInterval<I>, IterableInterval<O>> implements
+	Convert<IterableInterval<I>, IterableInterval<O>>
 {
 
+	@Parameter
+	private ConvertPix<I, O> pixConvert;
+
+	@Parameter
+	private OpService ops;
+
+	@SuppressWarnings("unchecked")
 	@Override
-	public void run() {
-		setOutput(new ConvertedIterableInterval<A, B>(getInput(), getFunction(),
-			getType()));
+	public IterableInterval<O> compute(final IterableInterval<I> input,
+		final IterableInterval<O> output)
+	{
+		pixConvert.checkInput(input.firstElement().createVariable(), output
+			.firstElement().createVariable());
+		pixConvert.checkInput(input);
+		return (IterableInterval<O>) ops.run("map", output, input, pixConvert);
 	}
+
 }

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyRAI.java
@@ -75,11 +75,11 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 		// previous iteration in order to calculate error stats)
 
 		// 2. divide observed image by reblurred
-		inPlaceDivide(getRaiExtendedReblurred(), getRaiExtendedInput());
+		inPlaceDivide(getRAIExtendedReblurred(), getRAIExtendedInput());
 
 		// 3. correlate psf with the output of step 2.
-		ops.run(CorrelateFFTRAI.class, getRaiExtendedReblurred(), null,
-			getFFTInput(), getFFTKernel(), getRaiExtendedReblurred(), true, false);
+		ops.run(CorrelateFFTRAI.class, getRAIExtendedReblurred(), null,
+			getFFTInput(), getFFTKernel(), getRAIExtendedReblurred(), true, false);
 
 		// compute estimate -
 		// for standard RL this step will multiply output of correlation step
@@ -137,7 +137,7 @@ public class RichardsonLucyRAI<I extends RealType<I>, O extends RealType<O>, K e
 	}
 
 	public void ComputeEstimate() {
-		inPlaceMultiply(getRaiExtendedEstimate(), getRaiExtendedReblurred());
+		inPlaceMultiply(getRAIExtendedEstimate(), getRAIExtendedReblurred());
 	}
 
 }

--- a/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/AbstractFFTFilterRAI.java
@@ -102,11 +102,11 @@ public abstract class AbstractFFTFilterRAI<I extends RealType<I>, O extends Real
 	@Parameter(required = false)
 	private boolean performKernelFFT = true;
 
-	protected RandomAccessibleInterval<I> getRaiExtendedInput() {
+	protected RandomAccessibleInterval<I> getRAIExtendedInput() {
 		return raiExtendedInput;
 	}
 
-	protected RandomAccessibleInterval<K> getRaiExtendedKernel() {
+	protected RandomAccessibleInterval<K> getRAIExtendedKernel() {
 		return raiExtendedKernel;
 	}
 

--- a/src/main/java/net/imagej/ops/fft/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/IterativeFFTFilterRAI.java
@@ -122,16 +122,16 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 				.interval(Views.extend(reblurred, obfOutput), imgConvolutionInterval);
 
 		// perform fft of input
-		ops.run("fft", getFFTInput(), getRaiExtendedInput());
+		ops.run("fft", getFFTInput(), getRAIExtendedInput());
 
 		// perform fft of psf
-		ops.run("fft", getFFTKernel(), getRaiExtendedKernel());
+		ops.run("fft", getFFTKernel(), getRAIExtendedKernel());
 
 		// set first guess of estimate
 		// TODO: implement logic for various first guesses.
 		// for now just set to original image
 		Cursor<O> c = Views.iterable(raiExtendedEstimate).cursor();
-		Cursor<I> cIn = Views.iterable(getRaiExtendedInput()).cursor();
+		Cursor<I> cIn = Views.iterable(getRAIExtendedInput()).cursor();
 
 		while (c.hasNext()) {
 			c.fwd();
@@ -159,11 +159,11 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 	abstract protected void performIteration();
 
-	protected RandomAccessibleInterval<O> getRaiExtendedReblurred() {
+	protected RandomAccessibleInterval<O> getRAIExtendedReblurred() {
 		return raiExtendedReblurred;
 	}
 
-	protected RandomAccessibleInterval<O> getRaiExtendedEstimate() {
+	protected RandomAccessibleInterval<O> getRAIExtendedEstimate() {
 		return raiExtendedEstimate;
 	}
 

--- a/src/main/java/net/imagej/ops/fft/filter/LinearFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/fft/filter/LinearFFTFilterRAI.java
@@ -58,12 +58,12 @@ public abstract class LinearFFTFilterRAI<I extends RealType<I>, O extends RealTy
 
 		// perform input FFT if needed
 		if (getPerformInputFFT()) {
-			ops.run("fft", getFFTInput(), getRaiExtendedInput());
+			ops.run("fft", getFFTInput(), getRAIExtendedInput());
 		}
 
 		// perform kernel FFT if needed
 		if (getPerformKernelFFT()) {
-			ops.run("fft", getFFTKernel(), getRaiExtendedKernel());
+			ops.run("fft", getFFTKernel(), getRAIExtendedKernel());
 		}
 
 		// perform the operation in frequency domain (ie multiplication for

--- a/src/main/java/net/imagej/ops/gauss/GaussRAIToRAI.java
+++ b/src/main/java/net/imagej/ops/gauss/GaussRAIToRAI.java
@@ -54,7 +54,7 @@ import org.scijava.plugin.Plugin;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 @Plugin(type = Op.class, name = "gauss")
-public class GaussRAI2RAI<T extends RealType<T>> extends
+public class GaussRAIToRAI<T extends RealType<T>> extends
 	AbstractStrictFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
 	implements Ops.Gauss
 {

--- a/src/main/java/net/imagej/ops/invert/InvertIterableInterval.java
+++ b/src/main/java/net/imagej/ops/invert/InvertIterableInterval.java
@@ -48,7 +48,7 @@ import org.scijava.plugin.Plugin;
  * @author Martin Horn
  */
 @Plugin(type = Op.class, name = Ops.Invert.NAME, priority = Priority.NORMAL_PRIORITY + 1)
-public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
+public class InvertIterableInterval<I extends RealType<I>, O extends RealType<O>> extends
 	AbstractStrictFunction<IterableInterval<I>, IterableInterval<O>> implements
 	MathOps.Invert
 {

--- a/src/main/java/net/imagej/ops/map/AbstractMapFunction.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapFunction.java
@@ -30,30 +30,35 @@
 
 package net.imagej.ops.map;
 
-import net.imagej.ops.Op;
-import net.imagej.ops.Ops;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.converter.read.ConvertedRandomAccessibleInterval;
-import net.imglib2.type.Type;
+import net.imagej.ops.AbstractStrictFunction;
+import net.imagej.ops.Function;
 
-import org.scijava.plugin.Plugin;
+import org.scijava.plugin.Parameter;
 
 /**
- * Map values of {@link RandomAccessibleInterval} to a View
+ * Abstract implementation of a {@link Map}.
  * 
  * @author Christian Dietz
- * 
- * @param <A>
- * @param <B>
+ * @param <A> mapped on {@code <B>}
+ * @param <B> mapped from {@code <A>}
+ * @param <C> provides {@code <A>}s
+ * @param <D> provides {@code <B>}s
  */
-@Plugin(type = Op.class, name = Ops.Map.NAME)
-public class MapRAI2View<A, B extends Type<B>> extends
-	MapView<A, B, RandomAccessibleInterval<A>, RandomAccessibleInterval<B>>
+public abstract class AbstractMapFunction<A, B, C, D> extends
+	AbstractStrictFunction<C, D> implements Map<A, B, Function<A, B>>
 {
 
+	/** {@link Function} to be used for mapping. */
+	@Parameter
+	protected Function<A, B> func;
+
 	@Override
-	public void run() {
-		setOutput(new ConvertedRandomAccessibleInterval<A, B>(getInput(),
-			getFunction(), getType()));
+	public Function<A, B> getFunction() {
+		return func;
+	}
+
+	@Override
+	public void setFunction(final Function<A, B> func) {
+		this.func = func;
 	}
 }

--- a/src/main/java/net/imagej/ops/map/AbstractMapInplace.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapInplace.java
@@ -28,52 +28,39 @@
  * #L%
  */
 
-package net.imagej.ops.normalize;
+package net.imagej.ops.map;
 
-import java.util.List;
+import net.imagej.ops.AbstractInplaceFunction;
+import net.imagej.ops.Function;
+import net.imagej.ops.InplaceFunction;
 
-import net.imagej.ops.AbstractStrictFunction;
-import net.imagej.ops.Op;
-import net.imagej.ops.OpService;
-import net.imagej.ops.Ops;
-import net.imglib2.IterableInterval;
-import net.imglib2.type.numeric.RealType;
-
-import org.scijava.plugin.Attr;
 import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
 
-@Plugin(type = Op.class, name = Ops.Normalize.NAME, attrs = { @Attr(
-	name = "aliases", value = Ops.Normalize.ALIASES) })
-public class NormalizeII<T extends RealType<T>> extends
-	AbstractStrictFunction<IterableInterval<T>, IterableInterval<T>> implements
-	Ops.Normalize
+/**
+ * Abstract implementation of an {@link MapIterableInplace}
+ * 
+ * @author Christian Dietz
+ * @param <A> type of values to be mapped
+ * @param <I> {@link Iterable} of <A>s
+ */
+public abstract class AbstractMapInplace<A, I extends Iterable<A>> extends
+	AbstractInplaceFunction<I> implements Map<A, A, InplaceFunction<A>>
 {
 
+	/**
+	 * {@link Function} to be used for mapping
+	 */
 	@Parameter
-	private OpService ops;
+	protected InplaceFunction<A> func;
 
 	@Override
-	public IterableInterval<T> compute(IterableInterval<T> input,
-		IterableInterval<T> output)
-	{
+	public InplaceFunction<A> getFunction() {
+		return func;
+	}
 
-		T outType = output.firstElement().createVariable();
-		List<T> minmax = (List<T>) ops.run("minmax", input);
-		double factor =
-			NormalizeRealType.normalizationFactor(minmax.get(0).getRealDouble(),
-				minmax.get(1).getRealDouble(), outType.getMinValue(), outType
-					.getMaxValue());
-
-		// lookup the pixel-wise normalize function
-		Op normalize =
-			ops.op(Ops.Normalize.class, outType, outType, minmax.get(0).getRealDouble(), outType.getMinValue(), outType
-					.getMaxValue(), factor);
-
-		// run normalize for each pixel
-		ops.run("map", output, input, normalize);
-
-		return output;
+	@Override
+	public void setFunction(final InplaceFunction<A> func) {
+		this.func = func;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/map/MapConvertRAIToRAI.java
+++ b/src/main/java/net/imagej/ops/map/MapConvertRAIToRAI.java
@@ -30,35 +30,30 @@
 
 package net.imagej.ops.map;
 
-import java.util.Iterator;
-
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.read.ConvertedRandomAccessibleInterval;
+import net.imglib2.type.Type;
 
-import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 /**
- * {@link Map} from {@link Iterable} to {@link Iterable}.
+ * Map values of {@link RandomAccessibleInterval} to a View
  * 
- * @author Martin Horn
  * @author Christian Dietz
+ * 
+ * @param <A>
+ * @param <B>
  */
-@Plugin(type = Op.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY - 1)
-public class MapI2I<A, B> extends
-	AbstractFunctionMap<A, B, Iterable<A>, Iterable<B>>
+@Plugin(type = Op.class, name = Ops.Map.NAME)
+public class MapConvertRAIToRAI<A, B extends Type<B>> extends
+	MapView<A, B, RandomAccessibleInterval<A>, RandomAccessibleInterval<B>>
 {
 
 	@Override
-	public Iterable<B> compute(final Iterable<A> input, final Iterable<B> output)
-	{
-		final Iterator<A> inCursor = input.iterator();
-		final Iterator<B> outCursor = output.iterator();
-
-		while (inCursor.hasNext()) {
-			func.compute(inCursor.next(), outCursor.next());
-		}
-
-		return output;
+	public void run() {
+		setOutput(new ConvertedRandomAccessibleInterval<A, B>(getInput(),
+			getFunction(), getType()));
 	}
 }

--- a/src/main/java/net/imagej/ops/map/MapConvertRandomAccessToRandomAccess.java
+++ b/src/main/java/net/imagej/ops/map/MapConvertRandomAccessToRandomAccess.java
@@ -30,44 +30,30 @@
 
 package net.imagej.ops.map;
 
-import net.imagej.ops.Function;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
-import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
-import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.converter.read.ConvertedRandomAccessible;
+import net.imglib2.type.Type;
 
-import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 /**
- * {@link Map} using a {@link Function} on {@link IterableInterval} and
- * {@link RandomAccessibleInterval}
+ * Maps values of a {@link RandomAccessible} in View.
  * 
- * @author Martin Horn
  * @author Christian Dietz
- * @param <A> mapped on <B>
- * @param <B> mapped from <A>
+ * 
+ * @param <A>
+ * @param <B>
  */
-@Plugin(type = Op.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY)
-public class MapII2RAI<A, B> extends
-	AbstractFunctionMap<A, B, IterableInterval<A>, RandomAccessibleInterval<B>>
+@Plugin(type = Op.class, name = Ops.Map.NAME)
+public class MapConvertRandomAccessToRandomAccess<A, B extends Type<B>> extends
+	MapView<A, B, RandomAccessible<A>, RandomAccessible<B>>
 {
 
 	@Override
-	public RandomAccessibleInterval<B> compute(final IterableInterval<A> input,
-		final RandomAccessibleInterval<B> output)
-	{
-		final Cursor<A> cursor = input.localizingCursor();
-		final RandomAccess<B> rndAccess = output.randomAccess();
-
-		while (cursor.hasNext()) {
-			cursor.fwd();
-			rndAccess.setPosition(cursor);
-			func.compute(cursor.get(), rndAccess.get());
-		}
-
-		return output;
+	public void run() {
+		setOutput(new ConvertedRandomAccessible<A, B>(getInput(), getFunction(),
+			getType()));
 	}
 }

--- a/src/main/java/net/imagej/ops/map/MapIterableInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableInplace.java
@@ -30,37 +30,29 @@
 
 package net.imagej.ops.map;
 
-import net.imagej.ops.AbstractInplaceFunction;
-import net.imagej.ops.Function;
-import net.imagej.ops.InplaceFunction;
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops;
 
-import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
 
 /**
- * Abstract implementation of an {@link MapI}
+ * Default (slower) implementation of an {@link MapIterableInplace}.
  * 
+ * @author Curtis Rueden
  * @author Christian Dietz
- * @param <A> type of values to be mapped
- * @param <I> {@link Iterable} of <A>s
+ * @param <A>
  */
-public abstract class AbstractInplaceMap<A, I extends Iterable<A>> extends
-	AbstractInplaceFunction<I> implements Map<A, A, InplaceFunction<A>>
-{
-
-	/**
-	 * {@link Function} to be used for mapping
-	 */
-	@Parameter
-	protected InplaceFunction<A> func;
+@Plugin(type = Op.class, name = Ops.Map.NAME,
+	priority = Priority.LOW_PRIORITY)
+public class MapIterableInplace<A> extends AbstractMapInplace<A, Iterable<A>> {
 
 	@Override
-	public InplaceFunction<A> getFunction() {
-		return func;
-	}
+	public Iterable<A> compute(final Iterable<A> arg) {
+		for (final A t : arg) {
+			func.compute(t, t);
+		}
 
-	@Override
-	public void setFunction(final InplaceFunction<A> func) {
-		this.func = func;
+		return arg;
 	}
-
 }

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalToRAI.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalToRAI.java
@@ -42,8 +42,8 @@ import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 /**
- * {@link Map} using a {@link Function} on {@link RandomAccessibleInterval} and
- * {@link IterableInterval}
+ * {@link Map} using a {@link Function} on {@link IterableInterval} and
+ * {@link RandomAccessibleInterval}
  * 
  * @author Martin Horn
  * @author Christian Dietz
@@ -51,21 +51,21 @@ import org.scijava.plugin.Plugin;
  * @param <B> mapped from <A>
  */
 @Plugin(type = Op.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY)
-public class MapRAI2III<A, B> extends
-	AbstractFunctionMap<A, B, RandomAccessibleInterval<A>, IterableInterval<B>>
+public class MapIterableIntervalToRAI<A, B> extends
+	AbstractMapFunction<A, B, IterableInterval<A>, RandomAccessibleInterval<B>>
 {
 
 	@Override
-	public IterableInterval<B> compute(final RandomAccessibleInterval<A> input,
-		final IterableInterval<B> output)
+	public RandomAccessibleInterval<B> compute(final IterableInterval<A> input,
+		final RandomAccessibleInterval<B> output)
 	{
-		final Cursor<B> cursor = output.localizingCursor();
-		final RandomAccess<A> rndAccess = input.randomAccess();
+		final Cursor<A> cursor = input.localizingCursor();
+		final RandomAccess<B> rndAccess = output.randomAccess();
 
 		while (cursor.hasNext()) {
 			cursor.fwd();
 			rndAccess.setPosition(cursor);
-			func.compute(rndAccess.get(), cursor.get());
+			func.compute(cursor.get(), rndAccess.get());
 		}
 
 		return output;

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalToView.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalToView.java
@@ -28,42 +28,24 @@
  * #L%
  */
 
-package net.imagej.ops.convert;
+package net.imagej.ops.map;
 
-import net.imagej.ops.AbstractStrictFunction;
 import net.imagej.ops.Op;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imglib2.IterableInterval;
-import net.imglib2.type.numeric.RealType;
+import net.imglib2.converter.read.ConvertedIterableInterval;
+import net.imglib2.type.Type;
 
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-/**
- * @author Martin Horn
- */
-@Plugin(type = Op.class, name = Ops.Convert.NAME)
-public class ConvertII<I extends RealType<I>, O extends RealType<O>> extends
-	AbstractStrictFunction<IterableInterval<I>, IterableInterval<O>> implements
-	Convert<IterableInterval<I>, IterableInterval<O>>
+@Plugin(type = Op.class, name = Ops.Map.NAME)
+public class MapIterableIntervalToView<A, B extends Type<B>> extends
+	MapView<A, B, IterableInterval<A>, IterableInterval<B>>
 {
 
-	@Parameter
-	private ConvertPix<I, O> pixConvert;
-
-	@Parameter
-	private OpService ops;
-
-	@SuppressWarnings("unchecked")
 	@Override
-	public IterableInterval<O> compute(final IterableInterval<I> input,
-		final IterableInterval<O> output)
-	{
-		pixConvert.checkInput(input.firstElement().createVariable(), output
-			.firstElement().createVariable());
-		pixConvert.checkInput(input);
-		return (IterableInterval<O>) ops.run("map", output, input, pixConvert);
+	public void run() {
+		setOutput(new ConvertedIterableInterval<A, B>(getInput(), getFunction(),
+			getType()));
 	}
-
 }

--- a/src/main/java/net/imagej/ops/misc/MinMaxRealType.java
+++ b/src/main/java/net/imagej/ops/misc/MinMaxRealType.java
@@ -28,31 +28,47 @@
  * #L%
  */
 
-package net.imagej.ops.map;
+package net.imagej.ops.misc;
+
+import java.util.Iterator;
 
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imglib2.type.numeric.RealType;
 
-import org.scijava.Priority;
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Default (slower) implementation of an {@link MapI}.
- * 
- * @author Curtis Rueden
- * @author Christian Dietz
- * @param <A>
+ * Calculates the minimum and maximum value of an image.
  */
-@Plugin(type = Op.class, name = Ops.Map.NAME,
-	priority = Priority.LOW_PRIORITY)
-public class MapI<A> extends AbstractInplaceMap<A, Iterable<A>> {
+@Plugin(type = Op.class, name = Ops.MinMax.NAME)
+public class MinMaxRealType<T extends RealType<T>> implements MinMax<T> {
+
+	@Parameter
+	private Iterable<T> img;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private T min;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private T max;
 
 	@Override
-	public Iterable<A> compute(final Iterable<A> arg) {
-		for (final A t : arg) {
-			func.compute(t, t);
-		}
+	public void run() {
+		min = img.iterator().next().createVariable();
+		max = min.copy();
 
-		return arg;
+		min.setReal(min.getMaxValue());
+		max.setReal(max.getMinValue());
+
+		final Iterator<T> it = img.iterator();
+		while (it.hasNext()) {
+			final T i = it.next();
+			if (min.compareTo(i) > 0) min.set(i);
+			if (max.compareTo(i) < 0) max.set(i);
+		}
 	}
+
 }

--- a/src/main/java/net/imagej/ops/threshold/global/image/ApplyConstantThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/global/image/ApplyConstantThreshold.java
@@ -34,7 +34,7 @@ import net.imagej.ops.AbstractStrictFunction;
 import net.imagej.ops.Op;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
-import net.imagej.ops.map.MapI2I;
+import net.imagej.ops.map.MapIterableToIterable;
 import net.imagej.ops.threshold.global.pixel.ApplyThresholdComparable;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
@@ -73,7 +73,7 @@ public class ApplyConstantThreshold<T extends RealType<T>> extends
 				.getClass(), threshold);
 
 		// TODO: Use ops.map(...) once multithreading of BitTypes is fixed.
-		ops.run(MapI2I.class, output, input, applyThreshold);
+		ops.run(MapIterableToIterable.class, output, input, applyThreshold);
 
 		return output;
 	}

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -38,9 +38,9 @@ import net.imagej.ops.arithmetic.add.AddConstantToImageFunctional;
 import net.imagej.ops.arithmetic.add.AddConstantToImageInPlace;
 import net.imagej.ops.arithmetic.add.AddConstantToNumericType;
 import net.imagej.ops.arithmetic.add.parallel.AddConstantToArrayByteImageP;
-import net.imagej.ops.map.ParallelMap;
-import net.imagej.ops.map.ParallelMapI2I;
-import net.imagej.ops.map.ParallelMapI2R;
+import net.imagej.ops.map.MapParallel;
+import net.imagej.ops.map.MapIterableToIterableParallel;
+import net.imagej.ops.map.MapIterableToRAIParallel;
 import net.imagej.ops.onthefly.ArithmeticOp;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.NumericType;
@@ -75,13 +75,13 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void fTestIterableIntervalMapperP() {
-		ops.run(ParallelMapI2I.class, out, in, ops.op(
+		ops.run(MapIterableToIterableParallel.class, out, in, ops.op(
 			AddConstantToNumericType.class, null, NumericType.class, new ByteType((byte) 10)));
 	}
 
 	@Test
 	public void fTestDefaultMapperP() {
-		ops.run(ParallelMapI2R.class, out, in, ops.op(
+		ops.run(MapIterableToRAIParallel.class, out, in, ops.op(
 			AddConstantToNumericType.class, null, NumericType.class, new ByteType((byte) 10)));
 	}
 
@@ -93,7 +93,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void inTestDefaultInplaceMapperP() {
-		ops.run(ParallelMap.class, in, ops.op(
+		ops.run(MapParallel.class, in, ops.op(
 			AddConstantInplace.class, NumericType.class, new ByteType((byte) 10)));
 	}
 

--- a/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
@@ -35,12 +35,12 @@ import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 
 import net.imagej.ops.MathOps;
 import net.imagej.ops.Op;
-import net.imagej.ops.map.MapI;
-import net.imagej.ops.map.MapII2II;
-import net.imagej.ops.map.MapII2RAI;
-import net.imagej.ops.map.ParallelMap;
-import net.imagej.ops.map.ParallelMapI2I;
-import net.imagej.ops.map.ParallelMapI2R;
+import net.imagej.ops.map.MapIterableInplace;
+import net.imagej.ops.map.MapIterableIntervalToIterableInterval;
+import net.imagej.ops.map.MapIterableIntervalToRAI;
+import net.imagej.ops.map.MapParallel;
+import net.imagej.ops.map.MapIterableToIterableParallel;
+import net.imagej.ops.map.MapIterableToRAIParallel;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -52,8 +52,8 @@ import org.junit.rules.TestRule;
 
 /**
  * Benchmarking various implementations of mappers. Benchmarked since now:
- * {@link MapII2RAI}, {@link MapII2II},
- * {@link ParallelMapI2R}, {@link ParallelMapI2I}
+ * {@link MapIterableIntervalToRAI}, {@link MapIterableIntervalToIterableInterval},
+ * {@link MapIterableToRAIParallel}, {@link MapIterableToIterableParallel}
  * 
  * @author Christian Dietz
  */
@@ -80,32 +80,32 @@ public class MappersBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void pixelWiseTestMapper() {
-		ops.run(new MapII2RAI<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(new MapIterableIntervalToRAI<ByteType, ByteType>(), out, in, addConstant);
 	}
 
 	@Test
 	public void pixelWiseTestMapperII() {
-		ops.run(new MapII2II<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(new MapIterableIntervalToIterableInterval<ByteType, ByteType>(), out, in, addConstant);
 	}
 
 	@Test
 	public void pixelWiseTestThreadedMapper() {
-		ops.run(new ParallelMapI2R<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(new MapIterableToRAIParallel<ByteType, ByteType>(), out, in, addConstant);
 	}
 
 	@Test
 	public void pixelWiseTestThreadedMapperII() {
-		ops.run(new ParallelMapI2I<ByteType, ByteType>(),
+		ops.run(new MapIterableToIterableParallel<ByteType, ByteType>(),
 			out, in, addConstant, out);
 	}
 
 	@Test
 	public void pixelWiseTestMapperInplace() {
-		ops.run(new MapI<ByteType>(), in, addConstantInplace);
+		ops.run(new MapIterableInplace<ByteType>(), in, addConstantInplace);
 	}
 
 	@Test
 	public void pixelWiseTestThreadedMapperInplace() {
-		ops.run(new ParallelMap<ByteType>(), in.copy(), addConstantInplace);
+		ops.run(new MapParallel<ByteType>(), in.copy(), addConstantInplace);
 	}
 }

--- a/src/test/java/net/imagej/ops/convert/ConvertIITest.java
+++ b/src/test/java/net/imagej/ops/convert/ConvertIITest.java
@@ -40,7 +40,7 @@ import net.imglib2.type.numeric.integer.ShortType;
 import org.junit.Test;
 
 /**
- * A test of {@link ConvertII}.
+ * A test of {@link ConvertIterableInterval}.
  * 
  * @author Martin Horn
  */

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -43,9 +43,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Testing multi threaded implementation ({@link ParallelMapI2R} and
- * {@link ParallelMapI2I}) of the mappers. Assumption: Naive Implementation of
- * {@link MapII2RAI} works fine.
+ * Testing multi threaded implementation ({@link MapIterableToRAIParallel} and
+ * {@link MapIterableToIterableParallel}) of the mappers. Assumption: Naive Implementation of
+ * {@link MapIterableIntervalToRAI} works fine.
  * 
  * @author Christian Dietz
  */
@@ -64,7 +64,7 @@ public class MapTest extends AbstractOpTest {
 	public void testMapII() {
 
 		final Op functional =
-			ops.op(MapII2II.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableIntervalToIterableInterval.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();
@@ -81,7 +81,7 @@ public class MapTest extends AbstractOpTest {
 	public void testMapRAIII() {
 
 		final Op functional =
-			ops.op(MapRAI2III.class, out, in, new AddOneFunctional());
+			ops.op(MapRAIToIterableInterval.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();
@@ -98,7 +98,7 @@ public class MapTest extends AbstractOpTest {
 	public void testMapIIRAI() {
 
 		final Op functional =
-			ops.op(MapII2RAI.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableIntervalToRAI.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();
@@ -117,7 +117,7 @@ public class MapTest extends AbstractOpTest {
 		final Cursor<ByteType> cursor1 = in.copy().cursor();
 		final Cursor<ByteType> cursor2 = in.cursor();
 
-		final Op functional = ops.op(MapI.class, in, new AddOneInplace());
+		final Op functional = ops.op(MapIterableInplace.class, in, new AddOneInplace());
 		functional.run();
 
 		while (cursor1.hasNext()) {

--- a/src/test/java/net/imagej/ops/map/parallel/ThreadedMapTest.java
+++ b/src/test/java/net/imagej/ops/map/parallel/ThreadedMapTest.java
@@ -35,11 +35,11 @@ import net.imagej.ops.AbstractInplaceFunction;
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.AbstractStrictFunction;
 import net.imagej.ops.Op;
-import net.imagej.ops.map.MapII2II;
-import net.imagej.ops.map.MapII2RAI;
-import net.imagej.ops.map.ParallelMap;
-import net.imagej.ops.map.ParallelMapI2I;
-import net.imagej.ops.map.ParallelMapI2R;
+import net.imagej.ops.map.MapIterableIntervalToIterableInterval;
+import net.imagej.ops.map.MapIterableIntervalToRAI;
+import net.imagej.ops.map.MapParallel;
+import net.imagej.ops.map.MapIterableToIterableParallel;
+import net.imagej.ops.map.MapIterableToRAIParallel;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -48,9 +48,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Testing multi threaded implementation ({@link ParallelMapI2R} and
- * {@link ParallelMapI2I}) of the mappers. Assumption: Naive Implementation of
- * {@link MapII2RAI} works fine.
+ * Testing multi threaded implementation ({@link MapIterableToRAIParallel} and
+ * {@link MapIterableToIterableParallel}) of the mappers. Assumption: Naive Implementation of
+ * {@link MapIterableIntervalToRAI} works fine.
  * 
  * @author Christian Dietz
  */
@@ -69,7 +69,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 	public void testMapII() {
 
 		final Op functional =
-			ops.op(MapII2II.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableIntervalToIterableInterval.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();
@@ -86,7 +86,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 	public void testFunctionMapIIRAIP() {
 
 		final Op functional =
-			ops.op(ParallelMapI2R.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableToRAIParallel.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();
@@ -104,7 +104,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 	public void testFunctionMapIIP() {
 
 		final Op functional =
-			ops.op(ParallelMapI2I.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableToIterableParallel.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();
@@ -123,7 +123,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 		final Cursor<ByteType> cursor1 = in.copy().cursor();
 		final Cursor<ByteType> cursor2 = in.cursor();
 
-		final Op functional = ops.op(ParallelMap.class, in, new AddOneInplace());
+		final Op functional = ops.op(MapParallel.class, in, new AddOneInplace());
 		functional.run();
 
 		while (cursor1.hasNext()) {

--- a/src/test/java/net/imagej/ops/map/view/MapViewTest.java
+++ b/src/test/java/net/imagej/ops/map/view/MapViewTest.java
@@ -34,9 +34,9 @@ import static org.junit.Assert.assertEquals;
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Op;
 import net.imagej.ops.arithmetic.add.AddConstantToNumericType;
-import net.imagej.ops.map.MapII2View;
-import net.imagej.ops.map.MapRA2View;
-import net.imagej.ops.map.MapRAI2View;
+import net.imagej.ops.map.MapIterableIntervalToView;
+import net.imagej.ops.map.MapConvertRandomAccessToRandomAccess;
+import net.imagej.ops.map.MapConvertRAIToRAI;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
@@ -68,7 +68,7 @@ public class MapViewTest extends AbstractOpTest {
 	public void testRandomAccessibleView() {
 		@SuppressWarnings("unchecked")
 		final RandomAccessible<ByteType> res =
-			(RandomAccessible<ByteType>) ops.run(MapRA2View.class, in, op,
+			(RandomAccessible<ByteType>) ops.run(MapConvertRandomAccessToRandomAccess.class, in, op,
 				new ByteType());
 
 		final Cursor<ByteType> iterable =
@@ -83,7 +83,7 @@ public class MapViewTest extends AbstractOpTest {
 	public void testRandomAccessibleIntervalView() {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<ByteType> res =
-			(RandomAccessibleInterval<ByteType>) ops.run(MapRAI2View.class, in, op,
+			(RandomAccessibleInterval<ByteType>) ops.run(MapConvertRAIToRAI.class, in, op,
 				new ByteType());
 
 		final Cursor<ByteType> iterable = Views.iterable(res).cursor();
@@ -97,7 +97,7 @@ public class MapViewTest extends AbstractOpTest {
 	public void testIterableIntervalView() {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<ByteType> res =
-			(IterableInterval<ByteType>) ops.run(MapII2View.class, in, op,
+			(IterableInterval<ByteType>) ops.run(MapIterableIntervalToView.class, in, op,
 				new ByteType());
 
 		final Cursor<ByteType> iterable = res.cursor();

--- a/src/test/java/net/imagej/ops/project/ProjectTest.java
+++ b/src/test/java/net/imagej/ops/project/ProjectTest.java
@@ -33,7 +33,7 @@ package net.imagej.ops.project;
 import static org.junit.Assert.assertEquals;
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Op;
-import net.imagej.ops.project.parallel.DefaultProjectP;
+import net.imagej.ops.project.parallel.DefaultProjectParallel;
 import net.imagej.ops.statistics.Sum;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
@@ -71,8 +71,8 @@ public class ProjectTest extends AbstractOpTest {
 
 	@Test
 	public void testProjector() {
-		ops.run(ProjectRAI2II.class, out1, in, op, PROJECTION_DIM);
-		ops.run(DefaultProjectP.class, out2, in, op, PROJECTION_DIM);
+		ops.run(ProjectRAIToIterableInterval.class, out1, in, op, PROJECTION_DIM);
+		ops.run(DefaultProjectParallel.class, out2, in, op, PROJECTION_DIM);
 
 		// test
 		final Cursor<ByteType> out1Cursor = out1.cursor();

--- a/src/test/java/net/imagej/ops/threading/RunInterleavedChunker.java
+++ b/src/test/java/net/imagej/ops/threading/RunInterleavedChunker.java
@@ -34,7 +34,7 @@ import net.imagej.ops.Op;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.chunker.CursorBasedChunk;
-import net.imagej.ops.chunker.InterleavedChunker;
+import net.imagej.ops.chunker.ChunkerInterleaved;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
@@ -56,7 +56,7 @@ public class RunInterleavedChunker<A extends RealType<A>> extends
 	public IterableInterval<A> compute(final IterableInterval<A> input,
 			final IterableInterval<A> output) {
 		
-			opService.run(InterleavedChunker.class, new CursorBasedChunk() {
+			opService.run(ChunkerInterleaved.class, new CursorBasedChunk() {
 
 			@Override
 			public void	execute(int startIndex, final int stepSize, final int numSteps)

--- a/src/test/java/net/imagej/ops/threading/RunInterleavedChunkerArray.java
+++ b/src/test/java/net/imagej/ops/threading/RunInterleavedChunkerArray.java
@@ -34,7 +34,7 @@ import net.imagej.ops.Op;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.chunker.Chunk;
-import net.imagej.ops.chunker.InterleavedChunker;
+import net.imagej.ops.chunker.ChunkerInterleaved;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
@@ -52,7 +52,7 @@ public class RunInterleavedChunkerArray<A> extends
 	public A[] compute(final A[] input,
 			final A[] output) {
 		
-		opService.run(InterleavedChunker.class, new Chunk() {
+		opService.run(ChunkerInterleaved.class, new Chunk() {
 
 			@Override
 			public void	execute(int startIndex, final int stepSize, final int numSteps)


### PR DESCRIPTION
While programming with ops, we figured, that the current way of method
naming causes a. confusion as it wasn't easily understandable
and b. was pretty inconsistent. Therefore we used the following naming
schema in addition to whats already written down in the WIKI:

- RandomAccessibleInterval -> Rai as the only abbreviation.
- Mappings are written with "To" instead of "2".
- OpXYInterface -> AbstractOpXY -> DefaultOpXY -> OpXYSpecialFunction

For me this somehow looks nicer and is easier to read. However, I'm happy to discuss a better naming schema with all of you. As soon as this PR is merged, I will update https://github.com/imagej/imagej-ops/wiki/Naming. 