### PR TITLE
Add OpResolverService

### DIFF
--- a/src/main/java/net/imagej/ops/resolver/DefaultOpResolverService.java
+++ b/src/main/java/net/imagej/ops/resolver/DefaultOpResolverService.java
@@ -1,0 +1,607 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.resolver;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import net.imagej.ops.Computer;
+import net.imagej.ops.InputOp;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpCandidate;
+import net.imagej.ops.OpMatchingService;
+import net.imagej.ops.OpRef;
+import net.imagej.ops.OpService;
+import net.imagej.ops.OutputOp;
+
+import org.scijava.convert.ConversionRequest;
+import org.scijava.convert.ConvertService;
+import org.scijava.module.MethodCallException;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleException;
+import org.scijava.module.ModuleInfo;
+import org.scijava.module.ModuleItem;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.AbstractService;
+import org.scijava.service.Service;
+
+/**
+ * Default implementation of the {@link OpResolverService}. {@link Op}s are
+ * resolved using a heuristic, which simply always takes the locally best
+ * {@link Op}, which means the {@link Op} with the highest priority. NB: A
+ * smarter implementation of the {@link OpResolverService} could find globally
+ * optimal solutions.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = OpResolverService.class)
+public class DefaultOpResolverService extends AbstractService implements
+	OpResolverService
+{
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private ConvertService cs;
+
+	@Parameter
+	private OpMatchingService matcher;
+
+	@Override
+	public <I> ResolvedOpSet<I> resolve(I input, OpRef<?>... refs) {
+		Set<OpRef<?>> pool = new HashSet<OpRef<?>>();
+		pool.addAll(Arrays.asList(refs));
+		return resolve(input, pool);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public <I, OP extends Op> Computer<I, OP> resolve(I input, Class<OP> type,
+		Object... args)
+	{
+		return resolve(input, new OpRef(type, args));
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public <I, O> Computer<I, O> resolve(Class<O> outType, I input,
+		OpRef<? extends OutputOp> ref)
+	{
+		final Computer<I, ? extends OutputOp> resolved = resolve(input, ref);
+		return new Computer<I, O>() {
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public O compute(I input) {
+				return ((OutputOp<O>) resolved.compute(input)).getOutput();
+			}
+		};
+	}
+
+	@Override
+	public <I, OP extends Op> Computer<I, OP> resolve(final I input,
+		final OpRef<OP> opRef)
+	{
+		final HashSet<OpRef<?>> set = new HashSet<OpRef<?>>();
+		set.add(opRef);
+
+		final ResolvedOpSet<I> resolved = resolve(input, set);
+		return new Computer<I, OP>() {
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public OP compute(I input) {
+				return (OP) resolved.compute(input).get(opRef);
+			}
+		};
+	}
+
+	@Override
+	public <I> ResolvedOpSet<I>
+		resolve(final I input, final Set<OpRef<?>> opPool)
+	{
+
+		final SourceOp<I> inputSource = new SourceOp<I>(input);
+
+		final Map<OpRef<?>, CachedModule> modulePool =
+			new HashMap<OpRef<?>, CachedModule>();
+
+		for (final OpRef<?> ref : opPool) {
+			try {
+				if (null == resolveModule(ref, opPool, inputSource, modulePool)) {
+					throw new IllegalArgumentException("Can't compile set of OpRefs!" +
+						" Reason:" + ref.getType().getSimpleName() +
+						" can't be auto-resolved!");
+				}
+
+			}
+			catch (ModuleException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		postProcess(modulePool, inputSource);
+
+		return new ResolvedOpSet<I>(inputSource, modulePool, opPool);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public <I, O> Computer<I, O> resolve(final Class<O> outType, final I input,
+		final Class<? extends OutputOp> o, Object... args)
+	{
+		return this.<I, O> resolve(outType, input, new OpRef(o, args));
+	}
+
+	/* Create one update listener */
+	private InputUpdateListener createUpdateListener(final Module module,
+		final ModuleItem<?> item)
+	{
+		return new InputUpdateListener() {
+
+			@Override
+			public void update(final Object o) {
+				ConversionRequest cr = new ConversionRequest(o, item.getType());
+
+				if (item.getType().isAssignableFrom(o.getClass())) {
+					module.setInput(item.getName(), o);
+				}
+				else if (cs.supports(cr)) {
+					module.setInput(item.getName(), cs.convert(cr));
+
+				}
+			}
+
+			// TODO: be more restrictive concerning generics here
+			@Override
+			public boolean listensTo(final Class<?> clazz) {
+				return item.getType().isAssignableFrom(clazz);
+			}
+
+			@Override
+			public String toString() {
+				return module.getInfo().getName();
+			}
+		};
+	}
+
+	private void postProcess(final Map<OpRef<?>, ? extends Module> modulePool,
+		final SourceOp<?> inputSource)
+	{
+
+		for (final Entry<OpRef<?>, ? extends Module> entry : modulePool.entrySet())
+		{
+			final Module module = entry.getValue();
+
+			for (final ModuleItem<?> item : module.getInfo().inputs()) {
+				final Class<?> type = item.getType();
+
+				// fields we can ignore during post-processing
+				if (Op.class.isAssignableFrom(type) ||
+					Service.class.isAssignableFrom(type) || !item.isRequired())
+				{
+					continue;
+				}
+
+				// TODO: we need to take care about generics here.
+				final InputUpdateListener listener = createUpdateListener(module, item);
+
+				// its an input parameter that we can convert
+				ConversionRequest cr =
+					new ConversionRequest(inputSource.getType(), type);
+				if (type.isAssignableFrom(inputSource.getType()) || cs.supports(cr)) {
+
+					inputSource.registerListener(listener);
+					// only use input !!ONCE!!
+					break;
+				}
+			}
+
+		}
+	}
+
+	// INTERNAL
+	private <I> CachedModule resolveModule(final OpRef<?> op,
+		final Set<OpRef<?>> opPool, final SourceOp<I> inputSource,
+		final Map<OpRef<?>, CachedModule> modulePool) throws ModuleException
+	{
+
+		if (modulePool.containsKey(op)) {
+			return modulePool.get(op);
+		}
+
+		// see if there are any candidates in the set of helpers or features
+		// which may also provide parameters
+		for (final OpRef<?> ref : opPool) {
+			if (op.getType().isAssignableFrom(ref.getType())) {
+				try {
+
+					CachedModule module = modulePool.get(ref);
+					if (module != null) return module;
+
+					Module tmp = ops.module(ref.getType(), ref.getArgs());
+					if (tmp != null) {
+
+						// here I need to instantiate the module differently as
+						// some of the parameters are already resolved.
+						//
+						module =
+							checkIfAvailable(ref, tmp.getInfo(), modulePool, inputSource,
+								opPool, ref.getArgs());
+						if (module != null) return module;
+					}
+				}
+				catch (IllegalArgumentException iae) {
+					// Nothing to do
+				}
+			}
+		}
+
+		// get all candidate ops for this module type
+		final List<OpCandidate<?>> candidates = createCandidates(op.getType());
+
+		// if there are no canidates, we can't resolve this module (and we fail)
+		if (candidates.size() == 0) {
+			return null;
+		}
+
+		// now: we check for the candidates. A candidate can be used, if all
+		// fields can be resolved, given the available set of operations.
+		// the only exceptions are special fields which are neither of
+		// inputType nor a DescriptorParameterSet.
+		for (final OpCandidate<?> candidate : candidates) {
+			final CachedModule m =
+				checkIfAvailable(op, candidate.getInfo(), modulePool, inputSource,
+					opPool, null);
+
+			if (m != null) return m;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param op
+	 * @return
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private List<OpCandidate<?>> createCandidates(final Class<? extends Op> op) {
+		return matcher.findCandidates(new OpRef(op));
+	}
+
+	/**
+	 * @param op
+	 * @return
+	 */
+	private <O extends Op> OpRef<O> createOpRef(final Class<O> type) {
+		return new OpRef<O>(type);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <I> CachedModule checkIfAvailable(final OpRef<?> parent,
+		final ModuleInfo candidate,
+		final Map<OpRef<?>, CachedModule> existingModules,
+		final SourceOp<I> inputSource, final Set<OpRef<?>> helpers,
+		final Object[] param)
+	{
+
+		final List<Object> resolvedParams = new ArrayList<Object>();
+
+		final List<CachedModule> dependencies = new ArrayList<CachedModule>();
+
+		final HashMap<OpRef<?>, CachedModule> tmpCompiledModules =
+			new HashMap<OpRef<?>, CachedModule>(existingModules);
+
+		int i = -1;
+
+		// we have to parse our items for other ops/features
+		for (final ModuleItem<?> item : candidate.inputs()) {
+			i++;
+
+			final Class<?> itemType = item.getType();
+
+			if (!item.isRequired() || Service.class.isAssignableFrom(itemType)) {
+				continue;
+			}
+
+			// It's an input parameter, we can ignore it
+			if (itemType.isAssignableFrom(inputSource.getType())) {
+				resolvedParams.add(inputSource.getInput());
+				continue;
+			}
+
+			// Handle operation
+			if (Op.class.isAssignableFrom(itemType)) {
+				final Class<? extends Op> opToResolve = (Class<? extends Op>) itemType;
+
+				if (tmpCompiledModules.containsKey(opToResolve)) {
+					resolvedParams.add(tmpCompiledModules.get(opToResolve)
+						.getDelegateObject());
+					dependencies.add(tmpCompiledModules.get(opToResolve));
+				}
+				else {
+					try {
+
+						CachedModule res =
+							resolveModule(createOpRef(opToResolve), helpers, inputSource,
+								tmpCompiledModules);
+
+						if (res == null) {
+							return null;
+						}
+
+						dependencies.add(res);
+						resolvedParams.add(res.getDelegateObject());
+					}
+					catch (ModuleException e) {
+						throw new RuntimeException(e);
+					}
+				}
+				continue;
+			}
+
+			// check if we can use on of the parameters
+			if (param != null && param.length > i && param[i] != null &&
+				cs.supports(param[i], itemType))
+			{
+				resolvedParams.add(param[i]);
+				continue;
+			}
+
+			// last option, check if we can convert the input
+			if (cs.supports(new ConversionRequest(inputSource.getType(), itemType))) {
+				resolvedParams.add(itemType);
+				continue;
+			}
+
+			return null;
+		}
+
+		final CachedModule module =
+			new CachedModule(ops.module(parent.getType(), resolvedParams.toArray()));
+
+		// set-up graph...
+		for (final CachedModule dependency : dependencies) {
+			dependency.addSuccessor(module);
+			module.addPredecessor(dependency);
+		}
+
+		// we build our "tree"
+		tmpCompiledModules.put(parent, module);
+
+		// we know that only additional modules are in local map
+		for (final Entry<OpRef<?>, CachedModule> entry : tmpCompiledModules
+			.entrySet())
+		{
+			existingModules.put(entry.getKey(), entry.getValue());
+		}
+
+		return module;
+	}
+
+	private class CachedModule implements Module {
+
+		private ArrayList<CachedModule> successors = new ArrayList<CachedModule>();
+		private ArrayList<CachedModule> predeccessors =
+			new ArrayList<CachedModule>();
+		private final Map<ModuleItem<?>, Set<InputUpdateListener>> outputReceivers =
+			new HashMap<ModuleItem<?>, Set<InputUpdateListener>>();
+		private final Module module;
+
+		public CachedModule(final Module module) {
+			this.module = module;
+		}
+
+		boolean dirty = true;
+
+		@Override
+		public void run() {
+			if (dirty) {
+				runPredeccessors();
+				module.run();
+				for (final Entry<ModuleItem<?>, Set<InputUpdateListener>> entry : outputReceivers
+					.entrySet())
+				{
+					// update the listeners if there are any
+					for (final InputUpdateListener listener : entry.getValue()) {
+						listener.update(module.getOutput(entry.getKey().getName()));
+					}
+				}
+				dirty = false;
+			}
+		}
+
+		void markDirty() {
+			dirty = true;
+			notifySuccessors();
+		}
+
+		private void notifySuccessors() {
+			for (final CachedModule op : successors) {
+				op.markDirty();
+			}
+		}
+
+		private void runPredeccessors() {
+			for (final CachedModule module : predeccessors) {
+				module.run();
+			}
+		}
+
+		public void addSuccessor(final CachedModule op) {
+			successors.add(op);
+		}
+
+		public void addPredecessor(final CachedModule op) {
+			predeccessors.add(op);
+		}
+
+		@Override
+		public void preview() {
+			module.preview();
+		}
+
+		@Override
+		public void cancel() {
+			module.cancel();
+		}
+
+		@Override
+		public void initialize() throws MethodCallException {
+			module.initialize();
+		}
+
+		@Override
+		public ModuleInfo getInfo() {
+			return module.getInfo();
+		}
+
+		@Override
+		public Object getDelegateObject() {
+			return module.getDelegateObject();
+		}
+
+		@Override
+		public Object getInput(final String name) {
+			return module.getInput(name);
+		}
+
+		@Override
+		public Object getOutput(final String name) {
+			return module.getOutput(name);
+		}
+
+		@Override
+		public Map<String, Object> getInputs() {
+			return module.getInputs();
+		}
+
+		@Override
+		public Map<String, Object> getOutputs() {
+			return module.getOutputs();
+		}
+
+		@Override
+		public void setInput(final String name, final Object value) {
+			markDirty();
+			module.setInput(name, value);
+		}
+
+		@Override
+		public void setOutput(final String name, final Object value) {
+			module.setOutput(name, value);
+		}
+
+		@Override
+		public void setInputs(final Map<String, Object> inputs) {
+			for (final Entry<String, Object> entry : inputs.entrySet()) {
+				setInput(entry.getKey(), entry.getValue());
+			}
+		}
+
+		@Override
+		public void setOutputs(final Map<String, Object> outputs) {
+			module.setOutputs(outputs);
+		}
+
+		@Override
+		public boolean isResolved(final String name) {
+			return module.isResolved(name);
+		}
+
+		@Override
+		public void setResolved(final String name, final boolean resolved) {
+			module.setResolved(name, resolved);
+		}
+
+		@Override
+		public String toString() {
+			return module.getInfo().getName();
+		}
+	}
+
+	private class SourceOp<I> implements InputOp<I> {
+
+		private ArrayList<InputUpdateListener> listeners =
+			new ArrayList<InputUpdateListener>();
+
+		private I input;
+
+		public SourceOp(final I input) {
+			this.input = input;
+		}
+
+		public void setInput(final I input) {
+			this.input = input;
+		}
+
+		public void registerListener(final InputUpdateListener listener) {
+			listeners.add(listener);
+		}
+
+		@SuppressWarnings("unchecked")
+		public Class<? extends I> getType() {
+			return (Class<? extends I>) input.getClass();
+		}
+
+		public I getInput() {
+			return input;
+		}
+
+		@Override
+		public void run() {
+			for (final InputUpdateListener listener : listeners) {
+				listener.update(input);
+			}
+		}
+	}
+
+	/*
+	 * Simple helper to mark Descriptors which listen for updates of external
+	 * inputs (i.e. inputs which are not generated by an {@link Op}).
+	 * 
+	 * @author Christian Dietz (University of Konstanz)
+	 */
+	private interface InputUpdateListener {
+
+		void update(Object o);
+
+		boolean listensTo(Class<?> clazz);
+	}
+}

--- a/src/main/java/net/imagej/ops/resolver/OpResolverService.java
+++ b/src/main/java/net/imagej/ops/resolver/OpResolverService.java
@@ -1,0 +1,143 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.resolver;
+
+import java.util.Map;
+import java.util.Set;
+
+import net.imagej.ops.Computer;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpRef;
+import net.imagej.ops.OutputOp;
+
+import org.scijava.service.Service;
+
+/**
+ * Given a set of {@link Op}s, the {@link OpResolverService} will create a
+ * directed acyclic graph (DAC) with a single source for the input. The
+ * {@link OpResolverService} finds dependencies between {@link Op}s and
+ * automatically injects all missing {@link Op}s, which other {@link Op}s
+ * potentially need to be executed. Example: A potential 'Mean' operation
+ * depends on the 'Area' and 'Sum' {@link Op}s. The 'Mean' {@link Op} is passed
+ * to the {@link OpResolverService}, which in turn will try to find suitable
+ * 'Area' and 'Sum' {@link Op}s which operate on the given input and inject them
+ * to the 'Mean' {@link Op}. The resulting {@link Computer} can then take
+ * arbitrary inputs of the same type and with equals properties as the input
+ * used for resolving the {@link Op}.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public interface OpResolverService extends Service {
+
+	/**
+	 * Resolves a {@link Set} of {@link OpRef}s. The resulting {@link Computer}
+	 * will calculate the output of all resolved {@link Op}s. Each computation
+	 * results in a {@link Map} from {@link OpRef} to the corresponding {@link Op}
+	 * which can be used to access the resolved {@link Op}s and their outputs.
+	 * 
+	 * @param input representing all the inputs which serve as input of the
+	 *          resulting {@link Computer}.
+	 * @param opPool {@link OpRef}s of {@link Op}s which will be automatically
+	 *          resolved.
+	 * @return a {@link Computer}.
+	 */
+	<I> Computer<I, Map<OpRef<?>, Op>> resolve(final I input,
+		final Set<OpRef<?>> opPool);
+
+	/**
+	 * Resolves an array of {@link OpRef}s. The resulting {@link Computer} will
+	 * calculate the output of all resolved {@link Op}s. Each computation results
+	 * in a {@link Map} from {@link OpRef} to the corresponding {@link Op} which
+	 * can be used to access the resolved {@link Op}s and their outputs.
+	 * 
+	 * @param input
+	 * @param refs
+	 * @return
+	 */
+	<I> Computer<I, Map<OpRef<?>, Op>> resolve(final I input, OpRef<?>... refs);
+
+	/**
+	 * Resolves a single {@link OpRef}. The resulting {@link Computer} can be
+	 * updated with some input. The output of the {@link Computer} is an already
+	 * resolved and executed {@link Op}.
+	 * 
+	 * @param input representing all the inputs which serve as input of the
+	 *          resulting {@link Computer}.
+	 * @param ref a single {@link OpRef} which will be resolved.
+	 * @return a {@link Computer}.
+	 */
+	<I, OP extends Op> Computer<I, OP>
+		resolve(final I input, final OpRef<OP> ref);
+
+	/**
+	 * Resolves an {@link Op} given the type of the {@link Op}. The resulting
+	 * {@link Computer} can be updated with some input. The output of the
+	 * {@link Computer} is an already resolved and executed {@link Op}.
+	 * 
+	 * @param input representing all the inputs which serve as input of the
+	 *          resulting {@link Computer}.
+	 * @param type type of the {@link Op}
+	 * @param args arguments of the {@link Op}
+	 * @return a {@link Computer}.
+	 */
+	<I, OP extends Op> Computer<I, OP> resolve(final I input,
+		final Class<OP> type, final Object... args);
+
+	/**
+	 * Resolved an {@link OutputOp}. The output of the {@link OutputOp} must be of
+	 * type outType. The resulting {@link Computer} returns the output given some
+	 * input.
+	 * 
+	 * @param outType type of the output of the {@link OutputOp}
+	 * @param input type of the input
+	 * @param type type of the {@link OutputOp}
+	 * @param args arguments required to resolve the {@link OutputOp}
+	 * @return {@link Computer} computing output given some input
+	 */
+	@SuppressWarnings("rawtypes")
+	<I, O> Computer<I, O> resolve(final Class<O> outType, final I input,
+		final Class<? extends OutputOp> type, final Object... args);
+
+	/**
+	 * Resolved an {@link OutputOp}. The output of the {@link OutputOp} must be of
+	 * type outType. The resulting {@link Computer} returns the output given some
+	 * input.
+	 * 
+	 * @param outType type of the output of the {@link OutputOp}
+	 * @param input type of the input
+	 * @param ref {@link OpRef} describing the {@link OutputOp}
+	 * @param args arguments required to resolve the {@link OutputOp}
+	 * @return {@link Computer} computing output given some input
+	 */
+	@SuppressWarnings("rawtypes")
+	<I, O> Computer<I, O> resolve(final Class<O> outType, final I input,
+		final OpRef<? extends OutputOp> ref);
+}

--- a/src/main/java/net/imagej/ops/resolver/ResolvedOp.java
+++ b/src/main/java/net/imagej/ops/resolver/ResolvedOp.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.resolver;
+
+import net.imagej.ops.Computer;
+import net.imagej.ops.InputOp;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpRef;
+import net.imagej.ops.OutputOp;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+
+/**
+ * A {@link ResolvedOp} is an {@link Op} which has been resolved by the
+ * {@link OpResolverService}. It is therefore part of an {@link ResolvedOpSet}.
+ * The {@link ResolvedOp} takes care, that all {@link Op}s, which are required
+ * by the {@link ResolvedOp} are executed before the {@link ResolvedOp} itself
+ * is executed, i.e. all parameters are available.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ * @param <I> type of the input
+ * @param <O> type of the output
+ */
+class ResolvedOp<I, O> implements InputOp<I>, OutputOp<O>, Computer<I, O> {
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private O output;
+
+	@Parameter
+	private I input;
+
+	private OutputOp<O> outputOp;
+
+	private ResolvedOpSet<I> resolvedSet;
+
+	@SuppressWarnings("unchecked")
+	public ResolvedOp(final ResolvedOpSet<I> build, final OpRef<?> ref) {
+		this.outputOp = (OutputOp<O>) build.getOutput().get(ref);
+		this.resolvedSet = build;
+	}
+
+	@Override
+	public void run() {
+		resolvedSet.compute(getInput());
+		resolvedSet.run();
+		output = outputOp.getOutput();
+	}
+
+	@Override
+	public I getInput() {
+		return input;
+	}
+
+	@Override
+	public void setInput(final I input) {
+		this.input = input;
+	}
+
+	@Override
+	public O compute(I input) {
+		setInput(input);
+		run();
+		return output;
+	}
+
+	@Override
+	public O getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(O output) {
+		this.output = output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/resolver/ResolvedOpSet.java
+++ b/src/main/java/net/imagej/ops/resolver/ResolvedOpSet.java
@@ -1,0 +1,121 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.resolver;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import net.imagej.ops.Computer;
+import net.imagej.ops.InputOp;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpRef;
+import net.imagej.ops.OutputOp;
+
+import org.scijava.ItemIO;
+import org.scijava.module.Module;
+import org.scijava.plugin.Parameter;
+
+/**
+ * A {@link ResolvedOpSet} represents a set of operations, which have been
+ * resolved by the {@link OpResolverService}. The resolved {@link Op}s can be
+ * used by updating the {@link ResolvedOpSet} and access the {@link Op}s via the
+ * {@link OpRef}s which were passed to the {@link OpResolverService}.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ * @param <I> type of input
+ */
+class ResolvedOpSet<I> implements InputOp<I>, OutputOp<Map<OpRef<?>, Op>>,
+	Computer<I, Map<OpRef<?>, Op>>
+{
+
+	@Parameter
+	private I input;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Map<OpRef<?>, Op> output;
+
+	private InputOp<I> source;
+	private Map<OpRef<?>, ? extends Module> globalSet;
+
+	public ResolvedOpSet(final InputOp<I> source,
+		final Map<OpRef<?>, ? extends Module> set, final Set<OpRef<?>> outputOpRefs)
+	{
+		this.source = source;
+
+		this.globalSet = set;
+		this.output = new HashMap<OpRef<?>, Op>();
+
+		for (final OpRef<?> ref : outputOpRefs) {
+			output.put(ref, (Op) set.get(ref).getDelegateObject());
+		}
+	}
+
+	public Map<OpRef<?>, Op> get() {
+		return output;
+	}
+
+	@Override
+	public void run() {
+		source.run();
+		for (final OpRef<?> op : output.keySet()) {
+			globalSet.get(op).run();
+		}
+	}
+
+	@Override
+	public I getInput() {
+		return input;
+	}
+
+	@Override
+	public void setInput(final I input) {
+		this.input = input;
+		source.setInput(input);
+	}
+
+	@Override
+	public Map<OpRef<?>, Op> compute(final I input) {
+		setInput(input);
+		run();
+		return getOutput();
+	}
+
+	@Override
+	public Map<OpRef<?>, Op> getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(final Map<OpRef<?>, Op> output) {
+		throw new UnsupportedOperationException("Not supported");
+	}
+}

--- a/src/test/java/net/imagej/ops/resolver/ChildOne.java
+++ b/src/test/java/net/imagej/ops/resolver/ChildOne.java
@@ -1,0 +1,15 @@
+
+package net.imagej.ops.resolver;
+
+import net.imagej.ops.OutputOp;
+import net.imglib2.type.numeric.real.DoubleType;
+
+/*
+ * Just for testing
+ * 
+ * @author Christian Dietz, University of Konstanz
+ * 
+ */
+public interface ChildOne extends OutputOp<DoubleType> {
+
+}

--- a/src/test/java/net/imagej/ops/resolver/ChildOneContigent.java
+++ b/src/test/java/net/imagej/ops/resolver/ChildOneContigent.java
@@ -1,0 +1,59 @@
+
+package net.imagej.ops.resolver;
+
+import net.imagej.ops.Contingent;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = ChildOne.class, priority = Priority.VERY_HIGH_PRIORITY)
+public class ChildOneContigent implements ChildOne, Contingent {
+
+	@Parameter
+	private RandomAccessibleInterval<?> rai;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private DoubleType output;
+
+	// for testing lazy behaviour
+	private int ctr = (int) Priority.VERY_HIGH_PRIORITY;
+
+	private RandomAccessibleInterval<?> curr;
+
+	public ChildOneContigent() {
+		//
+	}
+
+	@Override
+	public void run() {
+		if (curr == null) {
+			curr = rai;
+		}
+
+		if (curr != rai) {
+			ctr++;
+		}
+		output = new DoubleType(ctr);
+	}
+
+	@Override
+	public DoubleType getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(DoubleType output) {
+		this.output = output;
+	}
+
+	@Override
+	public boolean conforms() {
+		// this is never true. However, we want to check if there is an
+		// NullPointerException thrown.
+		return rai.numDimensions() == 1337;
+	}
+}

--- a/src/test/java/net/imagej/ops/resolver/ChildOneHighPrio.java
+++ b/src/test/java/net/imagej/ops/resolver/ChildOneHighPrio.java
@@ -1,0 +1,52 @@
+
+package net.imagej.ops.resolver;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = ChildOne.class, priority = Priority.HIGH_PRIORITY)
+public class ChildOneHighPrio implements ChildOne {
+
+	@Parameter
+	private RandomAccessibleInterval<?> rai;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private DoubleType output;
+
+	// for testing lazy behaviour
+	private int ctr = (int) Priority.HIGH_PRIORITY;
+
+	private RandomAccessibleInterval<?> curr;
+
+	public ChildOneHighPrio() {
+		//
+	}
+
+	@Override
+	public void run() {
+		if (curr == null) {
+			curr = rai;
+		}
+
+		if (curr != rai) {
+			ctr++;
+		}
+		output = new DoubleType(ctr);
+	}
+
+	@Override
+	public DoubleType getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(DoubleType output) {
+		this.output = output;
+	}
+
+}

--- a/src/test/java/net/imagej/ops/resolver/ChildOneLowPriority.java
+++ b/src/test/java/net/imagej/ops/resolver/ChildOneLowPriority.java
@@ -1,0 +1,50 @@
+
+package net.imagej.ops.resolver;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = ChildOne.class)
+public class ChildOneLowPriority implements ChildOne {
+
+	@Parameter
+	private RandomAccessibleInterval<?> rai;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private DoubleType output;
+
+	// for testing lazy behaviour
+	private int ctr = 1;
+
+	private RandomAccessibleInterval<?> curr;
+
+	public ChildOneLowPriority() {
+		//
+	}
+
+	@Override
+	public void run() {
+		if (curr == null) {
+			curr = rai;
+		}
+
+		if (curr != rai) {
+			ctr++;
+		}
+		output = new DoubleType(ctr);
+	}
+
+	@Override
+	public DoubleType getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(DoubleType output) {
+		this.output = output;
+	}
+}

--- a/src/test/java/net/imagej/ops/resolver/ChildTwo.java
+++ b/src/test/java/net/imagej/ops/resolver/ChildTwo.java
@@ -1,0 +1,50 @@
+package net.imagej.ops.resolver;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.OutputOp;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+	@Plugin(type = Op.class)
+public class ChildTwo implements OutputOp<DoubleType> {
+
+	@Parameter
+	private RandomAccessibleInterval<?> rai;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private DoubleType output;
+
+	// for testing lazy behaviour
+	private int ctr = 1;
+
+	private RandomAccessibleInterval<?> curr;
+
+	public ChildTwo() {
+		//
+	}
+
+	@Override
+	public void run() {
+		if (curr == null) {
+			curr = rai;
+		}
+
+		if (curr != rai) {
+			ctr++;
+		}
+		output = new DoubleType(ctr);
+	}
+
+	@Override
+	public DoubleType getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(DoubleType output) {
+		this.output = output;
+	}
+}

--- a/src/test/java/net/imagej/ops/resolver/OpResolverTest.java
+++ b/src/test/java/net/imagej/ops/resolver/OpResolverTest.java
@@ -1,0 +1,103 @@
+
+package net.imagej.ops.resolver;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Computer;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpMatchingService;
+import net.imagej.ops.OpRef;
+import net.imagej.ops.OpService;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.Priority;
+
+/**
+ * Tests for the {@link OpResolverService}.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public class OpResolverTest extends AbstractOpTest {
+
+	private OpResolverService resolver;
+	private Img<ByteType> inputA;
+	private ArrayImg<FloatType, FloatArray> inputB;
+
+	@Before
+	public void init() {
+		resolver =
+			new Context(OpService.class, OpMatchingService.class,
+				OpResolverService.class).getService(OpResolverService.class);
+
+		inputA = generateByteTestImg(false, new long[] { 2 });
+		inputB = generateFloatArrayTestImg(false, new long[] { 2 });
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public <T extends RealType<T>> void testResolvingByOpRef() {
+		final Computer<Img<T>, ParentOp> resolved =
+			resolver.resolve((Img<T>) inputA, new OpRef<ParentOp>(ParentOp.class));
+
+		assertNotNull(resolved);
+
+		// compute for first input (assuming highest priority op was chosen)
+		assertTrue(resolved.compute((Img<T>) inputA).getOutput().get() == 1 + Priority.HIGH_PRIORITY);
+
+		// compute for first input again. should have been cached (assuming highest
+		// priority op was chosen)
+		assertTrue(resolved.compute((Img<T>) inputA).getOutput().get() == 1 + Priority.HIGH_PRIORITY);
+
+		// compute for second input (assuming highest priority op was chosen)
+		assertTrue(resolved.compute((Img<T>) inputB).getOutput().get() == 3 + Priority.HIGH_PRIORITY);
+	}
+
+	@Test
+	public void testResolvingByRefSet() {
+
+		final OpRef<ParentOp> parent = new OpRef<ParentOp>(ParentOp.class);
+
+		// Enforce low priority op...
+		final OpRef<ChildOneLowPriority> childOne =
+			new OpRef<ChildOneLowPriority>(ChildOneLowPriority.class);
+
+		Set<OpRef<?>> refSet = new HashSet<OpRef<?>>();
+		refSet.add(parent);
+		refSet.add(childOne);
+
+		final Computer<Img<ByteType>, Map<OpRef<?>, Op>> resolved =
+			resolver.resolve(inputA, refSet);
+
+		assertNotNull(resolved);
+		// compute for first input
+		assertTrue(((ParentOp) resolved.compute(inputA).get(parent)).getOutput()
+			.get() == 2);
+
+	}
+
+	@Test
+	public void testOutputOp() {
+		final Computer<Img<ByteType>, DoubleType> resolved =
+			resolver.<Img<ByteType>, DoubleType> resolve(DoubleType.class, inputA,
+				ParentOp.class);
+
+		assertNotNull(resolved);
+
+		assertTrue(resolved.compute(inputA).get() == 1 + Priority.HIGH_PRIORITY);
+	}
+}

--- a/src/test/java/net/imagej/ops/resolver/ParentOp.java
+++ b/src/test/java/net/imagej/ops/resolver/ParentOp.java
@@ -1,0 +1,41 @@
+
+package net.imagej.ops.resolver;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.OutputOp;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = Op.class)
+public class ParentOp implements OutputOp<DoubleType> {
+
+	@Parameter
+	private ChildOne inOne;
+
+	@Parameter
+	private ChildTwo inTwo;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private DoubleType output;
+
+	@Override
+	public void run() {
+		if (output == null) output = new DoubleType();
+
+		output.set(inOne.getOutput());
+		output.add(inTwo.getOutput());
+	}
+
+	@Override
+	public DoubleType getOutput() {
+		return output;
+	}
+
+	@Override
+	public void setOutput(DoubleType output) {
+		this.output = output;
+	}
+}


### PR DESCRIPTION
Hi all,

this PR introduces the `OpResolverService`, a default implementation of this service and a few unit-tests. The `OpResolverService` can be used to resolve `Op`s which have dependencies to other `Op`s. This work is part of the work we are doing in https://github.com/imagej/imagej-ops/tree/outputop-service. However, I decided to split this branch into several smaller PRs such that its more reviewable!

Thanks for feedback in advance!