### PR TITLE
Allow use of Regions.sample(region, src)

### DIFF
--- a/src/main/java/net/imagej/ops/features/zernike/ZernikeComputer.java
+++ b/src/main/java/net/imagej/ops/features/zernike/ZernikeComputer.java
@@ -82,8 +82,8 @@ public class ZernikeComputer implements Op {
 	public void fastZernikeComputation(int _nMin, int _nMax) {
 
 		// what is the acutal N
-		final double width = ii.dimension(0) - ii.min(0);
-		final double height = ii.dimension(1) - ii.min(1);
+		final double width = ii.max(0) - ii.min(0) + 1;
+		final double height = ii.max(1) - ii.min(1) + 1;
 
 		// Compute pascal's triangle for binomal coefficients: d[x][y] equals (x
 		// over y)


### PR DESCRIPTION
Use of dimension(0) and dimension(1) resulted in negative width and
height when using Regions.sample(region,src) as the dimensions referred
to the src dimensions while the min referred to the region. Use of
max(0) and max(1) results in proper calculation using region only
information. Had to add +1 to make calculation accurate and pass tests.