### PR TITLE
Update input, avoid extra calc, and copy type

### DIFF
--- a/src/main/java/net/imagej/ops/features/sets/HistogramFeatureSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/HistogramFeatureSet.java
@@ -48,14 +48,11 @@ public class HistogramFeatureSet<T extends RealType<T>> extends
 	@Override
 	public void run() {
 
-		if (op == null) {
-			op = ops.op(HistogramCreate.class, getInput(), numBins);
-			output = new HashMap<OpRef<? extends Op>, Histogram1d<T>>();
-			setOutput(output);
-		}
+		op = ops.op(HistogramCreate.class, getInput(), numBins);
+		output = new HashMap<OpRef<? extends Op>, Histogram1d<T>>();
+		setOutput(output);
 
 		op.run();
-		op.getOutput().countData(getInput());
 
 		final OpRef<HistogramCreate> ref = new OpRef<HistogramCreate>(
 				HistogramCreate.class, numBins);
@@ -73,7 +70,7 @@ public class HistogramFeatureSet<T extends RealType<T>> extends
 		int n = 0;
 		for (LongType type : op.getOutput()) {
 			res.add(new ValuePair<String, LongType>("Histogram [" + ++n + "]",
-					type));
+					type.copy()));
 		}
 
 		return res;


### PR DESCRIPTION
1) if(op == null)... sets the input once and only once so that subsequent calls to run this feature set use the same input (e.g., LabelRegion) even though it is being called with .getFeatureList(Regions.sample(region, image)) where region is a new region each time. This very likely has alternative side effects I'm not aware of so please advise otherwise. Maybe a new HistogramFeatureSet op should be created for each region, which would also likely fix the issue? Potentially, if there were a simple way to just "set" the input variable for each new call instead of creating a new op instance every time, that might work but I couldn't see how to do so.

2) Remove extra call to countData(getInput()) as this is already done with the op.run() command. See HistogramCreate class line 75.

3) Copy the "type" variable when saving into "res" otherwise, all the Pair's in "res" refer to the same instance, resulting in a histogram that contains the same value for all bins.