### PR TITLE
Refactoring of `Gauss` implementations

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import net.imagej.ops.convert.ConvertPix;
 import net.imagej.ops.create.CreateNamespace;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
+import net.imagej.ops.gauss.DefaultGaussRAI;
+import net.imagej.ops.gauss.GaussRAISingleSigma;
 import net.imagej.ops.image.ImageNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
@@ -771,14 +773,74 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	}
 
 	@Override
-	public <T extends RealType<T>> RandomAccessibleInterval<T> gauss(
-		final RandomAccessibleInterval<T> out,
-		final RandomAccessibleInterval<T> in, final double sigma)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double[] sigmas,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
 	{
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) run(
-				net.imagej.ops.gauss.GaussRAIToRAI.class, out, in, sigma);
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) run(DefaultGaussRAI.class, out, in, sigmas,
+				outOfBounds);
+		return result;
+	}
+
+	@Override
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double... sigmas)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) run(DefaultGaussRAI.class, out, in, sigmas);
+		return result;
+	}
+
+	@Override
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(final RandomAccessibleInterval<T> in,
+			final double... sigmas)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) run(DefaultGaussRAI.class, in, sigmas);
+		return result;
+	}
+
+	@Override
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(RandomAccessibleInterval<V> out,
+			RandomAccessibleInterval<T> in, double sigma)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) run(GaussRAISingleSigma.class, out, in,
+				sigma);
+		return result;
+	}
+
+	@Override
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(RandomAccessibleInterval<V> out,
+			RandomAccessibleInterval<T> in, double sigma,
+			OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) run(GaussRAISingleSigma.class, out, in,
+				sigma, outOfBounds);
+		return result;
+	}
+
+	@Override
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(final RandomAccessibleInterval<T> in,
+			final double sigma)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) run(
+				net.imagej.ops.gauss.GaussRAISingleSigma.class, in, sigma);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -535,10 +535,40 @@ public interface OpService extends PTService<Op>, ImageJService {
 	Object gauss(Object... args);
 
 	/** Executes the "gauss" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.gauss.GaussRAIToRAI.class)
-	<T extends RealType<T>> RandomAccessibleInterval<T> gauss(
-		RandomAccessibleInterval<T> out, RandomAccessibleInterval<T> in,
-		double sigma);
+	@OpMethod(op = net.imagej.ops.gauss.DefaultGaussRAI.class)
+	<T extends RealType<T>, V extends RealType<V>> RandomAccessibleInterval<V>
+		gauss(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double[] sigmas,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds);
+
+	/** Executes the "gauss" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.gauss.DefaultGaussRAI.class)
+	<T extends RealType<T>, V extends RealType<V>> RandomAccessibleInterval<V>
+		gauss(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double... sigmas);
+
+	/** Executes the "gauss" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.gauss.DefaultGaussRAI.class)
+	<T extends RealType<T>, V extends RealType<V>> RandomAccessibleInterval<V>
+		gauss(final RandomAccessibleInterval<T> in, final double... sigmas);
+
+	/** Executes the "gauss" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.gauss.GaussRAISingleSigma.class)
+	<T extends RealType<T>, V extends RealType<V>> RandomAccessibleInterval<V>
+		gauss(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double sigma);
+
+	/** Executes the "gauss" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.gauss.GaussRAISingleSigma.class)
+	<T extends RealType<T>, V extends RealType<V>> RandomAccessibleInterval<V>
+		gauss(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double sigma,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds);
+
+	@OpMethod(op = net.imagej.ops.gauss.GaussRAISingleSigma.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> gauss(final RandomAccessibleInterval<T> in,
+			final double sigma);
 
 	/** Executes the "help" operation on the given arguments. */
 	@OpMethod(op = Ops.Help.class)

--- a/src/main/java/net/imagej/ops/gauss/GaussRAISingleSigma.java
+++ b/src/main/java/net/imagej/ops/gauss/GaussRAISingleSigma.java
@@ -1,0 +1,92 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.gauss;
+
+import java.util.Arrays;
+
+import net.imagej.ops.AbstractOutputFunction;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Gauss;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link Gauss} which can be called with single sigma, i.e. the sigma is the
+ * same in each dimension.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ * @param <T> type of input
+ * @param <V> type of output
+ */
+@SuppressWarnings({ "unchecked" })
+@Plugin(type = Op.class, name = Gauss.NAME)
+public class GaussRAISingleSigma<T extends RealType<T>, V extends RealType<V>>
+	extends
+	AbstractOutputFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<V>>
+	implements Ops.Gauss
+{
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private double sigma;
+
+	@Parameter(required = false)
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds;
+
+	@Override
+	public void safeCompute(final RandomAccessibleInterval<T> input,
+		final RandomAccessibleInterval<V> output)
+	{
+
+		final double[] sigmas = new double[input.numDimensions()];
+		Arrays.fill(sigmas, sigma);
+
+		ops.run(Gauss.class, output, input, sigmas, outOfBounds);
+	}
+
+	@Override
+	public RandomAccessibleInterval<V> createOutput(
+		final RandomAccessibleInterval<T> input)
+	{
+		return (RandomAccessibleInterval<V>) ops.create().img(input,
+			Util.getTypeFromInterval(input));
+	}
+
+}


### PR DESCRIPTION
In this first step of refactoring the default implementation `Gauss` we redefine which parameters are used. Especially, we allow the sigmas to vary over the dimensions. However, this is only a first step, as we should use convolve `Op`s as soon as `SeparableSymmetricConvolution` of ImgLib2 is integrated. 

