### PR TITLE
Add CCA

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -44,6 +44,7 @@ import net.imagej.ops.chunker.Chunker;
 import net.imagej.ops.convert.ConvertPix;
 import net.imagej.ops.create.CreateOps;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
+import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
 import net.imagej.ops.math.MathNamespace;
 import net.imagej.ops.misc.Size;
@@ -108,7 +109,10 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	private LogicNamespace logic;
 	private MathNamespace math;
 	private ThresholdNamespace threshold;
+	private LabelingNamespace labeling;
+
 	private boolean namespacesReady;
+
 
 	// -- OpService methods --
 
@@ -1962,6 +1966,12 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 		return threshold;
 	}
 
+	@Override
+	public LabelingNamespace labeling() {
+		if (!namespacesReady) initNamespaces();
+		return labeling;
+	}
+
 	// -- SingletonService methods --
 
 	@Override
@@ -1997,6 +2007,8 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 		getContext().inject(math);
 		threshold = new ThresholdNamespace();
 		getContext().inject(threshold);
+		labeling = new LabelingNamespace();
+		getContext().inject(labeling);
 		namespacesReady = true;
 	}
 

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -41,6 +41,7 @@ import net.imagej.ops.chunker.Chunk;
 import net.imagej.ops.convert.ConvertPix;
 import net.imagej.ops.create.CreateOps;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
+import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
 import net.imagej.ops.math.MathNamespace;
 import net.imagej.ops.misc.Size;
@@ -1144,5 +1145,8 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	/** Gateway into ops of the "threshold" namespace. */
 	ThresholdNamespace threshold();
+
+	/** Gateway into ops of the "labeling" namespace. */
+	LabelingNamespace labeling();
 
 }

--- a/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
+++ b/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.labeling;
+
+import java.util.Iterator;
+
+import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpMethod;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.roi.labeling.ImgLabeling;
+import net.imglib2.type.numeric.IntegerType;
+
+/**
+ * Namespace for {@link Op}s related to Labelings.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public class LabelingNamespace extends AbstractNamespace {
+
+	@OpMethod(op = net.imagej.ops.LabelingOps.CCA.class)
+	public <T extends IntegerType<T>, L, I extends IntegerType<I>>
+		ImgLabeling<L, I> cca(Object... args)
+	{
+		@SuppressWarnings("unchecked")
+		final ImgLabeling<L, I> result =
+			(ImgLabeling<L, I>) ops().run(net.imagej.ops.LabelingOps.CCA.class, args);
+		return result;
+	}
+
+	@Override
+	public String getName() {
+		return "labeling";
+	}
+
+}

--- a/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
+++ b/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
@@ -57,6 +57,32 @@ public class LabelingNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.labeling.cca.DefaultCCA.class)
+	public <T extends IntegerType<T>, L, I extends IntegerType<I>>
+		ImgLabeling<L, I> cca(final ImgLabeling<L, I> out,
+			final RandomAccessibleInterval<T> in, final StructuringElement element,
+			final Iterator<L> labelGenerator)
+	{
+
+		return cca(out, in, element, labelGenerator);
+	}
+
+	@OpMethod(op = net.imagej.ops.labeling.cca.DefaultCCA.class)
+	public <T extends IntegerType<T>, L, I extends IntegerType<I>>
+		ImgLabeling<L, I> cca(final RandomAccessibleInterval<T> in,
+			final StructuringElement element)
+	{
+		return cca(null, in, element, null);
+	}
+
+	@OpMethod(op = net.imagej.ops.labeling.cca.DefaultCCA.class)
+	public <T extends IntegerType<T>, L, I extends IntegerType<I>>
+		ImgLabeling<L, I> cca(final ImgLabeling<L, I> out,
+			final RandomAccessibleInterval<T> in, final StructuringElement element)
+	{
+		return cca(out, in, element, null);
+	}
+
 	@Override
 	public String getName() {
 		return "labeling";

--- a/src/main/java/net/imagej/ops/labeling/cca/DefaultCCA.java
+++ b/src/main/java/net/imagej/ops/labeling/cca/DefaultCCA.java
@@ -1,0 +1,125 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.labeling.cca;
+
+import java.util.Iterator;
+
+import net.imagej.ops.AbstractOutputFunction;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.LabelingOps.CCA;
+import net.imagej.ops.OpService;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.labeling.ConnectedComponents;
+import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.roi.labeling.ImgLabeling;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.util.Intervals;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.thread.ThreadService;
+
+/**
+ * Default Implementation wrapping {@link ConnectedComponents} of
+ * ImgLib2-algorithms.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CCA.class, name = CCA.NAME, priority = 1.0)
+public class DefaultCCA<T extends IntegerType<T>, L, I extends IntegerType<I>>
+	extends
+	AbstractOutputFunction<RandomAccessibleInterval<T>, ImgLabeling<L, I>>
+	implements Contingent, CCA
+{
+
+	@Parameter
+	private ThreadService threads;
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private StructuringElement se;
+
+	@Parameter(required = false)
+	private Iterator<L> labelGenerator;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected ImgLabeling<L, I> safeCompute(RandomAccessibleInterval<T> input,
+		ImgLabeling<L, I> output)
+	{
+		if (labelGenerator == null) {
+			labelGenerator = (Iterator<L>) new DefaultLabelIterator();
+		}
+
+		ConnectedComponents.labelAllConnectedComponents(input, output,
+			labelGenerator, se, threads.getExecutorService());
+
+		return output;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ImgLabeling<L, I>
+		createOutput(final RandomAccessibleInterval<T> input)
+	{
+		return (ImgLabeling<L, I>) ops.createImgLabeling(input);
+	}
+
+	@Override
+	public boolean conforms() {
+		if (getOutput() != null) {
+			return Intervals.equalDimensions(getInput(), getOutput());
+		}
+		else {
+			return true;
+		}
+	}
+
+	/*
+	 * Simple Default LabelIterator providing integer labels, starting from zero.
+	 */
+	class DefaultLabelIterator implements Iterator<Integer> {
+
+		private Integer i = 0;
+
+		@Override
+		public boolean hasNext() {
+			return i < Integer.MAX_VALUE;
+		}
+
+		@Override
+		public Integer next() {
+			return i++;
+		}
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -175,3 +175,13 @@ ops = ```
 	[name: "richardsonLucy",         iface: "RichardsonLucy"]
 ]
 ```
+
+[LabelingOps.java]
+className = "LabelingOps"
+namespace = "labeling"
+authors = ["Christian Dietz"]
+ops = ```
+[
+	[name: "cca", iface: "CCA", aliases: ["connected-components", "connected-component-analysis"]]
+]
+```

--- a/src/test/java/net/imagej/ops/labeling/LabelingNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/labeling/LabelingNamespaceTest.java
@@ -1,0 +1,53 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.labeling;
+
+import net.imagej.ops.AbstractNamespaceTest;
+import net.imagej.ops.LabelingOps.CCA;
+
+import org.junit.Test;
+
+/**
+ * Tests that the ops of the {@code labeling} namespace have corresponding
+ * type-safe Java method signatures declared in the {@link LabelingNamespace}
+ * class.
+ *
+ * @author Christian Dietz, University of Konstanz
+ */
+public class LabelingNamespaceTest extends AbstractNamespaceTest {
+
+	/** Tests for {@link CCA} method convergence. */
+	@Test
+	public void testCCA() {
+		assertComplete("labeling", LabelingNamespace.class, CCA.NAME);
+	}
+
+}


### PR DESCRIPTION
This PR adds a wrapper for the `ConnectedComponents` implementation of imglib2-algorithms (see https://github.com/imglib/imglib2-algorithm/blob/master/src/main/java/net/imglib2/algorithm/labeling/ConnectedComponents.java). 