### PR TITLE
Add difference of gaussian implementations

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -73,8 +73,8 @@ public class FilterNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final O result =
-			(O) ops().run(net.imagej.ops.filter.addNoise.AddNoiseRealType.class, out, in,
-				rangeMin, rangeMax, rangeStdDev, rng);
+			(O) ops().run(net.imagej.ops.filter.addNoise.AddNoiseRealType.class, out,
+				in, rangeMin, rangeMax, rangeStdDev, rng);
 		return result;
 	}
 
@@ -697,6 +697,94 @@ public class FilterNamespace extends AbstractNamespace {
 			(List<long[]>) ops().run(
 				net.imagej.ops.filter.fftSize.ComputeFFTSize.class, inputSize,
 				paddedSize, fftSize, forward, fast);
+		return result;
+	}
+
+	// -- difference of gaussian --
+	@OpMethod(op = Ops.Filter.DoG.class)
+	public Object dog(Object... args) {
+		return ops().run(Ops.Filter.DoG.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoG.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double[] sigmas1,
+			final double[] sigmas2,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) ops().run(
+				net.imagej.ops.filter.dog.DefaultDoG.class, out, in, sigmas1, sigmas2,
+				outOfBounds);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoG.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double[] sigmas1,
+			final double... sigmas2)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) ops().run(
+				net.imagej.ops.filter.dog.DefaultDoG.class, out, in, sigmas1, sigmas2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoG.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<T> in,
+			final double[] sigmas1, final double... sigmas2)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) ops().run(
+				net.imagej.ops.filter.dog.DefaultDoG.class, in, sigmas1, sigmas2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoGSingleSigmas.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double sigma1,
+			final double sigma2,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) ops().run(
+				net.imagej.ops.filter.dog.DefaultDoGSingleSigmas.class, out, in,
+				sigma1, sigma2, outOfBounds);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoGSingleSigmas.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<V> out,
+			final RandomAccessibleInterval<T> in, final double sigma1,
+			final double sigma2)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) ops().run(
+				net.imagej.ops.filter.dog.DefaultDoGSingleSigmas.class, out, in,
+				sigma1, sigma2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoGSingleSigmas.class)
+	public <T extends RealType<T>, V extends RealType<V>>
+		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<T> in,
+			final double sigma1, final double sigma2)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<V> result =
+			(RandomAccessibleInterval<V>) ops().run(
+				net.imagej.ops.filter.dog.DefaultDoGSingleSigmas.class, null, in,
+				sigma1, sigma2);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -700,7 +700,8 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	// -- difference of gaussian --
+	// -- dog --
+
 	@OpMethod(op = Ops.Filter.DoG.class)
 	public Object dog(Object... args) {
 		return ops().run(Ops.Filter.DoG.class, args);

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
@@ -37,7 +37,6 @@ import net.imagej.ops.Ops.Filter.DoG;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.dog.DifferenceOfGaussian;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary;
@@ -52,7 +51,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.thread.ThreadService;
 
 /**
- * Default implementation of {@link DifferenceOfGaussian}.
+ * Default Difference of Gaussians (DoG) implementation.
  * 
  * @author Christian Dietz (University of Konstanz)
  * @param <T>

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
@@ -1,0 +1,136 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.dog;
+
+import net.imagej.ops.AbstractOutputFunction;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Filter.DoG;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.dog.DifferenceOfGaussian;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
+import net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.thread.ThreadService;
+
+/**
+ * Default implementation of {@link DifferenceOfGaussian}.
+ * 
+ * @author Christian Dietz (University of Konstanz)
+ * @param <T>
+ */
+@Plugin(type = DoG.class, name = DoG.NAME)
+public class DefaultDoG<T extends NumericType<T> & NativeType<T>>
+	extends
+	AbstractOutputFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
+	implements DoG, Contingent
+{
+
+	@Parameter
+	private ThreadService ts;
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private double[] sigmas1;
+
+	@Parameter
+	private double[] sigmas2;
+
+	@Parameter(required = false)
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> fac;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public RandomAccessibleInterval<T> createOutput(
+		final RandomAccessibleInterval<T> input)
+	{
+		return (RandomAccessibleInterval<T>) ops.create().img(input);
+	}
+
+	@Override
+	protected void safeCompute(final RandomAccessibleInterval<T> input,
+		final RandomAccessibleInterval<T> output)
+	{
+
+		if (fac == null) {
+			fac =
+				new OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>>(
+					Boundary.SINGLE);
+		}
+
+		// input may potentially be translated
+		final long[] translation = new long[input.numDimensions()];
+		input.min(translation);
+
+		final IntervalView<T> tmpInterval =
+			Views.interval(Views.translate((RandomAccessible<T>) ops.create().img(
+				input, Util.getTypeFromInterval(input)), translation), output);
+
+		// TODO: How can I enforce that a certain gauss implementation is used
+		// here? I don't want to pass the Gauss class in the DoG, I rather
+		// would love to have something that allows me to enforce
+		// that certain Ops are used, even if they have lower priority. This is a
+		// common use-case if you want to let the user
+		// select in a GUI if (for example) he wants to use CUDA or CPU
+		// see issue https://github.com/imagej/imagej-ops/issues/154)
+
+		ops.filter().gauss(tmpInterval, input, sigmas1);
+		ops.filter().gauss(output, input, sigmas2);
+
+		// TODO: Use SUbtractOp as soon as available (see issue
+		// https://github.com/imagej/imagej-ops/issues/161).
+		final Cursor<T> tmpCursor = Views.flatIterable(tmpInterval).cursor();
+		final Cursor<T> outputCursor = Views.flatIterable(output).cursor();
+
+		while (outputCursor.hasNext()) {
+			outputCursor.next().sub(tmpCursor.next());
+		}
+
+	}
+
+	@Override
+	public boolean conforms() {
+		return sigmas1.length == sigmas2.length &&
+			sigmas1.length == getInput().numDimensions();
+	}
+}

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
@@ -116,7 +116,7 @@ public class DefaultDoG<T extends NumericType<T> & NativeType<T>>
 		ops.filter().gauss(tmpInterval, input, sigmas1);
 		ops.filter().gauss(output, input, sigmas2);
 
-		// TODO: Use SUbtractOp as soon as available (see issue
+		// TODO: Use SubtractOp as soon as available (see issue
 		// https://github.com/imagej/imagej-ops/issues/161).
 		final Cursor<T> tmpCursor = Views.flatIterable(tmpInterval).cursor();
 		final Cursor<T> outputCursor = Views.flatIterable(output).cursor();

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoGSingleSigmas.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoGSingleSigmas.java
@@ -36,7 +36,6 @@ import net.imagej.ops.AbstractOutputFunction;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops.Filter.DoG;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.dog.DifferenceOfGaussian;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
@@ -46,8 +45,8 @@ import org.scijava.plugin.Plugin;
 import org.scijava.thread.ThreadService;
 
 /**
- * Implementation of {@link DifferenceOfGaussian} where all sigmas are the same
- * in each dimension. Internally running {@link DifferenceOfGaussian} on arrays.
+ * Difference of Gaussians (DoG) implementation where all sigmas are the same in each
+ * dimension. Internally running DoG on arrays.
  * 
  * @author Christian Dietz (University of Konstanz)
  * @param <T>

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoGSingleSigmas.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoGSingleSigmas.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.dog;
+
+import java.util.Arrays;
+
+import net.imagej.ops.AbstractOutputFunction;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Filter.DoG;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.dog.DifferenceOfGaussian;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.NumericType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.thread.ThreadService;
+
+/**
+ * Implementation of {@link DifferenceOfGaussian} where all sigmas are the same
+ * in each dimension. Internally running {@link DifferenceOfGaussian} on arrays.
+ * 
+ * @author Christian Dietz (University of Konstanz)
+ * @param <T>
+ */
+@Plugin(type = DoG.class, name = DoG.NAME, priority = 1.0)
+public class DefaultDoGSingleSigmas<T extends NumericType<T> & NativeType<T>>
+	extends
+	AbstractOutputFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
+	implements DoG
+{
+
+	@Parameter
+	private ThreadService ts;
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter
+	private double sigma1;
+
+	@Parameter
+	private double sigma2;
+
+	@Parameter(required = false)
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> fac;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public RandomAccessibleInterval<T> createOutput(
+		final RandomAccessibleInterval<T> input)
+	{
+		return (RandomAccessibleInterval<T>) ops.create().img(input);
+	}
+
+	@Override
+	protected void safeCompute(final RandomAccessibleInterval<T> input,
+		final RandomAccessibleInterval<T> output)
+	{
+		final double[] sigmas1 = new double[input.numDimensions()];
+		final double[] sigmas2 = new double[input.numDimensions()];
+
+		Arrays.fill(sigmas1, sigma1);
+		Arrays.fill(sigmas2, sigma2);
+
+		ops.run(DoG.class, output, input, sigmas1, sigmas2, fac);
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -46,7 +46,7 @@ namespaces = ```
 		[name: "fft",                iface: "FFT"],
 		[name: "fftSize",            iface: "FFTSize"],
 		[name: "gauss",              iface: "Gauss",               aliases: ["smooth"]],
-		[name: "dog",                iface: "DoG",                 aliases: ["differenceofgaussian"]],
+		[name: "dog",                iface: "DoG",                 aliases: ["differenceOfGaussian"]],
 		[name: "ifft",               iface: "IFFT"]
 	]],
 	[name: "image",      iface: "Image", ops: [
@@ -60,7 +60,7 @@ namespaces = ```
 		[name: "scale",              iface: "Scale",               aliases: ["resize"]]
 	]],
 	[name: "labeling",   iface: "Labeling", ops: [
-		[name: "cca",                iface: "CCA",                 aliases: ["connected-components", "connected-component-analysis"]]
+		[name: "cca",                iface: "CCA",                 aliases: ["connectedComponents", "connectedComponentAnalysis"]]
 	]],
 	[name: "logic", iface: "Logic", ops: [
 		[name: "and",                iface: "And"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -46,6 +46,7 @@ namespaces = ```
 		[name: "fft",                iface: "FFT"],
 		[name: "fftSize",            iface: "FFTSize"],
 		[name: "gauss",              iface: "Gauss",               aliases: ["smooth"]],
+		[name: "dog",                iface: "DoG",                 aliases: ["differenceofgaussian"]],
 		[name: "ifft",               iface: "IFFT"]
 	]],
 	[name: "image",      iface: "Image", ops: [

--- a/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
+++ b/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
@@ -43,7 +43,7 @@ import net.imglib2.view.Views;
 import org.junit.Test;
 
 /**
- * Tests implementations of {@link DifferenceOfGaussian}
+ * Tests Difference of Gaussians (DoG) implementations.
  * 
  * @author Christian Dietz, University of Konstanz
  */

--- a/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
+++ b/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
@@ -63,8 +63,8 @@ public class DoGTest extends AbstractOpTest {
 		ops.filter().dog(out1, in, sigmas1, sigmas2);
 
 		// test against native imglib2 implementation
-		net.imglib2.algorithm.dog.DifferenceOfGaussian.DoG(sigmas1, sigmas2, Views
-			.extendMirrorSingle(in), out2, Executors.newFixedThreadPool(10));
+		DifferenceOfGaussian.DoG(sigmas1, sigmas2, Views.extendMirrorSingle(in),
+			out2, Executors.newFixedThreadPool(10));
 
 		final Cursor<ByteType> out1Cursor = out1.cursor();
 		final Cursor<ByteType> out2Cursor = out2.cursor();

--- a/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
+++ b/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
@@ -1,0 +1,85 @@
+/*
+ * #%L,
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.dog;
+
+import java.util.concurrent.Executors;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.dog.DifferenceOfGaussian;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+
+/**
+ * Tests implementations of {@link DifferenceOfGaussian}
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public class DoGTest extends AbstractOpTest {
+
+	@Test
+	public void dogRAITest() {
+
+		final double[] sigmas1 = new double[] { 1, 1 };
+		final double[] sigmas2 = new double[] { 2, 2 };
+		final long[] dims = new long[] { 10, 10 };
+
+		final Img<ByteType> in = generateByteTestImg(true, dims);
+		final Img<ByteType> out1 = generateByteTestImg(false, dims);
+		final Img<ByteType> out2 = generateByteTestImg(false, dims);
+
+		ops.filter().dog(out1, in, sigmas1, sigmas2);
+
+		// test against native imglib2 implementation
+		net.imglib2.algorithm.dog.DifferenceOfGaussian.DoG(sigmas1, sigmas2, Views
+			.extendMirrorSingle(in), out2, Executors.newFixedThreadPool(10));
+
+		final Cursor<ByteType> out1Cursor = out1.cursor();
+		final Cursor<ByteType> out2Cursor = out2.cursor();
+
+		while (out1Cursor.hasNext()) {
+			org.junit.Assert.assertEquals(out1Cursor.next().getRealDouble(),
+				out2Cursor.next().getRealDouble(), 0);
+		}
+	}
+
+	@Test
+	public void dogRAISingleSigmasTest() {
+		final RandomAccessibleInterval<ByteType> res =
+			ops.filter().dog(generateByteTestImg(true, new long[] { 10, 10 }), 1, 2);
+
+		org.junit.Assert.assertNotNull(res);
+	}
+}


### PR DESCRIPTION
this PR adds a default implemenation of `DifferenceOfGaussian`s to ImageJ-Ops. There are still open (internal) 'TODO's, however the algorithm is working and the API will not change.