### PR TITLE
CreateImg / CreateLabeling: Respect minimum/maximum

### DIFF
--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -37,6 +37,7 @@ import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
 import net.imglib2.Dimensions;
+import net.imglib2.Interval;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.roi.labeling.ImgLabeling;
@@ -103,6 +104,35 @@ public class CreateNamespace extends AbstractNamespace {
 		final Img<T> result =
 			(Img<T>) ops().run(net.imagej.ops.create.img.DefaultCreateImg.class,
 				dims, outType, fac);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
+	public <T extends Type<T>> Img<T> img(final Interval interval) {
+		@SuppressWarnings("unchecked")
+		final Img<T> result =
+			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
+				interval);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
+	public <T extends Type<T>> Img<T> img(final Interval interval, final T outType) {
+		@SuppressWarnings("unchecked")
+		final Img<T> result =
+			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
+				interval, outType);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
+	public <T extends Type<T>> Img<T> img(final Interval interval, final T outType,
+		final ImgFactory<T> fac)
+	{
+		@SuppressWarnings("unchecked")
+		final Img<T> result =
+			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
+				interval, outType, fac);
 		return result;
 	}
 
@@ -240,14 +270,17 @@ public class CreateNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Create.IntegerType.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.create.integerType.DefaultCreateIntegerType.class)
+	@OpMethod(
+		op = net.imagej.ops.create.integerType.DefaultCreateIntegerType.class)
 	public IntegerType integerType() {
 		final IntegerType result =
-			(IntegerType) ops().run(net.imagej.ops.create.integerType.DefaultCreateIntegerType.class);
+			(IntegerType) ops().run(
+				net.imagej.ops.create.integerType.DefaultCreateIntegerType.class);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.create.integerType.DefaultCreateIntegerType.class)
+	@OpMethod(
+		op = net.imagej.ops.create.integerType.DefaultCreateIntegerType.class)
 	public IntegerType integerType(final long maxValue) {
 		final IntegerType result =
 			(IntegerType) ops().run(

--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -117,7 +117,9 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
-	public <T extends Type<T>> Img<T> img(final Interval interval, final T outType) {
+	public <T extends Type<T>> Img<T>
+		img(final Interval interval, final T outType)
+	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
@@ -126,8 +128,8 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
-	public <T extends Type<T>> Img<T> img(final Interval interval, final T outType,
-		final ImgFactory<T> fac)
+	public <T extends Type<T>> Img<T> img(final Interval interval,
+		final T outType, final ImgFactory<T> fac)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
@@ -232,6 +234,59 @@ public class CreateNamespace extends AbstractNamespace {
 			(ImgLabeling<L, T>) ops().run(
 				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
 				outType, fac, maxNumLabelSets);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
+	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
+		final Interval interval)
+	{
+		@SuppressWarnings("unchecked")
+		final ImgLabeling<L, T> result =
+			(ImgLabeling<L, T>) ops().run(
+				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				interval);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
+	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
+		final Interval interval, final T outType)
+	{
+		@SuppressWarnings("unchecked")
+		final ImgLabeling<L, T> result =
+			(ImgLabeling<L, T>) ops().run(
+				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				interval, outType);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
+	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
+		final Interval interval, final T outType, final ImgFactory<T> fac)
+	{
+		@SuppressWarnings("unchecked")
+		final ImgLabeling<L, T> result =
+			(ImgLabeling<L, T>) ops().run(
+				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				interval, outType, fac);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
+	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
+		final Interval interval, final T outType, final ImgFactory<T> fac,
+		final int maxNumLabelSets)
+	{
+		@SuppressWarnings("unchecked")
+		final ImgLabeling<L, T> result =
+			(ImgLabeling<L, T>) ops().run(
+				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				interval, outType, fac, maxNumLabelSets);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/create/img/CreateImgFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/img/CreateImgFromInterval.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.create.img;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Output;
+import net.imglib2.Interval;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.ImgView;
+import net.imglib2.type.Type;
+import net.imglib2.view.Views;
+
+import org.scijava.ItemIO;
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Creates an {@link Img} from an {@link Interval}. Minimum and maximum of
+ * resulting {@link Img} are the same as the minimum and maximum of the incoming
+ * {@link Interval}.
+ *
+ * @author Christian Dietz (University of Konstanz)
+ * @param <T>
+ */
+@Plugin(type = Ops.Create.Img.class, name = Ops.Create.Img.NAME,
+	priority = Priority.HIGH_PRIORITY)
+public class CreateImgFromInterval<T extends Type<T>> implements
+	Ops.Create.Img, Output<Img<T>>
+{
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Img<T> output;
+
+	@Parameter
+	private Interval interval;
+
+	@Parameter(required = false)
+	private T outType;
+
+	@Parameter(required = false)
+	private ImgFactory<T> fac;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void run() {
+		output = (Img<T>) ops.run(DefaultCreateImg.class, interval, outType, fac);
+		long[] min = new long[interval.numDimensions()];
+		interval.min(min);
+
+		for (int d = 0; d < min.length; d++) {
+			if (min[d] > 0) {
+				output = ImgView.wrap(Views.translate(output, min), output.factory());
+				break;
+			}
+		}
+	}
+
+	@Override
+	public Img<T> getOutput() {
+		return output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/create/img/CreateImgFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/img/CreateImgFromInterval.java
@@ -82,7 +82,7 @@ public class CreateImgFromInterval<T extends Type<T>> implements
 		interval.min(min);
 
 		for (int d = 0; d < min.length; d++) {
-			if (min[d] > 0) {
+			if (min[d] != 0) {
 				output = ImgView.wrap(Views.translate(output, min), output.factory());
 				break;
 			}

--- a/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.create.imgLabeling;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Output;
+import net.imglib2.Interval;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.roi.labeling.ImgLabeling;
+import net.imglib2.type.numeric.IntegerType;
+
+import org.scijava.ItemIO;
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Creates an {@link ImgLabeling} from an {@link Interval}. Minimum and maximum
+ * of resulting {@link ImgLabeling} are the same as the minimum and maximum of
+ * the incoming {@link Interval}.
+ *
+ * @author Christian Dietz (University of Konstanz)
+ * @param <T>
+ */
+@Plugin(type = Ops.Create.ImgLabeling.class,
+	name = Ops.Create.ImgLabeling.NAME, priority = Priority.HIGH_PRIORITY)
+public class CreateImgLabelingFromInterval<L, T extends IntegerType<T>>
+	implements Ops.Create.ImgLabeling, Output<ImgLabeling<L, T>>
+{
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private ImgLabeling<L, T> output;
+
+	@Parameter
+	private Interval interval;
+
+	@Parameter(required = false)
+	private T outType;
+
+	@Parameter(required = false)
+	private ImgFactory<T> fac;
+
+	@Parameter(required = false)
+	private int maxNumLabelSets;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void run() {
+
+		if (outType == null) {
+			outType = (T) ops.create().integerType(maxNumLabelSets);
+		}
+
+		output = new ImgLabeling<L, T>(ops.create().img(interval, outType, fac));
+	}
+
+	@Override
+	public ImgLabeling<L, T> getOutput() {
+		return output;
+	}
+
+}

--- a/src/test/java/net/imagej/ops/create/CreateImgTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgTest.java
@@ -67,6 +67,31 @@ public class CreateImgTest extends AbstractOpTest {
 	private static final int TEST_SIZE = 100;
 
 	@Test
+	public void testImageMinimum() {
+
+		final Random randomGenerator = new Random();
+
+		for (int i = 0; i < TEST_SIZE; i++) {
+
+			// between 2 and 5 dimensions
+			final long[] max = new long[randomGenerator.nextInt(4) + 2];
+			final long[] min = new long[max.length];
+
+			// between 2 and 10 pixels per dimensions
+			for (int j = 0; j < max.length; j++) {
+				max[j] = randomGenerator.nextInt(9) + 2;
+				min[j] = Math.max(0, max[j] - randomGenerator.nextInt(4));
+			}
+
+			// create img
+			final Img<?> img = (Img<?>) ops.create().img(new FinalInterval(min, max));
+
+			assertArrayEquals("Image Minimum:", min, Intervals.minAsLongArray(img));
+			assertArrayEquals("Image Maximum:", max, Intervals.maxAsLongArray(img));
+		}
+	}
+
+	@Test
 	public void testImageDimensions() {
 
 		final Random randomGenerator = new Random();
@@ -121,8 +146,8 @@ public class CreateImgTest extends AbstractOpTest {
 
 		final long[] dim = new long[] { 10, 10, 10 };
 
-		assertEquals("Image Type: ", BitType.class, ((Img<?>) ops.create().img(
-			dim, new BitType(), null)).firstElement().getClass());
+		assertEquals("Image Type: ", BitType.class, ((Img<?>) ops.create().img(dim,
+			new BitType(), null)).firstElement().getClass());
 
 		assertEquals("Image Type: ", ByteType.class, ((Img<?>) ops.create().img(
 			dim, new ByteType(), null)).firstElement().getClass());


### PR DESCRIPTION
Hi all,

until now, we were only able to create `Img`s or `ImgLabeling`s with zero minimum. However, in many situations (`Region`s, transformed `RandomAccessibleInterval`s etc.) the minimum can be non-zero. This PR add capabilities to ImageJ-Ops to create objects with non-zero minimum or more general to create `Img`s and `ImgLabeling`s in arbitrary `Interval`s. 
