### PR TITLE
add /bin/ exclude in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /.settings/
 /target/
+/bin/


### PR DESCRIPTION
see text. I don't know why, but in my setting git always wants to add all files in the /bin/ folder. It would be great if we could add /bin/ to the exclude list.
