### PR TITLE
Neighborhood maps and center aware neighborhood operations

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -44,6 +44,7 @@ import net.imagej.ops.filter.FilterNamespace;
 import net.imagej.ops.image.ImageNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
+import net.imagej.ops.map.neighborhood.CenterAwareComputerOp;
 import net.imagej.ops.math.MathNamespace;
 import net.imagej.ops.stats.StatsNamespace;
 import net.imagej.ops.thread.ThreadNamespace;
@@ -495,6 +496,19 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) run(
 				net.imagej.ops.map.neighborhood.MapNeighborhood.class, out, in, op, shape);
+		return result;
+	}
+	
+	@Override
+	public <I, O> RandomAccessibleInterval<O> map(
+		final RandomAccessibleInterval<O> out,
+		final RandomAccessibleInterval<I> in,
+		final CenterAwareComputerOp<Iterable<I>, O> func, final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) run(
+				net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class, out, in, func, shape);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -494,7 +494,7 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) run(
-				net.imagej.ops.map.MapNeighborhood.class, out, in, op, shape);
+				net.imagej.ops.map.neighborhood.MapNeighborhood.class, out, in, op, shape);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -348,7 +348,7 @@ public interface OpService extends PTService<Op>, ImageJService {
 		RandomAccessibleInterval<A> in, ComputerOp<A, B> op);
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.map.MapNeighborhood.class)
+	@OpMethod(op = net.imagej.ops.map.neighborhood.MapNeighborhood.class)
 	<I, O> RandomAccessibleInterval<O>
 		map(RandomAccessibleInterval<O> out, RandomAccessibleInterval<I> in,
 			ComputerOp<Iterable<I>, O> op, Shape shape);

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -42,6 +42,7 @@ import net.imagej.ops.filter.FilterNamespace;
 import net.imagej.ops.image.ImageNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
+import net.imagej.ops.map.neighborhood.CenterAwareComputerOp;
 import net.imagej.ops.math.MathNamespace;
 import net.imagej.ops.stats.StatsNamespace;
 import net.imagej.ops.thread.ThreadNamespace;
@@ -349,9 +350,16 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.map.neighborhood.MapNeighborhood.class)
-	<I, O> RandomAccessibleInterval<O>
+	<I, O> RandomAccessibleInterval<O> 
 		map(RandomAccessibleInterval<O> out, RandomAccessibleInterval<I> in,
 			ComputerOp<Iterable<I>, O> op, Shape shape);
+
+	/** Executes the "map" operation on the given arguments. */
+	@OpMethod(
+		op = net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class)
+	<I, O> RandomAccessibleInterval<O> map(RandomAccessibleInterval<O> out,
+		RandomAccessibleInterval<I> in, CenterAwareComputerOp<Iterable<I>, O> op,
+		Shape shape);
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.map.MapIterableToIterable.class)

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -350,9 +350,8 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.map.neighborhood.MapNeighborhood.class)
-	<I, O> RandomAccessibleInterval<O> 
-		map(RandomAccessibleInterval<O> out, RandomAccessibleInterval<I> in,
-			ComputerOp<Iterable<I>, O> op, Shape shape);
+	<I, O> RandomAccessibleInterval<O> map(RandomAccessibleInterval<O> out,
+		RandomAccessibleInterval<I> in, ComputerOp<Iterable<I>, O> op, Shape shape);
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(

--- a/src/main/java/net/imagej/ops/map/neighborhood/AbstractCenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/AbstractCenterAwareComputerOp.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map.neighborhood;
+
+import net.imagej.ops.AbstractComputerOp;
+import net.imglib2.util.Pair;
+
+/**
+ * Abstract superclass for {@link CenterAwareComputerOp} implementations.
+ * 
+ * @author Jonathan Hale (University of Konstanz)
+ */
+public abstract class AbstractCenterAwareComputerOp<I, O> extends
+	AbstractComputerOp<Pair<I, Iterable<I>>, O> implements
+	CenterAwareComputerOp<I, O>
+{
+	// NB: Empty.
+}

--- a/src/main/java/net/imagej/ops/map/neighborhood/AbstractMapCenterAwareComputer.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/AbstractMapCenterAwareComputer.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map.neighborhood;
+
+import net.imagej.ops.AbstractComputerOp;
+import net.imagej.ops.map.MapOp;
+import net.imglib2.util.Pair;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract implementation of a {@link MapOp} for {@link CenterAwareComputerOp}.
+ * 
+ * @author Jonathan Hale (University of Konstanz)
+ * @param <A> mapped on {@code <B>}
+ * @param <B> mapped from {@code <A>}
+ * @param <C> provides {@code <A>}s
+ * @param <D> provides {@code <B>}s
+ */
+public abstract class AbstractMapCenterAwareComputer<A, B, C, D> extends
+	AbstractComputerOp<C, D> implements
+	MapOp<Pair<A, Iterable<A>>, B, CenterAwareComputerOp<A, B>>
+{
+
+	@Parameter
+	private CenterAwareComputerOp<A, B> op;
+
+	@Override
+	public CenterAwareComputerOp<A, B> getOp() {
+		return op;
+	}
+
+	@Override
+	public void setOp(final CenterAwareComputerOp<A, B> op) {
+		this.op = op;
+	}
+}

--- a/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
@@ -1,0 +1,19 @@
+
+package net.imagej.ops.map.neighborhood;
+
+import net.imagej.ops.ComputerOp;
+import net.imglib2.util.Pair;
+
+/**
+ * A <em>center aware computer</em> calculates a result from a given input and
+ * its surrounding neighborhood, storing it into the specified output reference.
+ * 
+ * @author Jonathan Hale (University of Konstanz)
+ * @param <I> type of input
+ * @param <O> type of output
+ */
+public interface CenterAwareComputerOp<I, O> extends
+	ComputerOp<Pair<I, Iterable<I>>, O>
+{
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
@@ -43,11 +43,16 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Evaluates an {@link ComputerOp} for each {@link Neighborhood} on the in
+ * Evaluates a {@link ComputerOp} for each {@link Neighborhood} on the input
  * {@link RandomAccessibleInterval}.
  * 
  * @author Christian Dietz (University of Konstanz)
  * @author Martin Horn (University of Konstanz)
+ * @param <I> input type
+ * @param <O> output type
+ * @see OpService#map(RandomAccessibleInterval, RandomAccessibleInterval, Shape,
+ *      ComputerOp)
+ * @see ComputerOp
  */
 @Plugin(type = Ops.Map.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY)
 public class MapNeighborhood<I, O> extends

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
@@ -28,11 +28,12 @@
  * #L%
  */
 
-package net.imagej.ops.map;
+package net.imagej.ops.map.neighborhood;
 
 import net.imagej.ops.ComputerOp;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
+import net.imagej.ops.map.AbstractMapComputer;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.Shape;
@@ -49,8 +50,7 @@ import org.scijava.plugin.Plugin;
  * @author Martin Horn (University of Konstanz)
  */
 @Plugin(type = Ops.Map.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY)
-public class MapNeighborhood<I, O>
-	extends
+public class MapNeighborhood<I, O> extends
 	AbstractMapComputer<Iterable<I>, O, RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
 {
 
@@ -64,8 +64,9 @@ public class MapNeighborhood<I, O>
 	public void compute(final RandomAccessibleInterval<I> input,
 		final RandomAccessibleInterval<O> output)
 	{
+		// Call map on the neighborhoods iterable interval. This may use a
+		// threaded implementation of map.
 		ops.map(output, shape.neighborhoodsSafe(input), getOp());
-		// TODO: threaded map neighborhood
 		// TODO: optimization with integral images, if there is a rectangular
 		// neighborhood
 	}

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map.neighborhood;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.util.ValuePair;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Evaluates a {@link CenterAwareComputerOp} for each {@link Neighborhood} on
+ * the input {@link RandomAccessibleInterval} and sets the value of the
+ * corresponding pixel on the output {@link RandomAccessibleInterval}. Similar
+ * to {@link MapNeighborhood}, but passes the center pixel to the op aswell.
+ * 
+ * @author Jonathan Hale
+ * @see OpService#map(RandomAccessibleInterval, RandomAccessibleInterval,
+ *      CenterAwareComputerOp, Shape)
+ * @see CenterAwareComputerOp
+ */
+@Plugin(type = Op.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY)
+public class MapNeighborhoodWithCenter<I, O>
+	extends
+	AbstractMapCenterAwareComputer<I, O, RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
+{
+
+	@Parameter
+	private Shape shape;
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final RandomAccessibleInterval<I> input,
+		final RandomAccessibleInterval<O> output)
+	{
+		final IterableInterval<Neighborhood<I>> neighborhoods =
+			shape.neighborhoods(input);
+
+		final Cursor<Neighborhood<I>> cNeigh = neighborhoods.localizingCursor();
+
+		final RandomAccess<I> raIn = input.randomAccess();
+		final RandomAccess<O> raOut = output.randomAccess();
+
+		final CenterAwareComputerOp<I, O> op = getOp();
+
+		while (cNeigh.hasNext()) {
+			Neighborhood<I> neigh = cNeigh.next();
+
+			raIn.setPosition(cNeigh);
+			raOut.setPosition(cNeigh);
+
+			op.compute(new ValuePair<I, Iterable<I>>(raIn.get(), neigh), raOut.get());
+		}
+
+		// TODO: threaded map neighborhood
+		// TODO: optimization with integral images, if there is a rectangular
+		// neighborhood
+		// TODO: provide threaded implementation and specialized ones for
+		// rectangular neighborhoods (using integral images)
+	}
+
+}

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -56,7 +56,8 @@ import org.scijava.plugin.Plugin;
  *      CenterAwareComputerOp, Shape)
  * @see CenterAwareComputerOp
  */
-@Plugin(type = Op.class, name = Ops.Map.NAME, priority = Priority.LOW_PRIORITY)
+@Plugin(type = Op.class, name = Ops.Map.NAME,
+	priority = Priority.LOW_PRIORITY + 1)
 public class MapNeighborhoodWithCenter<I, O>
 	extends
 	AbstractMapCenterAwareComputer<I, O, RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -381,7 +381,10 @@ public class MapNeighborhoodWithCenter<I, O>
 			IterableInterval<Neighborhood<I>> neighborhoods, IterableInterval<I> input)
 		{
 			super(neighborhoods);
-			assert input.iterationOrder() == neighborhoods.iterationOrder();
+			if (!input.iterationOrder().equals(neighborhoods.iterationOrder())) {
+				throw new IllegalArgumentException(
+					"Iteration order of neighborhood InterableInterval and input InterableInterval are not equal!");
+			}
 
 			cIn = input.cursor();
 		}

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -1,0 +1,188 @@
+
+package net.imagej.ops.map.neighborhood;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import net.imagej.ops.AbstractComputerOp;
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Op;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.util.Pair;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test for {@link MapNeighborhood} and {@link MapNeighborhoodWithCenter}.
+ *
+ * @author Jonathan Hale (University of Konstanz)
+ */
+public class MapNeighborhoodTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+	private Img<ByteType> out;
+
+	@Before
+	public void initImg() {
+		in = generateByteTestImg(true, 11, 10);
+		out = generateByteTestImg(false, 11, 10);
+	}
+
+	/**
+	 * Test if every neighborhood pixel of the image was really accessed during
+	 * the map operation.
+	 *
+	 * @see MapNeighborhood
+	 */
+	@Test
+	public void testMapNeighborhoodsAccess() {
+		final Op mapOp =
+			ops.op(MapNeighborhood.class, out, in, new CountNeighbors(),
+				new RectangleShape(1, false));
+		mapOp.run();
+
+		for (final ByteType t : out) {
+			assertEquals(9, t.get());
+		}
+	}
+
+	@Test
+	@Ignore("There is no way to throw an error for invalid typed computers at the moment.")
+	public
+		void testMapNeighoodsWrongArgs() {
+		final Op mapOp =
+			ops.op(MapNeighborhood.class, out, in, new Increment(),
+				new RectangleShape(1, false));
+		// ClassCastException will be thrown
+		mapOp.run();
+	}
+
+	/**
+	 * Test if every neighborhood pixel of the image was really accessed during
+	 * the map operation.
+	 *
+	 * @see MapNeighborhoodWithCenter
+	 */
+	@Test
+	public void testMapNeighborhoodsWithCenterAccess() {
+		final Op mapOp =
+			ops.op(MapNeighborhoodWithCenter.class, out, in,
+				new CountNeighborsWithCenter(), new RectangleShape(1, false));
+		mapOp.run();
+
+		for (final ByteType t : out) {
+			assertEquals(9, t.get());
+		}
+	}
+
+	/**
+	 * Function which increments the output value for every pixel in the
+	 * neighborhood.
+	 *
+	 * @author Jonathan Hale
+	 */
+	private static class CountNeighbors extends
+		AbstractComputerOp<Iterable<ByteType>, ByteType>
+	{
+
+		@Override
+		public void compute(final Iterable<ByteType> input, final ByteType output) {
+			for (final ByteType b : input) {
+				output.inc();
+			}
+		}
+	}
+
+	/**
+	 * Function which increments a outputPixel for every neighboring pixel defined
+	 * by the mapping.
+	 *
+	 * @author Jonathan Hale
+	 */
+	private static class CountNeighborsWithCenter extends
+		AbstractCenterAwareComputerOp<ByteType, ByteType>
+	{
+
+		@Override
+		public void compute(final Pair<ByteType, Iterable<ByteType>> input,
+			final ByteType output)
+		{
+			for (final ByteType b : input.getB()) {
+				output.inc();
+			}
+		}
+	}
+
+	/**
+	 * Computer which increments a outputPixel for every neighboring pixel defined
+	 * by the mapping and tries to access the input pixels value to ensure that no
+	 * access is out of bounds.
+	 *
+	 * @author Jonathan Hale
+	 */
+	private static class CountNeighborsWithAccess extends
+		AbstractComputerOp<Iterable<ByteType>, ByteType>
+	{
+
+		@Override
+		public void compute(final Iterable<ByteType> input, final ByteType output) {
+			try {
+				for (final ByteType t : input) {
+					output.inc();
+					t.inc();
+				}
+			}
+			catch (final Exception e) {
+				fail(e.toString());
+			}
+		}
+	}
+
+	/**
+	 * Computer which increments a outputPixel for every neighboring pixel defined
+	 * by the mapping and tries to access the input pixels value to ensure that no
+	 * access is out of bounds.
+	 *
+	 * @author Jonathan Hale
+	 */
+	private static class CountNeighborsWithAccessWithCenter extends
+		AbstractCenterAwareComputerOp<ByteType, ByteType>
+	{
+
+		@Override
+		public void compute(final Pair<ByteType, Iterable<ByteType>> input,
+			final ByteType output)
+		{
+			try {
+				input.getA().inc();
+
+				for (final ByteType t : input.getB()) {
+					output.inc();
+					t.inc();
+				}
+			}
+			catch (final Exception e) {
+				fail(e.toString());
+			}
+		}
+	}
+
+	/**
+	 * Computer which sets a outputPixel to <code>input.get() + 1</code>.
+	 * Generally, this computer is invalid as input to neighborhood maps.
+	 *
+	 * @author Jonathan Hale
+	 */
+	private static class Increment extends AbstractComputerOp<ByteType, ByteType>
+	{
+
+		@Override
+		public void compute(final ByteType input, final ByteType output) {
+			output.set((byte) (input.get() + 1));
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -56,6 +56,7 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 		final Op mapOp =
 			ops.op(MapNeighborhood.class, out, in, new Increment(),
 				new RectangleShape(1, false));
+
 		// ClassCastException will be thrown
 		mapOp.run();
 	}
@@ -74,6 +75,10 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 		mapOp.run();
 
 		for (final ByteType t : out) {
+			assertEquals(9, t.get());
+		}
+
+		for (final ByteType t : in) {
 			assertEquals(9, t.get());
 		}
 	}
@@ -110,8 +115,14 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 		public void compute(final Pair<ByteType, Iterable<ByteType>> input,
 			final ByteType output)
 		{
+			ByteType a = input.getA();
+
+			a.set((byte) 0);
+			output.set((byte) 0);
+
 			for (final ByteType b : input.getB()) {
 				output.inc();
+				a.inc();
 			}
 		}
 	}


### PR DESCRIPTION
Hello @ctrueden !

Here are some improvements/changes/additions to neighborhood maps:

I added a `CenterAwareComputerOp` to allow implementation of neighborhood operations which require access to the center pixel value of a neighborhood (prime example, local thresholding). And a map which maps these to neighborhoods.

I moved the neighborhood related classes to a separate package in map, since there are more to come (on another day, on another PR). Since `CenterAwareComputerOp` is only relevant for neighborhood operations, it resides in that package aswell.

As soon as this is merged, I will prepare a PR for local thresholding. 

Greetings, Squareys

PS: I used the eclipse prefs/formatter/cleanup, but things seemed not quite right (no whitespace between closing `>` and `implements`, non-alphabetic import order...). I did pay careful attention to remove weird reformatting code changes, though.
