### PR TITLE
PR: Haralick Features

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import net.imagej.ops.convert.ConvertPix;
 import net.imagej.ops.create.CreateNamespace;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
+import net.imagej.ops.features.haralick.HaralickNamespace;
 import net.imagej.ops.filter.FilterNamespace;
 import net.imagej.ops.image.ImageNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
@@ -557,6 +558,11 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 	@Override
 	public FilterNamespace filter() {
 		return namespace(FilterNamespace.class);
+	}
+	
+	@Override
+	public HaralickNamespace haralick() {
+		return namespace(HaralickNamespace.class);
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/OpRef.java
+++ b/src/main/java/net/imagej/ops/OpRef.java
@@ -29,6 +29,8 @@
  */
 package net.imagej.ops;
 
+import java.util.Arrays;
+
 
 /**
  * Data structure which identifies an op by name and/or type, along with a list
@@ -131,6 +133,30 @@ public class OpRef<OP extends Op> {
 		sb.append(")");
 
 		return sb.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		OpRef<?> other = (OpRef<?>) obj;
+		if (!Arrays.equals(args, other.args))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (type == null) {
+			if (other.type != null)
+				return false;
+		} else if (!type.equals(other.type))
+			return false;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -38,6 +38,7 @@ import net.imagej.ImageJService;
 import net.imagej.ops.convert.ConvertPix;
 import net.imagej.ops.create.CreateNamespace;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
+import net.imagej.ops.features.haralick.HaralickNamespace;
 import net.imagej.ops.filter.FilterNamespace;
 import net.imagej.ops.image.ImageNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
@@ -382,6 +383,9 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	/** Gateway into ops of the "filter" namespace. */
 	FilterNamespace filter();
+	
+	/** Gateway into ops of the "haralick " namespace. */
+	HaralickNamespace haralick();
 
 	/** Gateway into ops of the "image" namespace. */
 	ImageNamespace image();

--- a/src/main/java/net/imagej/ops/features/haralick/AbstractHaralickFeature.java
+++ b/src/main/java/net/imagej/ops/features/haralick/AbstractHaralickFeature.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.AbstractHybridOp;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.OpService;
+import net.imagej.ops.image.cooccurrencematrix.CooccurrenceMatrix2D;
+import net.imagej.ops.image.cooccurrencematrix.MatrixOrientation;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract class for Haralick2DFeatures.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ * @param <T>
+ */
+public abstract class AbstractHaralickFeature<T extends RealType<T>> extends
+		AbstractHybridOp<IterableInterval<T>, DoubleType> implements
+		HaralickFeature<T>, Contingent {
+
+	@Parameter
+	protected OpService ops;
+
+	@Parameter
+	protected int numGreyLevels = 32;
+
+	@Parameter
+	protected int distance = 1;
+
+	@Parameter
+	protected MatrixOrientation orientation;
+
+	@Override
+	public DoubleType createOutput(final IterableInterval<T> input) {
+		return new DoubleType();
+	}
+
+	/**
+	 * Creates {@link CooccurrenceMatrix2D} from {@link IterableInterval} on
+	 * demand, given the specified parameters. No caching!
+	 * 
+	 * @return the {@link CooccurrenceMatrix2D}
+	 */
+	protected double[][] getCooccurrenceMatrix(final IterableInterval<T> input) {
+		return (double[][]) ops.image().cooccurrencematrix(input,
+				numGreyLevels, distance, orientation);
+	}
+
+	@Override
+	public boolean conforms() {
+		return orientation.numDims() == getInput().numDimensions();
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultASM.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultASM.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.ASM;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Angular Second Moment Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Angular Second Moment (Energy)", name = Haralick.ASM.NAME)
+public class DefaultASM<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements ASM {
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+		final int nrGrayLevels = matrix.length;
+
+		double res = 0;
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				res += matrix[i][j] * matrix[i][j];
+			}
+		}
+		output.setReal(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultClusterPromenence.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultClusterPromenence.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.ClusterPromenence;
+import net.imagej.ops.features.haralick.helper.CoocMeanX;
+import net.imagej.ops.features.haralick.helper.CoocMeanY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Cluster Promenence Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Cluster Promenence", name = Haralick.ClusterPromenence.NAME)
+public class DefaultClusterPromenence<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements ClusterPromenence {
+
+	@Parameter
+	private OpService ops;
+
+	public DoubleType createOutput(final double[][] input) {
+		return new DoubleType();
+	}
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final int nrGrayLevels = matrix.length;
+
+		final double mux = ((DoubleType) ops.run(CoocMeanX.class,
+				(Object) matrix)).getRealDouble();
+		final double muy = ((DoubleType) ops.run(CoocMeanY.class,
+				(Object) matrix)).getRealDouble();
+
+		double res = 0;
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				res += Math.pow(i + j - mux - muy, 4) * matrix[i][j];
+			}
+		}
+		output.setReal(res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultClusterShade.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultClusterShade.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.ClusterShade;
+import net.imagej.ops.features.haralick.helper.CoocMeanX;
+import net.imagej.ops.features.haralick.helper.CoocMeanY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Implementation of Cluster Shade Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Cluster Shade", name = Haralick.ClusterShade.NAME)
+public class DefaultClusterShade<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements ClusterShade {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double mux = ((DoubleType) ops.run(CoocMeanX.class,
+				(Object) matrix)).getRealDouble();
+
+		final double muy = ((DoubleType) ops.run(CoocMeanY.class,
+				(Object) matrix)).getRealDouble();
+
+		double res = 0;
+		for (int j = 0; j < matrix.length; j++) {
+			for (int i = 0; i < matrix.length; i++) {
+				res += (Math.pow((i + j - mux - muy), 3) * matrix[j][i]);
+			}
+		}
+		output.setReal(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultContrast.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultContrast.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.Contrast;
+import net.imagej.ops.features.haralick.helper.CoocPXMinusY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of texture contrast haralick feature.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Contrast", name = Haralick.Contrast.NAME)
+public class DefaultContrast<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements Contrast {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double[] pxminusxy = (double[]) ops.run(CoocPXMinusY.class,
+				(Object) matrix);
+
+		double res = 0;
+		for (int k = 0; k <= matrix.length - 1; k++) {
+			res += k * k * pxminusxy[k];
+		}
+
+		output.set(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultCorrelation.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultCorrelation.java
@@ -1,0 +1,95 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.Correlation;
+import net.imagej.ops.features.haralick.helper.CoocMeanX;
+import net.imagej.ops.features.haralick.helper.CoocMeanY;
+import net.imagej.ops.features.haralick.helper.CoocStdX;
+import net.imagej.ops.features.haralick.helper.CoocStdY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of texture correlation haralick feature.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Correlation", name = Haralick.Correlation.NAME)
+public class DefaultCorrelation<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements Correlation {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final int nrGrayLevels = matrix.length;
+
+		final double meanx = ((DoubleType) ops.run(CoocMeanX.class,
+				(Object) matrix)).getRealDouble();
+
+		final double meany = ((DoubleType) ops.run(CoocMeanY.class,
+				(Object) matrix)).getRealDouble();
+
+		final double stdx = ((DoubleType) ops.run(CoocStdX.class,
+				(Object) matrix)).getRealDouble();
+
+		final double stdy = ((DoubleType) ops.run(CoocStdY.class,
+				(Object) matrix)).getRealDouble();
+
+		double res = 0;
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				res += ((i - meanx) * (j - meany))
+						* (matrix[i][j] / (stdx * stdy));
+			}
+		}
+
+		// if NaN
+		if (Double.isNaN(res)) {
+			output.set(0);
+		} else {
+			output.set(res);
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultDifferenceEntropy.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultDifferenceEntropy.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.DifferenceEntropy;
+import net.imagej.ops.features.haralick.helper.CoocPXMinusY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Difference Entropy Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Difference Entropy", name = Haralick.DifferenceEntropy.NAME)
+public class DefaultDifferenceEntropy<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements DifferenceEntropy {
+
+	// Avoid log 0
+	private static final double EPSILON = 0.00000001f;
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double[] pxminusy = (double[]) ops.run(CoocPXMinusY.class,
+				(Object) matrix);
+		final int nrGrayLevels = matrix.length;
+
+		double res = 0;
+		for (int k = 0; k <= nrGrayLevels - 1; k++) {
+			res += pxminusy[k] * Math.log(pxminusy[k] + EPSILON);
+		}
+
+		output.set(-res);
+
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultDifferenceVariance.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultDifferenceVariance.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.DifferenceVariance;
+import net.imagej.ops.features.haralick.helper.CoocPXMinusY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Difference Variance Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Difference Variance", name = Haralick.DifferenceVariance.NAME)
+public class DefaultDifferenceVariance<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements DifferenceVariance {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double[] pxminusy = (double[]) ops.run(CoocPXMinusY.class,
+				(Object) matrix);
+		double sum = 0.0d;
+		double res = 0;
+		for (int k = 0; k < pxminusy.length; k++) {
+			sum += k * pxminusy[k];
+		}
+
+		for (int k = 0; k < pxminusy.length; k++) {
+			res += (k - sum) * pxminusy[k];
+		}
+
+		output.set(res);
+
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultEntropy.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultEntropy.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.Entropy;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Entropy Haralick Feature Definition: -( sum_{i=1}^q
+ * sum_{j=1}^q c(i,j) log10(c(i,j)) )
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Entropy", name = Haralick.Entropy.NAME)
+public class DefaultEntropy<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements Entropy {
+
+	private static final double EPSILON = 0.00000001f;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+		double res = 0;
+
+		final int nrGrayLevels = matrix.length;
+
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				res += matrix[i][j] * Math.log10(matrix[i][j] + EPSILON);
+			}
+		}
+
+		output.set(-res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultICM1.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultICM1.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.ICM1;
+import net.imagej.ops.features.haralick.helper.CoocHXY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Implementation of Information Measure of Correlation 1 Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, name = Haralick.ICM1.NAME, label = "Haralick: Information Measure of Correlation 1")
+public class DefaultICM1<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements ICM1 {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+		double res = 0;
+
+		final double[] coochxy = (double[]) ops.run(CoocHXY.class,
+				(Object) matrix);
+
+		res = (ops.haralick()
+				.entropy(input, numGreyLevels, distance, orientation).get() - coochxy[2])
+				/ (coochxy[0] > coochxy[1] ? coochxy[0] : coochxy[1]);
+
+		output.set(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultICM2.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultICM2.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.ICM2;
+import net.imagej.ops.features.haralick.helper.CoocHXY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Implementation of Information Measure of Correlation 2 Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, name = Haralick.ICM2.NAME, label = "Haralick: Information Measure of Correlation 2")
+public class DefaultICM2<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements ICM2 {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		double res = 0;
+		final double[] coochxy = (double[]) ops.run(CoocHXY.class,
+				(Object) matrix);
+		res = Math.sqrt(1 - Math.exp(-2
+				* (coochxy[3] - ops.haralick()
+						.entropy(input, numGreyLevels, distance, orientation)
+						.get())));
+
+		// if NaN
+		if (Double.isNaN(res)) {
+			output.set(0);
+		} else {
+			output.set(res);
+		}
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultIFDM.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultIFDM.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.IFDM;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Inverse Difference Moment Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, Univesity of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, name = Haralick.IFDM.NAME, label = "Haralick: Inverse Difference Moment")
+public class DefaultIFDM<T extends RealType<T>> extends AbstractHaralickFeature<T>
+		implements IFDM {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		double res = 0;
+
+		final int nrGrayLevels = matrix.length;
+
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				if (i != j) {
+					res += matrix[i][j] / (Math.abs(i - j));
+				}
+			}
+		}
+
+		output.set(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultMaxProbability.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultMaxProbability.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.MaxProbability;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Implementation of Maximum Probability Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Maximum Probability Feature", name = Haralick.MaxProbability.NAME)
+public class DefaultMaxProbability<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements MaxProbability {
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double nrGreyLevel = matrix.length;
+
+		double res = 0;
+		for (int i = 0; i < nrGreyLevel; i++) {
+			for (int j = 0; j < nrGreyLevel; j++) {
+				if (matrix[i][j] > res)
+					res = matrix[i][j];
+			}
+		}
+
+		output.set(res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultSumAverage.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultSumAverage.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.SumAverage;
+import net.imagej.ops.features.haralick.helper.CoocPXPlusY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Sum Average Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Sum Average", name = Haralick.SumAverage.NAME)
+public class DefaultSumAverage<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements SumAverage {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double[] pxplusy = (double[]) ops.run(CoocPXPlusY.class,
+				(Object) matrix);
+
+		final int nrGrayLevels = matrix.length;
+
+		double res = 0;
+		for (int i = 2; i <= 2 * nrGrayLevels; i++) {
+			res += i * pxplusy[i];
+		}
+		output.set(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultSumEntropy.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultSumEntropy.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.SumEntropy;
+import net.imagej.ops.features.haralick.helper.CoocPXPlusY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Sum Entropy Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ * 
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Sum Entropy", name = Haralick.SumEntropy.NAME)
+public class DefaultSumEntropy<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements SumEntropy {
+
+	// Avoid log 0
+	private static final double EPSILON = 0.00000001f;
+
+	@Parameter
+	private OpService ops;
+
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+		final double[] pxplusy = (double[]) ops.run(CoocPXPlusY.class,
+				(Object) matrix);
+		final int nrGrayLevels = matrix.length;
+
+		double res = 0;
+		for (int i = 2; i <= 2 * nrGrayLevels; i++) {
+			res += pxplusy[i] * Math.log10(pxplusy[i] + EPSILON);
+		}
+
+		output.set(-res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultSumVariance.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultSumVariance.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.SumVariance;
+import net.imagej.ops.features.haralick.helper.CoocPXPlusY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Implementation of Sum Variance Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Sum Variance", name = Haralick.SumVariance.NAME)
+public class DefaultSumVariance<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements SumVariance {
+
+	@Parameter
+	private OpService ops;
+
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double[] pxplusy = (double[]) ops.run(CoocPXPlusY.class,
+				(Object) matrix);
+		final int nrGrayLevels = matrix.length;
+		final double average = ((DoubleType) ops.haralick().sumaverage(input,
+				numGreyLevels, distance, orientation)).getRealDouble();
+
+		double res = 0;
+		for (int i = 2; i <= 2 * nrGrayLevels; i++) {
+			res += (i - average) * (i - average) * pxplusy[i];
+		}
+
+		output.set(res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultTextureHomogeneity.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultTextureHomogeneity.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.TextureHomogeneity;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Implementation of Texture Homogeneity Haralick Feature
+ * 
+ * @author Andreas Grauman, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Texture Homogeneity Feature", name = Haralick.TextureHomogeneity.NAME)
+public class DefaultTextureHomogeneity<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements TextureHomogeneity {
+
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double nrGreyLevel = matrix.length;
+
+		double res = 0;
+		for (int i = 0; i < nrGreyLevel; i++) {
+			for (int j = 0; j < nrGreyLevel; j++) {
+				res += matrix[i][j] / (1 + Math.abs(i - j));
+			}
+		}
+
+		output.set(res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/DefaultVariance.java
+++ b/src/main/java/net/imagej/ops/features/haralick/DefaultVariance.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Haralick;
+import net.imagej.ops.Ops.Haralick.Variance;
+import net.imagej.ops.features.haralick.helper.CoocMeanX;
+import net.imagej.ops.features.haralick.helper.CoocMeanY;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * 
+ * Implementation of Variance Haralick Feature
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+@Plugin(type = HaralickFeature.class, label = "Haralick: Variance", name = Haralick.Variance.NAME)
+public class DefaultVariance<T extends RealType<T>> extends
+		AbstractHaralickFeature<T> implements Variance {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public void compute(final IterableInterval<T> input, final DoubleType output) {
+		final double[][] matrix = getCooccurrenceMatrix(input);
+
+		final double mux = ((DoubleType) ops.run(CoocMeanX.class,
+				(Object) matrix)).getRealDouble();
+
+		final double muy = ((DoubleType) ops.run(CoocMeanY.class,
+				(Object) matrix)).getRealDouble();
+
+		final int nrGreyLevel = matrix.length;
+
+		double result = 0.0;
+		for (int i = 0; i < nrGreyLevel; i++) {
+			for (int j = 0; j < nrGreyLevel; j++) {
+				result += (((i - mux) * (i - mux)) * matrix[i][j] + ((j - muy) * (j - muy))
+						* matrix[i][j]);
+			}
+		}
+
+		output.set(result / 2);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/HaralickFeature.java
+++ b/src/main/java/net/imagej/ops/features/haralick/HaralickFeature.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.HybridOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+/**
+ * Simple marker interface for Haralick Features.
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ * @param <T>
+ *            type of the incoming {@link IterableInterval}
+ */
+public interface HaralickFeature<T extends RealType<T>> extends
+		HybridOp<IterableInterval<T>, DoubleType> {
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/HaralickNamespace.java
+++ b/src/main/java/net/imagej/ops/features/haralick/HaralickNamespace.java
@@ -1,0 +1,441 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.haralick;
+
+import java.util.Map;
+
+import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.Namespace;
+import net.imagej.ops.OpMethod;
+import net.imagej.ops.OpRef;
+import net.imagej.ops.image.cooccurrencematrix.MatrixOrientation;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Namespace for Haralick Features
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = Namespace.class)
+public class HaralickNamespace extends AbstractNamespace {
+
+	@Override
+	public String getName() {
+		return "haralick";
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultASM.class)
+	public <T extends RealType<T>> DoubleType asm(final IterableInterval<T> in,
+		final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultASM.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultASM.class)
+	public <T extends RealType<T>> DoubleType asm(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultASM.class, out, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultClusterPromenence.class)
+	public <T extends RealType<T>> DoubleType clusterpromenence(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultClusterPromenence.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultClusterPromenence.class)
+	public <T extends RealType<T>> DoubleType clusterpromenence(
+		final DoubleType out, final IterableInterval<T> in, final int numGreyLevels,
+		final int distance, final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultClusterPromenence.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultClusterShade.class)
+	public <T extends RealType<T>> DoubleType clustershade(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultClusterShade.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultClusterShade.class)
+	public <T extends RealType<T>> DoubleType clustershade(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultClusterShade.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultContrast.class)
+	public <T extends RealType<T>> DoubleType contrast(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultContrast.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultContrast.class)
+	public <T extends RealType<T>> DoubleType contrast(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultContrast.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultCorrelation.class)
+	public <T extends RealType<T>> DoubleType correlation(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultCorrelation.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultCorrelation.class)
+	public <T extends RealType<T>> DoubleType correlation(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultCorrelation.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultDifferenceEntropy.class)
+	public <T extends RealType<T>> DoubleType differenceentropy(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultDifferenceEntropy.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultDifferenceEntropy.class)
+	public <T extends RealType<T>> DoubleType differenceentropy(
+		final DoubleType out, final IterableInterval<T> in, final int numGreyLevels,
+		final int distance, final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultDifferenceEntropy.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultDifferenceVariance.class)
+	public <T extends RealType<T>> DoubleType differencevariance(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultDifferenceVariance.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultDifferenceVariance.class)
+	public <T extends RealType<T>> DoubleType differencevariance(
+		final DoubleType out, final IterableInterval<T> in, final int numGreyLevels,
+		final int distance, final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultDifferenceVariance.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultEntropy.class)
+	public <T extends RealType<T>> DoubleType entropy(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultEntropy.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultEntropy.class)
+	public <T extends RealType<T>> DoubleType entropy(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultEntropy.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultICM1.class)
+	public <T extends RealType<T>> DoubleType icm1(final IterableInterval<T> in,
+		final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultICM1.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultICM1.class)
+	public <T extends RealType<T>> DoubleType icm1(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultICM1.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultICM2.class)
+	public <T extends RealType<T>> DoubleType icm2(final IterableInterval<T> in,
+		final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultICM2.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultICM2.class)
+	public <T extends RealType<T>> DoubleType icm2(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultICM2.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultIFDM.class)
+	public <T extends RealType<T>> DoubleType ifdm(final IterableInterval<T> in,
+		final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultIFDM.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultIFDM.class)
+	public <T extends RealType<T>> DoubleType ifdm(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultIFDM.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultMaxProbability.class)
+	public <T extends RealType<T>> DoubleType maxprobability(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultMaxProbability.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultMaxProbability.class)
+	public <T extends RealType<T>> DoubleType maxprobability(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultMaxProbability.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultSumAverage.class)
+	public <T extends RealType<T>> DoubleType sumaverage(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultSumAverage.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultSumAverage.class)
+	public <T extends RealType<T>> DoubleType sumaverage(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultSumAverage.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultSumEntropy.class)
+	public <T extends RealType<T>> DoubleType sumentropy(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultSumEntropy.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultSumEntropy.class)
+	public <T extends RealType<T>> DoubleType sumentropy(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultSumEntropy.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultSumVariance.class)
+	public <T extends RealType<T>> DoubleType sumvariance(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultSumVariance.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultSumVariance.class)
+	public <T extends RealType<T>> DoubleType sumvariance(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultSumVariance.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultTextureHomogeneity.class)
+	public <T extends RealType<T>> DoubleType texturehomogeneity(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultTextureHomogeneity.class, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.features.haralick.DefaultTextureHomogeneity.class)
+	public <T extends RealType<T>> DoubleType texturehomogeneity(
+		final DoubleType out, final IterableInterval<T> in, final int numGreyLevels,
+		final int distance, final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultTextureHomogeneity.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultVariance.class)
+	public <T extends RealType<T>> DoubleType variance(
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultVariance.class, in, numGreyLevels,
+			distance, orientation);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.features.haralick.DefaultVariance.class)
+	public <T extends RealType<T>> DoubleType variance(final DoubleType out,
+		final IterableInterval<T> in, final int numGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
+		final DoubleType result = (DoubleType) ops().run(
+			net.imagej.ops.features.haralick.DefaultVariance.class, out, in,
+			numGreyLevels, distance, orientation);
+		return result;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocHXY.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocHXY.java
@@ -1,0 +1,84 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.OpService;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocHXY.class)
+public class CoocHXY extends AbstractFunctionOp<double[][], double[]> {
+
+	private static final double EPSILON = 0.00000001f;
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public double[] compute(double[][] matrix) {
+		double hx = 0.0d;
+		double hy = 0.0d;
+		double hxy1 = 0.0d;
+		double hxy2 = 0.0d;
+
+		final int nrGrayLevels = matrix.length;
+
+		final double[] px = (double[]) ops.run(CoocPX.class, (Object) matrix);
+		final double[] py = (double[]) ops.run(CoocPY.class, (Object) matrix);
+
+		for (int i = 0; i < px.length; i++) {
+			hx += px[i] * Math.log(px[i] + EPSILON);
+		}
+		hx = -hx;
+
+		for (int j = 0; j < py.length; j++) {
+			hy += py[j] * Math.log(py[j] + EPSILON);
+		}
+		hy = -hy;
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				hxy1 += matrix[i][j] * Math.log(px[i] * py[j] + EPSILON);
+				hxy2 += px[i] * py[j] * Math.log(px[i] * py[j] + EPSILON);
+			}
+		}
+		hxy1 = -hxy1;
+		hxy2 = -hxy2;
+
+		return new double[] { hx, hy, hxy1, hxy2 };
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocMeanX.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocMeanX.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.OpService;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocMeanX.class)
+public class CoocMeanX extends AbstractFunctionOp<double[][], DoubleType> {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public DoubleType compute(double[][] input) {
+
+		double res = 0;
+		final double[] px = (double[]) ops.run(CoocPX.class,
+				(Object) getInput());
+		for (int i = 0; i < px.length; i++) {
+			res += i * px[i];
+		}
+
+		return new DoubleType(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocMeanY.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocMeanY.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.OpService;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocMeanY.class)
+public class CoocMeanY extends AbstractFunctionOp<double[][], DoubleType> {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public DoubleType compute(double[][] input) {
+
+		double res = 0;
+		final double[] py = (double[]) ops.run(CoocPY.class, (Object) input);
+		for (int i = 0; i < py.length; i++) {
+			res += i * py[i];
+		}
+		return new DoubleType(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocPX.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocPX.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocPX.class)
+public class CoocPX extends AbstractFunctionOp<double[][], double[]> {
+
+	@Override
+	public double[] compute(double[][] input) {
+		final int nrGrayLevels = input.length;
+		final double[] output = new double[nrGrayLevels];
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				output[j] += input[i][j];
+			}
+		}
+
+		return output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocPXMinusY.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocPXMinusY.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocPXMinusY.class)
+public class CoocPXMinusY extends AbstractFunctionOp<double[][], double[]> {
+
+	@Override
+	public double[] compute(final double[][] matrix) {
+
+		final int nrGrayLevels = matrix.length;
+
+		final double[] pxminusy = new double[nrGrayLevels];
+		for (int k = 0; k < nrGrayLevels; k++) {
+			for (int i = 0; i < nrGrayLevels; i++) {
+				for (int j = 0; j < nrGrayLevels; j++) {
+					if (Math.abs(i - j) == k) {
+						pxminusy[k] += matrix[i][j];
+					}
+				}
+			}
+		}
+
+		return pxminusy;
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocPXPlusY.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocPXPlusY.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocPXPlusY.class)
+public class CoocPXPlusY extends AbstractFunctionOp<double[][], double[]> {
+
+	@Override
+	public double[] compute(double[][] matrix) {
+
+		final int nrGrayLevels = matrix.length;
+
+		final double[] pxplusy = new double[2 * nrGrayLevels + 1];
+
+		for (int k = 2; k <= 2 * nrGrayLevels; k++) {
+			for (int i = 0; i < nrGrayLevels; i++) {
+				for (int j = 0; j < nrGrayLevels; j++) {
+					if ((i + 1) + (j + 1) == k) {
+						pxplusy[k] += matrix[i][j];
+					}
+				}
+			}
+		}
+		return pxplusy;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocPY.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocPY.java
@@ -1,0 +1,59 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocPY.class)
+public class CoocPY extends AbstractFunctionOp<double[][], double[]> {
+
+	@Override
+	public double[] compute(final double[][] matrix) {
+		final int nrGrayLevels = matrix.length;
+
+		final double[] px = new double[nrGrayLevels];
+		for (int i = 0; i < nrGrayLevels; i++) {
+			for (int j = 0; j < nrGrayLevels; j++) {
+				px[i] += matrix[i][j];
+			}
+		}
+
+		return px;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocStdX.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocStdX.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.OpService;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocStdX.class)
+public class CoocStdX extends AbstractFunctionOp<double[][], DoubleType> {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public DoubleType compute(double[][] input) {
+
+		double res = 0;
+
+		final double meanx = ((DoubleType) ops.run(CoocMeanX.class,
+				(Object) getInput())).getRealDouble();
+		final double[] px = (double[]) ops.run(CoocPX.class,
+				(Object) getInput());
+
+		for (int i = 0; i < px.length; i++) {
+			res += ((i - meanx) * (i - meanx)) * px[i];
+		}
+
+		return new DoubleType(res);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/haralick/helper/CoocStdY.java
+++ b/src/main/java/net/imagej/ops/features/haralick/helper/CoocStdY.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick.helper;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.OpService;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * NB: Helper class. Internal usage only.
+ * 
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CoocStdY.class)
+public class CoocStdY extends AbstractFunctionOp<double[][], DoubleType> {
+
+	@Parameter
+	private OpService ops;
+
+	@Override
+	public DoubleType compute(double[][] input) {
+		double res = 0;
+
+		final double meany = ((DoubleType) ops.run(CoocMeanY.class,
+				(Object) input)).getRealDouble();
+
+		final double[] py = (double[]) ops.run(CoocPY.class,
+				(Object) getInput());
+
+		for (int i = 0; i < py.length; i++) {
+			res += ((i - meany) * (i - meany)) * py[i];
+		}
+
+		return new DoubleType(res);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -36,6 +36,8 @@ import net.imagej.ops.ComputerOp;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Image.CooccurrenceMatrix;
+import net.imagej.ops.image.cooccurrencematrix.MatrixOrientation;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
@@ -67,30 +69,41 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "ascii" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.ascii.DefaultASCII.class)
 	public <T extends RealType<T>> String ascii(final IterableInterval<T> image) {
-		final String result =
-			(String) ops().run(net.imagej.ops.image.ascii.DefaultASCII.class, image);
+		final String result = (String) ops().run(
+				net.imagej.ops.image.ascii.DefaultASCII.class, image);
 		return result;
 	}
 
 	/** Executes the "ascii" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.ascii.DefaultASCII.class)
-	public <T extends RealType<T>> String ascii(final IterableInterval<T> image,
-		final RealType<T> min)
-	{
-		final String result =
-			(String) ops().run(net.imagej.ops.image.ascii.DefaultASCII.class, image,
-				min);
+	public <T extends RealType<T>> String ascii(
+			final IterableInterval<T> image, final RealType<T> min) {
+		final String result = (String) ops().run(
+				net.imagej.ops.image.ascii.DefaultASCII.class, image, min);
 		return result;
 	}
 
 	/** Executes the "ascii" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.ascii.DefaultASCII.class)
-	public <T extends RealType<T>> String ascii(final IterableInterval<T> image,
-		final RealType<T> min, final RealType<T> max)
-	{
-		final String result =
-			(String) ops().run(net.imagej.ops.image.ascii.DefaultASCII.class, image,
-				min, max);
+	public <T extends RealType<T>> String ascii(
+			final IterableInterval<T> image, final RealType<T> min,
+			final RealType<T> max) {
+		final String result = (String) ops().run(
+				net.imagej.ops.image.ascii.DefaultASCII.class, image, min, max);
+		return result;
+	}
+
+	// -- cooccurrence matrix --
+
+	@OpMethod(ops = {
+			net.imagej.ops.image.cooccurrencematrix.CooccurrenceMatrix3D.class,
+			net.imagej.ops.image.cooccurrencematrix.CooccurrenceMatrix2D.class })
+	public <T extends RealType<T>> double[][] cooccurrenceMatrix(
+			final IterableInterval<T> in, final int nrGreyLevels,
+			final int distance, final MatrixOrientation orientation) {
+		final double[][] result = (double[][]) ops().run(
+				CooccurrenceMatrix.class, in, nrGreyLevels, distance,
+				orientation);
 		return result;
 	}
 
@@ -105,50 +118,43 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "crop" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.crop.CropImgPlus.class)
 	public <T extends Type<T>> ImgPlus<T> crop(final ImgPlus<T> in,
-		final Interval interval)
-	{
+			final Interval interval) {
 		@SuppressWarnings("unchecked")
-		final ImgPlus<T> result =
-			(ImgPlus<T>) ops().run(net.imagej.ops.image.crop.CropImgPlus.class, in,
-				interval);
+		final ImgPlus<T> result = (ImgPlus<T>) ops().run(
+				net.imagej.ops.image.crop.CropImgPlus.class, in, interval);
 		return result;
 	}
 
 	/** Executes the "crop" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.crop.CropImgPlus.class)
 	public <T extends Type<T>> ImgPlus<T> crop(final ImgPlus<T> in,
-		final Interval interval, final boolean dropSingleDimensions)
-	{
+			final Interval interval, final boolean dropSingleDimensions) {
 		@SuppressWarnings("unchecked")
-		final ImgPlus<T> result =
-			(ImgPlus<T>) ops().run(net.imagej.ops.image.crop.CropImgPlus.class, in,
-				interval, dropSingleDimensions);
-		return result;
-	}
-
-	/** Executes the "crop" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.image.crop.CropRAI.class)
-	public <T> RandomAccessibleInterval<T> crop(
-		final RandomAccessibleInterval<T> in, final Interval interval)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.image.crop.CropRAI.class, in, interval);
-		return result;
-	}
-
-	/** Executes the "crop" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.image.crop.CropRAI.class)
-	public <T> RandomAccessibleInterval<T> crop(
-		final RandomAccessibleInterval<T> in, final Interval interval,
-		final boolean dropSingleDimensions)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.image.crop.CropRAI.class, in, interval,
+		final ImgPlus<T> result = (ImgPlus<T>) ops().run(
+				net.imagej.ops.image.crop.CropImgPlus.class, in, interval,
 				dropSingleDimensions);
+		return result;
+	}
+
+	/** Executes the "crop" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.image.crop.CropRAI.class)
+	public <T> RandomAccessibleInterval<T> crop(
+			final RandomAccessibleInterval<T> in, final Interval interval) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
+				.run(net.imagej.ops.image.crop.CropRAI.class, in, interval);
+		return result;
+	}
+
+	/** Executes the "crop" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.image.crop.CropRAI.class)
+	public <T> RandomAccessibleInterval<T> crop(
+			final RandomAccessibleInterval<T> in, final Interval interval,
+			final boolean dropSingleDimensions) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
+				.run(net.imagej.ops.image.crop.CropRAI.class, in, interval,
+						dropSingleDimensions);
 		return result;
 	}
 
@@ -164,8 +170,7 @@ public class ImageNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.image.equation.DefaultEquation.class)
 	public <T extends RealType<T>> IterableInterval<T> equation(final String in) {
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
 				net.imagej.ops.image.equation.DefaultEquation.class, in);
 		return result;
 	}
@@ -173,11 +178,9 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "equation" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.equation.DefaultEquation.class)
 	public <T extends RealType<T>> IterableInterval<T> equation(
-		final IterableInterval<T> out, final String in)
-	{
+			final IterableInterval<T> out, final String in) {
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
 				net.imagej.ops.image.equation.DefaultEquation.class, out, in);
 		return result;
 	}
@@ -192,24 +195,21 @@ public class ImageNamespace extends AbstractNamespace {
 
 	/** Executes the "histogram" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.histogram.HistogramCreate.class)
-	public <T extends RealType<T>> Histogram1d<T> histogram(final Iterable<T> in)
-	{
+	public <T extends RealType<T>> Histogram1d<T> histogram(final Iterable<T> in) {
 		@SuppressWarnings("unchecked")
-		final Histogram1d<T> result =
-			(Histogram1d<T>) ops().run(
+		final Histogram1d<T> result = (Histogram1d<T>) ops().run(
 				net.imagej.ops.image.histogram.HistogramCreate.class, in);
 		return result;
 	}
 
 	/** Executes the "histogram" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.histogram.HistogramCreate.class)
-	public <T extends RealType<T>> Histogram1d<T> histogram(final Iterable<T> in,
-		final int numBins)
-	{
+	public <T extends RealType<T>> Histogram1d<T> histogram(
+			final Iterable<T> in, final int numBins) {
 		@SuppressWarnings("unchecked")
-		final Histogram1d<T> result =
-			(Histogram1d<T>) ops().run(
-				net.imagej.ops.image.histogram.HistogramCreate.class, in, numBins);
+		final Histogram1d<T> result = (Histogram1d<T>) ops().run(
+				net.imagej.ops.image.histogram.HistogramCreate.class, in,
+				numBins);
 		return result;
 	}
 
@@ -223,13 +223,12 @@ public class ImageNamespace extends AbstractNamespace {
 
 	/** Executes the "invert" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.invert.InvertIterableInterval.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O>
-		invert(final IterableInterval<O> out, final IterableInterval<I> in)
-	{
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
+			final IterableInterval<O> out, final IterableInterval<I> in) {
 		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result =
-			(IterableInterval<O>) ops().run(
-				net.imagej.ops.image.invert.InvertIterableInterval.class, out, in);
+		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
+				net.imagej.ops.image.invert.InvertIterableInterval.class, out,
+				in);
 		return result;
 	}
 
@@ -407,16 +406,15 @@ public class ImageNamespace extends AbstractNamespace {
 	}
 
 	/** Executes the "project" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.image.project.DefaultProjectParallel.class,
-		net.imagej.ops.image.project.ProjectRAIToIterableInterval.class })
+	@OpMethod(ops = {
+			net.imagej.ops.image.project.DefaultProjectParallel.class,
+			net.imagej.ops.image.project.ProjectRAIToIterableInterval.class })
 	public <T, V> IterableInterval<V> project(final IterableInterval<V> out,
-		final RandomAccessibleInterval<T> in,
-		final ComputerOp<Iterable<T>, V> method, final int dim)
-	{
+			final RandomAccessibleInterval<T> in,
+			final ComputerOp<Iterable<T>, V> method, final int dim) {
 		@SuppressWarnings("unchecked")
-		final IterableInterval<V> result =
-			(IterableInterval<V>) ops().run(net.imagej.ops.Ops.Image.Project.class,
-				out, in, method, dim);
+		final IterableInterval<V> result = (IterableInterval<V>) ops().run(
+				net.imagej.ops.Ops.Image.Project.class, out, in, method, dim);
 		return result;
 	}
 
@@ -431,13 +429,12 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "scale" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.scale.ScaleImg.class)
 	public <T extends RealType<T>> Img<T> scale(final Img<T> in,
-		final double[] scaleFactors,
-		final InterpolatorFactory<T, RandomAccessible<T>> interpolator)
-	{
+			final double[] scaleFactors,
+			final InterpolatorFactory<T, RandomAccessible<T>> interpolator) {
 		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.image.scale.ScaleImg.class, in,
-				scaleFactors, interpolator);
+		final Img<T> result = (Img<T>) ops().run(
+				net.imagej.ops.image.scale.ScaleImg.class, in, scaleFactors,
+				interpolator);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -98,7 +98,7 @@ public class ImageNamespace extends AbstractNamespace {
 	@OpMethod(ops = {
 			net.imagej.ops.image.cooccurrencematrix.CooccurrenceMatrix3D.class,
 			net.imagej.ops.image.cooccurrencematrix.CooccurrenceMatrix2D.class })
-	public <T extends RealType<T>> double[][] cooccurrenceMatrix(
+	public <T extends RealType<T>> double[][] cooccurrencematrix(
 			final IterableInterval<T> in, final int nrGreyLevels,
 			final int distance, final MatrixOrientation orientation) {
 		final double[][] result = (double[][]) ops().run(

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix2D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix2D.java
@@ -1,3 +1,32 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imagej.ops.image.cooccurrencematrix;
 
 import java.util.Arrays;

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix2D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix2D.java
@@ -1,0 +1,156 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.cooccurrencematrix;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Image.CooccurrenceMatrix;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This Helper Class holds a co-occurrence matrix.
+ * 
+ * @author Stephan Sellien, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ * @author Andreas Graumann, University of Konstanz
+ */
+@Plugin(type = CooccurrenceMatrix.class, name = CooccurrenceMatrix.NAME)
+public class CooccurrenceMatrix2D<T extends RealType<T>> extends
+		AbstractFunctionOp<IterableInterval<T>, double[][]> implements
+		CooccurrenceMatrix, Contingent {
+
+	public static enum MatrixOrientation {
+		DIAGONAL(1, -1), ANTIDIAGONAL(1, 1), HORIZONTAL(1, 0), VERTICAL(0, 1);
+
+		public final int dx;
+
+		public final int dy;
+
+		private MatrixOrientation(int dx, int dy) {
+			this.dx = dx;
+			this.dy = dy;
+		}
+	}
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter(label = "Number of Gray Levels", min = "0", max = "128", stepSize = "1", initializer = "32")
+	private int nrGreyLevels;
+
+	@Parameter(label = "Distance", min = "0", max = "128", stepSize = "1", initializer = "1")
+	private int distance;
+
+	// TODO use enum
+	@Parameter(label = "Matrix Orientation", choices = { "DIAGONAL",
+			"ANTIDIAGONAL", "HORIZONTAL", "VERTICAL" })
+	private String orientation;
+
+	@Override
+	public double[][] compute(IterableInterval<T> input) {
+
+		double[][] output = new double[nrGreyLevels][nrGreyLevels];
+
+		final MatrixOrientation orientation = MatrixOrientation
+				.valueOf(this.orientation);
+
+		final Cursor<? extends RealType<?>> cursor = input.cursor();
+
+		final List<T> minMax = ops.stats().minMax(input);
+
+		double localMin = minMax.get(0).getRealDouble();
+		double localMax = minMax.get(1).getRealDouble();
+
+		final int[][] pixels = new int[(int) input.dimension(1)][(int) input
+				.dimension(0)];
+
+		for (int i = 0; i < pixels.length; i++) {
+			Arrays.fill(pixels[i], Integer.MAX_VALUE);
+		}
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			pixels[cursor.getIntPosition(1) - (int) input.min(1)][cursor
+					.getIntPosition(0) - (int) input.min(0)] = (int) (((cursor
+					.get().getRealDouble() - localMin) / (localMax - localMin)) * (nrGreyLevels - 1));
+		}
+
+		int nrPairs = 0;
+
+		for (int y = 0; y < pixels.length; y++) {
+			for (int x = 0; x < pixels[y].length; x++) {
+				// ignore pixels not in mask
+				if (pixels[y][x] == Integer.MAX_VALUE) {
+					continue;
+				}
+
+				// // get second pixel
+				final int sx = x + orientation.dx * distance;
+				final int sy = y + orientation.dy * distance;
+
+				// second pixel in interval and mask
+				if (sx >= 0 && sy >= 0 && sy < pixels.length
+						&& sx < pixels[sy].length
+						&& pixels[sy][sx] != Integer.MAX_VALUE) {
+					output[pixels[y][x]][pixels[sy][sx]]++;
+					nrPairs++;
+				}
+
+			}
+		}
+
+		if (nrPairs > 0) {
+			double divisor = 1.0 / nrPairs;
+			for (int row = 0; row < output.length; row++) {
+				for (int col = 0; col < output[row].length; col++) {
+					output[row][col] *= divisor;
+				}
+			}
+		}
+
+		return output;
+	}
+
+	@Override
+	public boolean conforms() {
+		return getInput().numDimensions() == 2;
+	}
+}

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix2D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix2D.java
@@ -1,33 +1,3 @@
-/*
- * #%L
- * ImageJ software for multidimensional image processing and analysis.
- * %%
- * Copyright (C) 2014 Board of Regents of the University of
- * Wisconsin-Madison and University of Konstanz.
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
-
 package net.imagej.ops.image.cooccurrencematrix;
 
 import java.util.Arrays;
@@ -35,7 +5,6 @@ import java.util.List;
 
 import net.imagej.ops.AbstractFunctionOp;
 import net.imagej.ops.Contingent;
-import net.imagej.ops.Op;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops.Image.CooccurrenceMatrix;
 import net.imglib2.Cursor;
@@ -46,7 +15,7 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * This Helper Class holds a co-occurrence matrix.
+ * Calculates coocccurrence matrix from an 2D-{@link IterableInterval}.
  * 
  * @author Stephan Sellien, University of Konstanz
  * @author Christian Dietz, University of Konstanz
@@ -57,19 +26,6 @@ public class CooccurrenceMatrix2D<T extends RealType<T>> extends
 		AbstractFunctionOp<IterableInterval<T>, double[][]> implements
 		CooccurrenceMatrix, Contingent {
 
-	public static enum MatrixOrientation {
-		DIAGONAL(1, -1), ANTIDIAGONAL(1, 1), HORIZONTAL(1, 0), VERTICAL(0, 1);
-
-		public final int dx;
-
-		public final int dy;
-
-		private MatrixOrientation(int dx, int dy) {
-			this.dx = dx;
-			this.dy = dy;
-		}
-	}
-
 	@Parameter
 	private OpService ops;
 
@@ -79,18 +35,13 @@ public class CooccurrenceMatrix2D<T extends RealType<T>> extends
 	@Parameter(label = "Distance", min = "0", max = "128", stepSize = "1", initializer = "1")
 	private int distance;
 
-	// TODO use enum
-	@Parameter(label = "Matrix Orientation", choices = { "DIAGONAL",
-			"ANTIDIAGONAL", "HORIZONTAL", "VERTICAL" })
-	private String orientation;
+	@Parameter(label = "Matrix Orientation")
+	private MatrixOrientation orientation;
 
 	@Override
-	public double[][] compute(IterableInterval<T> input) {
+	public double[][] compute(final IterableInterval<T> input) {
 
 		double[][] output = new double[nrGreyLevels][nrGreyLevels];
-
-		final MatrixOrientation orientation = MatrixOrientation
-				.valueOf(this.orientation);
 
 		final Cursor<? extends RealType<?>> cursor = input.cursor();
 
@@ -123,8 +74,8 @@ public class CooccurrenceMatrix2D<T extends RealType<T>> extends
 				}
 
 				// // get second pixel
-				final int sx = x + orientation.dx * distance;
-				final int sy = y + orientation.dy * distance;
+				final int sx = x + orientation.getValueAtDim(0) * distance;
+				final int sy = y + orientation.getValueAtDim(1) * distance;
 
 				// second pixel in interval and mask
 				if (sx >= 0 && sy >= 0 && sy < pixels.length
@@ -151,6 +102,6 @@ public class CooccurrenceMatrix2D<T extends RealType<T>> extends
 
 	@Override
 	public boolean conforms() {
-		return getInput().numDimensions() == 2;
+		return getInput().numDimensions() == 2 && orientation.isCompatible(2);
 	}
 }

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix3D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix3D.java
@@ -1,3 +1,32 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imagej.ops.image.cooccurrencematrix;
 
 import java.util.List;

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix3D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix3D.java
@@ -1,54 +1,20 @@
-/*
- * #%L
- * ImageJ software for multidimensional image processing and analysis.
- * %%
- * Copyright (C) 2014 Board of Regents of the University of
- * Wisconsin-Madison and University of Konstanz.
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
-
 package net.imagej.ops.image.cooccurrencematrix;
 
 import java.util.List;
 
 import net.imagej.ops.AbstractFunctionOp;
 import net.imagej.ops.Contingent;
-import net.imagej.ops.Op;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops.Image.CooccurrenceMatrix;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
-import net.imglib2.ops.operation.iterableinterval.unary.MakeCooccurrenceMatrix.HaralickFeature;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * This Helper Class holds a co-occurrence matrix for volumetric images
- * (3-Dimensional). It's features are ordered according to
- * {@link HaralickFeature}
+ * Calculates coocccurrence matrix from an 3D-{@link IterableInterval}.
  * 
  * @author Stephan Sellien, University of Konstanz
  * @author Andreas Graumann, University of Konstanz
@@ -59,37 +25,6 @@ public class CooccurrenceMatrix3D<T extends RealType<T>> extends
 		AbstractFunctionOp<IterableInterval<T>, double[][]> implements
 		CooccurrenceMatrix, Contingent {
 
-	public static enum MatrixOrientation {
-		// 2D directions
-		HORIZONTAL(1, 0, 0), VERTICAL(0, 1, 0), DIAGONAL(-1, 1, 0), ANTIDIAGONAL(
-				1, 1, 0),
-
-		// 3D Horizontal directions
-		HORIZONTAL_VERTICAL(1, 0, 1), HORIZONTAL_DIAGONAL(1, 0, -1),
-
-		// 3D Vertical directions
-		VERTICAL_VERTICAL(0, 1, 1), VERTICAL_DIAGONAL(0, 1, -1),
-
-		// 3D Diagonal directions
-		DIAGONAL_VERTICAL(-1, 1, 1), DIAGONAL_DIAGONAL(-1, 1, -1),
-
-		// 3D Antidiagonal directions
-		ANTIDIAGONAL_VERTICAL(1, 1, 1), ANTIDIAGONAL_DIAGONAL(1, 1, -1),
-
-		// 3D depth direction
-		DEPTH(0, 0, 1);
-
-		public final int dx;
-		public final int dy;
-		public final int dz;
-
-		private MatrixOrientation(int dx, int dy, int dz) {
-			this.dx = dx;
-			this.dy = dy;
-			this.dz = dz;
-		}
-	}
-
 	@Parameter
 	private OpService ops;
 
@@ -99,18 +34,11 @@ public class CooccurrenceMatrix3D<T extends RealType<T>> extends
 	@Parameter(label = "Distance", min = "0", max = "128", stepSize = "1", initializer = "1")
 	private int distance;
 
-	@Parameter(label = "Matrix Orientation", choices = { "HORIZONTAL",
-			"VERTICAL", "DIAGONAL", "ANTIDIAGONAL", "HORIZONTAL_VERTICAL",
-			"HORIZONTAL_DIAGONAL", "VERTICAL_VERTICAL", "VERTICAL_DIAGONAL",
-			"DIAGONAL_VERTICAL", "DIAGONAL_DIAGONAL", "ANTIDIAGONAL_VERTICAL",
-			"ANTIDIAGONAL_DIAGONAL", "DEPTH" })
-	private String orientation;
+	@Parameter(label = "Matrix Orientation")
+	private MatrixOrientation orientation;
 
 	@Override
-	public double[][] compute(IterableInterval<T> input) {
-
-		final MatrixOrientation orientation = MatrixOrientation
-				.valueOf(this.orientation);
+	public double[][] compute(final IterableInterval<T> input) {
 
 		double[][] matrix = new double[nrGreyLevels][nrGreyLevels];
 
@@ -143,9 +71,9 @@ public class CooccurrenceMatrix3D<T extends RealType<T>> extends
 					}
 
 					// get second pixel
-					final int sx = x + orientation.dx * distance;
-					final int sy = y + orientation.dy * distance;
-					final int sz = z + orientation.dz * distance;
+					final int sx = x + orientation.getValueAtDim(0) * distance;
+					final int sy = y + orientation.getValueAtDim(1) * distance;
+					final int sz = z + orientation.getValueAtDim(2) * distance;
 
 					// second pixel in interval and mask
 					if (sx >= 0 && sy >= 0 && sz >= 0 && sz < pixels.length
@@ -175,6 +103,6 @@ public class CooccurrenceMatrix3D<T extends RealType<T>> extends
 
 	@Override
 	public boolean conforms() {
-		return getInput().numDimensions() == 3;
+		return getInput().numDimensions() == 3 && orientation.isCompatible(3);
 	}
 }

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix3D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/CooccurrenceMatrix3D.java
@@ -1,0 +1,180 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.cooccurrencematrix;
+
+import java.util.List;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops.Image.CooccurrenceMatrix;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.ops.operation.iterableinterval.unary.MakeCooccurrenceMatrix.HaralickFeature;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This Helper Class holds a co-occurrence matrix for volumetric images
+ * (3-Dimensional). It's features are ordered according to
+ * {@link HaralickFeature}
+ * 
+ * @author Stephan Sellien, University of Konstanz
+ * @author Andreas Graumann, University of Konstanz
+ * @author Christian Dietz, University of Konstanz
+ */
+@Plugin(type = CooccurrenceMatrix.class, name = CooccurrenceMatrix.NAME)
+public class CooccurrenceMatrix3D<T extends RealType<T>> extends
+		AbstractFunctionOp<IterableInterval<T>, double[][]> implements
+		CooccurrenceMatrix, Contingent {
+
+	public static enum MatrixOrientation {
+		// 2D directions
+		HORIZONTAL(1, 0, 0), VERTICAL(0, 1, 0), DIAGONAL(-1, 1, 0), ANTIDIAGONAL(
+				1, 1, 0),
+
+		// 3D Horizontal directions
+		HORIZONTAL_VERTICAL(1, 0, 1), HORIZONTAL_DIAGONAL(1, 0, -1),
+
+		// 3D Vertical directions
+		VERTICAL_VERTICAL(0, 1, 1), VERTICAL_DIAGONAL(0, 1, -1),
+
+		// 3D Diagonal directions
+		DIAGONAL_VERTICAL(-1, 1, 1), DIAGONAL_DIAGONAL(-1, 1, -1),
+
+		// 3D Antidiagonal directions
+		ANTIDIAGONAL_VERTICAL(1, 1, 1), ANTIDIAGONAL_DIAGONAL(1, 1, -1),
+
+		// 3D depth direction
+		DEPTH(0, 0, 1);
+
+		public final int dx;
+		public final int dy;
+		public final int dz;
+
+		private MatrixOrientation(int dx, int dy, int dz) {
+			this.dx = dx;
+			this.dy = dy;
+			this.dz = dz;
+		}
+	}
+
+	@Parameter
+	private OpService ops;
+
+	@Parameter(label = "Number of Gray Levels", min = "0", max = "128", stepSize = "1", initializer = "32")
+	private int nrGreyLevels;
+
+	@Parameter(label = "Distance", min = "0", max = "128", stepSize = "1", initializer = "1")
+	private int distance;
+
+	@Parameter(label = "Matrix Orientation", choices = { "HORIZONTAL",
+			"VERTICAL", "DIAGONAL", "ANTIDIAGONAL", "HORIZONTAL_VERTICAL",
+			"HORIZONTAL_DIAGONAL", "VERTICAL_VERTICAL", "VERTICAL_DIAGONAL",
+			"DIAGONAL_VERTICAL", "DIAGONAL_DIAGONAL", "ANTIDIAGONAL_VERTICAL",
+			"ANTIDIAGONAL_DIAGONAL", "DEPTH" })
+	private String orientation;
+
+	@Override
+	public double[][] compute(IterableInterval<T> input) {
+
+		final MatrixOrientation orientation = MatrixOrientation
+				.valueOf(this.orientation);
+
+		double[][] matrix = new double[nrGreyLevels][nrGreyLevels];
+
+		final Cursor<T> cursor = input.cursor();
+		final List<T> minMax = ops.stats().minMax(input);
+
+		double localMin = minMax.get(0).getRealDouble();
+		double localMax = minMax.get(1).getRealDouble();
+
+		final int[][][] pixels = new int[(int) input.dimension(2)][(int) input
+				.dimension(1)][(int) input.dimension(0)];
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			pixels[cursor.getIntPosition(2) - (int) input.min(2)][cursor
+					.getIntPosition(1) - (int) input.min(1)][cursor
+					.getIntPosition(0) - (int) input.min(0)] = (int) (((cursor
+					.get().getRealDouble() - localMin) / (localMax - localMin)) * (nrGreyLevels - 1));
+		}
+
+		int nrPairs = 0;
+
+		for (int z = 0; z < pixels.length; z++) {
+			for (int y = 0; y < pixels[z].length; y++) {
+				for (int x = 0; x < pixels[z][y].length; x++) {
+
+					// ignore pixels not in mask
+					if (pixels[z][y][x] == Integer.MAX_VALUE) {
+						continue;
+					}
+
+					// get second pixel
+					final int sx = x + orientation.dx * distance;
+					final int sy = y + orientation.dy * distance;
+					final int sz = z + orientation.dz * distance;
+
+					// second pixel in interval and mask
+					if (sx >= 0 && sy >= 0 && sz >= 0 && sz < pixels.length
+							&& sy < pixels[sz].length
+							&& sx < pixels[sz][sy].length) {
+
+						matrix[pixels[z][y][x]][pixels[sz][sy][sx]]++;
+						nrPairs++;
+
+					}
+				}
+			}
+		}
+
+		// normalize matrix
+		if (nrPairs > 0) {
+			double divisor = 1.0 / nrPairs;
+			for (int row = 0; row < matrix.length; row++) {
+				for (int col = 0; col < matrix[row].length; col++) {
+					matrix[row][col] *= divisor;
+				}
+			}
+		}
+
+		return matrix;
+	}
+
+	@Override
+	public boolean conforms() {
+		return getInput().numDimensions() == 3;
+	}
+}

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation.java
@@ -1,0 +1,22 @@
+package net.imagej.ops.image.cooccurrencematrix;
+
+import net.imagej.ops.Ops.Image.CooccurrenceMatrix;
+
+/**
+ * Simple interface for enums representing the orientation of a
+ * {@link CooccurrenceMatrix}
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+public interface MatrixOrientation {
+
+	boolean isCompatible(int numDims);
+
+	MatrixOrientation getByName(String name);
+
+	int getValueAtDim(int d);
+
+	int numDims();
+
+}

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation.java
@@ -1,3 +1,32 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imagej.ops.image.cooccurrencematrix;
 
 import net.imagej.ops.Ops.Image.CooccurrenceMatrix;

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation2D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation2D.java
@@ -1,0 +1,37 @@
+package net.imagej.ops.image.cooccurrencematrix;
+
+/**
+ * Orientation of a {@link CooccurrenceMatrix2D}
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+public enum MatrixOrientation2D implements MatrixOrientation {
+	DIAGONAL(1, -1), ANTIDIAGONAL(1, 1), HORIZONTAL(1, 0), VERTICAL(0, 1);
+
+	private int[] d;
+
+	private MatrixOrientation2D(int... d) {
+		this.d = d;
+	}
+
+	@Override
+	public boolean isCompatible(int numDims) {
+		return numDims == 2;
+	}
+
+	@Override
+	public MatrixOrientation getByName(String name) {
+		return valueOf(name);
+	}
+
+	@Override
+	public int getValueAtDim(int d) {
+		return this.d[d];
+	}
+
+	@Override
+	public int numDims() {
+		return 2;
+	}
+}

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation2D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation2D.java
@@ -1,3 +1,32 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imagej.ops.image.cooccurrencematrix;
 
 /**

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation3D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation3D.java
@@ -1,3 +1,32 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imagej.ops.image.cooccurrencematrix;
 
 /**

--- a/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation3D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrencematrix/MatrixOrientation3D.java
@@ -1,0 +1,54 @@
+package net.imagej.ops.image.cooccurrencematrix;
+
+/**
+ * Orientation of a {@link CooccurrenceMatrix3D}
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ */
+public enum MatrixOrientation3D implements MatrixOrientation {
+	// 2D directions
+	HORIZONTAL(1, 0, 0), VERTICAL(0, 1, 0), DIAGONAL(-1, 1, 0), ANTIDIAGONAL(1,
+			1, 0),
+
+	// 3D Horizontal directions
+	HORIZONTAL_VERTICAL(1, 0, 1), HORIZONTAL_DIAGONAL(1, 0, -1),
+
+	// 3D Vertical directions
+	VERTICAL_VERTICAL(0, 1, 1), VERTICAL_DIAGONAL(0, 1, -1),
+
+	// 3D Diagonal directions
+	DIAGONAL_VERTICAL(-1, 1, 1), DIAGONAL_DIAGONAL(-1, 1, -1),
+
+	// 3D Antidiagonal directions
+	ANTIDIAGONAL_VERTICAL(1, 1, 1), ANTIDIAGONAL_DIAGONAL(1, 1, -1),
+
+	// 3D depth direction
+	DEPTH(0, 0, 1);
+
+	private int[] d;
+
+	private MatrixOrientation3D(int... d) {
+		this.d = d;
+	}
+
+	@Override
+	public boolean isCompatible(int numDims) {
+		return numDims == 3;
+	}
+
+	@Override
+	public MatrixOrientation getByName(String name) {
+		return valueOf(name);
+	}
+
+	@Override
+	public int getValueAtDim(int d) {
+		return this.d[d];
+	}
+
+	@Override
+	public int numDims() {
+		return 3;
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -49,6 +49,25 @@ namespaces = ```
 		[name: "dog",                iface: "DoG",                 aliases: ["differenceOfGaussian"]],
 		[name: "ifft",               iface: "IFFT"]
 	]],
+		[name: "haralick",           iface: "Haralick", ops: [
+		[name: "asm",		     iface: "ASM"],
+		[name: "clusterpromenence",  iface: "ClusterPromenence"],
+		[name: "clustershade",	     iface: "ClusterShade"],
+		[name: "contrast", 	     iface: "Contrast"],
+		[name: "correlation",        iface: "Correlation"],
+		[name: "differenceentropy",  iface: "DifferenceEntropy"],
+		[name: "entropy",            iface: "Entropy"],
+		[name: "differencevariance", iface: "DifferenceVariance"],
+		[name: "variance",           iface: "Variance"],
+		[name: "icm1",               iface: "ICM1"],
+		[name: "icm2",               iface: "ICM2"],
+		[name: "ifdm",               iface: "IFDM"],
+		[name: "sumaverage",         iface: "SumAverage"],
+		[name: "sumentropy",         iface: "SumEntropy"],
+		[name: "sumvariance",        iface: "SumVariance"],
+		[name: "maxprobability",     iface: "MaxProbability"],
+		[name: "texturehomogeneity", iface: "TextureHomogeneity"]
+	]],
 	[name: "image",      iface: "Image", ops: [
 		[name: "ascii",              iface: "ASCII"],
 		[name: "cooccurrencematrix", iface:"CooccurrenceMatrix"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -51,6 +51,7 @@ namespaces = ```
 	]],
 	[name: "image",      iface: "Image", ops: [
 		[name: "ascii",              iface: "ASCII"],
+		[name: "cooccurrencematrix", iface:"CooccurrenceMatrix"],
 		[name: "crop",               iface: "Crop",                aliases: ["slice"]],
 		[name: "equation",           iface: "Equation"],
 		[name: "histogram",          iface: "Histogram"],

--- a/src/test/java/net/imagej/ops/features/AbstractFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/AbstractFeatureTest.java
@@ -1,0 +1,302 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features;
+
+import ij.ImagePlus;
+import ij.io.Opener;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Random;
+
+import javax.imageio.ImageIO;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.OpService;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayCursor;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.roi.EllipseRegionOfInterest;
+import net.imglib2.roi.labeling.ImgLabeling;
+import net.imglib2.roi.labeling.LabelRegion;
+import net.imglib2.roi.labeling.LabelRegions;
+import net.imglib2.roi.labeling.LabelingType;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Before;
+import org.scijava.Context;
+
+/**
+ * @author Daniel Seebacher (University of Konstanz)
+ * @author Andreas Graumann (University of Konstanz)
+ */
+public class AbstractFeatureTest extends AbstractOpTest {
+
+	/**
+	 * Really small number, used for assertEquals with floating or double
+	 * values.
+	 */
+	protected static final double SMALL_DELTA = 1e-07;
+
+	/**
+	 * Medium small number, used for assertEquals with very little error margin.
+	 */
+	protected static final double MEDIUM_DELTA = 1e-5;
+
+	/**
+	 * Small number, used for assertEquals if a little error margin is allowed.
+	 */
+	protected static final double BIG_DELTA = 1e-3;
+
+	/**
+	 * Seed
+	 */
+	protected static final long SEED = 1234567890L;
+
+	/**
+	 * Some random images
+	 */
+	protected Img<UnsignedByteType> empty;
+	protected Img<UnsignedByteType> constant;
+	protected Img<UnsignedByteType> random;
+
+	protected Img<UnsignedByteType> empty3d;
+	protected Img<UnsignedByteType> constant3d;
+	protected Img<UnsignedByteType> random3d;
+
+	protected Img<UnsignedByteType> ellipse;
+	protected Img<UnsignedByteType> rotatedEllipse;
+
+	@Before
+	public void setup() {
+		ImageGenerator dataGenerator = new ImageGenerator(SEED);
+		long[] dim = new long[] { 100, 100 };
+		long[] dim3 = new long[] { 100, 100, 30 };
+
+		empty = dataGenerator.getEmptyUnsignedByteImg(dim);
+		constant = dataGenerator.getConstantUnsignedByteImg(dim, 15);
+		random = dataGenerator.getRandomUnsignedByteImg(dim);
+
+		empty3d = dataGenerator.getEmptyUnsignedByteImg(dim3);
+		constant3d = dataGenerator.getConstantUnsignedByteImg(dim3, 15);
+		random3d = dataGenerator.getRandomUnsignedByteImg(dim3);
+
+		double[] offset = new double[] { 0.0, 0.0 };
+		double[] radii = new double[] { 20, 40 };
+		ellipse = dataGenerator.getEllipsedBitImage(dim, radii, offset);
+
+		// translate and rotate ellipse
+		offset = new double[] { 10.0, -10.0 };
+		radii = new double[] { 40, 20 };
+		rotatedEllipse = dataGenerator.getEllipsedBitImage(dim, radii, offset);
+	}
+
+	@Override
+	protected Context createContext() {
+		return new Context(OpService.class);
+	}
+
+	/**
+	 * 
+	 * Simple class to generate empty, randomly filled or constantly filled
+	 * images of various types.
+	 * 
+	 * @author Daniel Seebacher, University of Konstanz.
+	 * @author Andreas Graumann, University of Konstanz
+	 */
+	class ImageGenerator {
+
+		private Random rand;
+
+		/**
+		 * Create the image generator with a predefined seed.
+		 * 
+		 * @param seed
+		 *            a seed which is used by the random generator.
+		 */
+		public ImageGenerator(long seed) {
+			this.rand = new Random(seed);
+		}
+
+		/**
+		 * Default constructor, initialize with random seed.
+		 */
+		public ImageGenerator() {
+			this.rand = new Random();
+		}
+
+		/**
+		 * 
+		 * @param dim
+		 *            a long array with the desired dimensions of the image
+		 * @return an empty {@link Img} of {@link UnsignedByteType}.
+		 */
+		public Img<UnsignedByteType> getEmptyUnsignedByteImg(long[] dim) {
+			return ArrayImgs.unsignedBytes(dim);
+		}
+
+		/**
+		 * 
+		 * @param dim
+		 *            a long array with the desired dimensions of the image
+		 * @return an {@link Img} of {@link UnsignedByteType} filled with random
+		 *         values.
+		 */
+		public Img<UnsignedByteType> getRandomUnsignedByteImg(long[] dim) {
+			ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(dim);
+
+			UnsignedByteType type = img.firstElement();
+
+			ArrayCursor<UnsignedByteType> cursor = img.cursor();
+			while (cursor.hasNext()) {
+				cursor.next().set(rand.nextInt((int) type.getMaxValue()));
+			}
+
+			return (Img<UnsignedByteType>) img;
+		}
+
+		/**
+		 * 
+		 * @param dim
+		 *            a long array with the desired dimensions of the image
+		 * @return an {@link Img} of {@link UnsignedByteType} filled with a
+		 *         constant value.
+		 */
+		public Img<UnsignedByteType> getConstantUnsignedByteImg(long[] dim, int constant) {
+			ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(dim);
+
+			UnsignedByteType type = img.firstElement();
+			if (constant < type.getMinValue() || constant >= type.getMaxValue()) {
+				throw new IllegalArgumentException("Can't create image for constant [" + constant + "]");
+			}
+
+			ArrayCursor<UnsignedByteType> cursor = img.cursor();
+			while (cursor.hasNext()) {
+				cursor.next().set(constant);
+			}
+
+			return (Img<UnsignedByteType>) img;
+		}
+
+		/**
+		 * 
+		 * @param dim
+		 * @param radii
+		 * @return an {@link Img} of {@link BitType} filled with a ellipse
+		 */
+		public Img<UnsignedByteType> getEllipsedBitImage(long[] dim, double[] radii, double[] offset) {
+
+			// create empty bittype image with desired dimensions
+			ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(dim);
+
+			// create ellipse
+			EllipseRegionOfInterest ellipse = new EllipseRegionOfInterest();
+			ellipse.setRadii(radii);
+
+			// set origin in the center of image
+			double[] origin = new double[dim.length];
+			for (int i = 0; i < dim.length; i++)
+				origin[i] = dim[i] / 2;
+			ellipse.setOrigin(origin);
+
+			// get iterable intervall and cursor of ellipse
+			IterableInterval<UnsignedByteType> ii = ellipse.getIterableIntervalOverROI(img);
+			Cursor<UnsignedByteType> cursor = ii.cursor();
+
+			// fill image with ellipse
+			while (cursor.hasNext()) {
+				cursor.next();
+				cursor.get().set(255);
+			}
+
+			return (Img<UnsignedByteType>) img;
+		}
+	}
+
+	protected LabelRegion<?> createLabelRegion2D() throws MalformedURLException, IOException {
+		// read simple polygon image
+		BufferedImage read = ImageIO.read(AbstractFeatureTest.class.getResourceAsStream("cZgkFsK.png"));
+
+		ImgLabeling<String, IntType> img = new ImgLabeling<String, IntType>(
+				ArrayImgs.ints(read.getWidth(), read.getHeight()));
+
+		// at each black pixel of the polygon add a "1" label.
+		RandomAccess<LabelingType<String>> randomAccess = img.randomAccess();
+		for (int y = 0; y < read.getHeight(); y++) {
+			for (int x = 0; x < read.getWidth(); x++) {
+				randomAccess.setPosition(new int[] { x, y });
+				Color c = new Color(read.getRGB(x, y));
+				if (c.getRed() == Color.black.getRed()) {
+					randomAccess.get().add("1");
+				}
+			}
+		}
+
+		LabelRegions<String> labelRegions = new LabelRegions<String>(img);
+		return labelRegions.getLabelRegion("1");
+
+	}
+
+	protected LabelRegion<?> createLabelRegion3D() throws MalformedURLException, IOException {
+
+		Opener o = new Opener();
+		ImagePlus imp = o.openImage("/home/tibuch/Shape3D.tif");
+
+		ImgLabeling<String, IntType> labeling = new ImgLabeling<String, IntType>(ArrayImgs.ints(100, 100, 100));
+
+		RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
+		Img<FloatType> img = ImageJFunctions.convertFloat(imp);
+		Cursor<FloatType> c = img.cursor();
+		while (c.hasNext()) {
+			FloatType item = c.next();
+			int[] pos = new int[3];
+			c.localize(pos);
+			ra.setPosition(pos);
+			if (item.get() > 0) {
+				ra.get().add("1");
+			}
+		}
+		LabelRegions<String> labelRegions = new LabelRegions<String>(labeling);
+
+		return labelRegions.getLabelRegion("1");
+
+	}
+}

--- a/src/test/java/net/imagej/ops/features/haralick/HaralickNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/features/haralick/HaralickNamespaceTest.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.haralick;
+
+import net.imagej.ops.AbstractNamespaceTest;
+
+import org.junit.Test;
+
+/**
+ * Tests the {@link HaralickNamespace}
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public class HaralickNamespaceTest extends AbstractNamespaceTest {
+	/**
+	 * Tests that the ops of the math namespace have corresponding type-safe
+	 * Java method signatures declared in the {@link HaralickNamespace} class.
+	 */
+	@Test
+	public void testCompleteness() {
+		assertComplete("haralick", HaralickNamespace.class);
+	}
+
+}

--- a/src/test/templates/net/imagej/ops/features/haralick/HaralickFeaturesTest.list
+++ b/src/test/templates/net/imagej/ops/features/haralick/HaralickFeaturesTest.list
@@ -1,0 +1,22 @@
+[HaralickFeaturesTest.java]
+ops	=	```
+[
+	[iface: "ASM",					label: "asm",				empty2d: 1.0,					random2d: 0.020156637077849197,		constant2d: 1.0,					empty3d: 1.0,					random3d: 0.02009638381678881,		constant3d: 1.0],
+	[iface: "ClusterPromenence",	label: "clusterpromenence",	empty2d: 0.0,					random2d: 156.43714126689318,		constant2d: 0.0,					empty3d: 0.0,					random3d: 156.05081146855233,		constant3d: 0.0],
+	[iface: "Contrast",				label: "contrast",			empty2d: 0.0,					random2d: 8.272626262626263,		constant2d: 0.0,					empty3d: 0.0,					random3d: 8.132981539533265,		constant3d: 0.0],
+	[iface: "ClusterShade",			label: "clustershade",		empty2d: 0.0,					random2d: 0.3306676545456644,		constant2d: 0.0,					empty3d: 0.0,					random3d: 0.048357707174167326,		constant3d: 0.0],
+	[iface: "Correlation",			label: "correlation",		empty2d: 0.0,					random2d: -0.0030307841707376422,	constant2d: 0.0,					empty3d: 0.0,					random3d:-	7.670780437882068E-4,	constant3d: 0.0],
+	[iface: "DifferenceEntropy",	label: "differenceentropy",	empty2d: 0.0,					random2d: 1.8476756084894421,		constant2d: 0.0,					empty3d: 0.0,					random3d: 1.8458725093917443,		constant3d: 0.0],
+	[iface: "DifferenceVariance",	label: "differencevariance",empty2d: 0.0,					random2d: 0.0,						constant2d: 0.0,					empty3d: 0.0,					random3d: 0.0,						constant3d: 0.0],
+	[iface: "Entropy",				label: "entropy",			empty2d: 0.0,					random2d: 1.7061673583045558,		constant2d: 0.0,					empty3d: 0.0,					random3d: 1.7059752468491929,		constant3d: 0.0],
+	[iface: "ICM1",					label: "icm1",				empty2d: -0.5657055180967482,	random2d: -1.13190278555301,		constant2d: -0.5657055180967482,	empty3d: -0.5657054958922876,	random3d: -1.1314266456516264,		constant3d: -0.5657054958922876],
+	[iface: "ICM2",					label: "icm2",				empty2d: 0.0,					random2d: 0.994143823300342,		constant2d: 0.0,					empty3d: 0.0,					random3d: 0.9941113078948867,		constant3d: 0.0],
+	[iface: "IFDM",					label: "ifdm",				empty2d: 0.0,					random2d: 0.4596948051948054,		constant2d: 0.0,					empty3d: 0.0,					random3d: 0.4542897115655735,		constant3d: 0.0],
+	[iface: "SumAverage",			label: "sumaverage",		empty2d: 2.0,					random2d: 8.044343434343435,		constant2d: 2.0,					empty3d: 2.0,					random3d: 8.009804946011842,		constant3d: 2.0],
+	[iface: "SumEntropy",			label: "sumentropy",		empty2d: -0.0,					random2d: 1.0574462007349505,		constant2d: 0,						empty3d: 0.0,					random3d: 1.058331669907167,		constant3d: 0.0],
+	[iface: "SumVariance",			label: "sumvariance",		empty2d: 0.0,					random2d: 8.07025588205285,			constant2d: 0.0,					empty3d: 0.0,					random3d: 8.082561473622349,		constant3d: 0.0],
+	[iface: "Variance",				label: "variance",			empty2d: 0.0,					random2d: 4.085721156004489,		constant2d: 0.0,					empty3d: 0.0,					random3d: 4.053886887109363,		constant3d: 0.0],
+	[iface: "MaxProbability",		label: "maxprobability",	empty2d: 1.0,					random2d: 0.023333333333333334,		constant2d: 1.0,					empty3d: 1.0,					random3d: 0.02127133402995472,		constant3d: 1.0],
+	[iface: "TextureHomogeneity",	label: "texturehomogeneity",empty2d: 1.0,					random2d: 0.41295262145262135,		constant2d: 1.0,					empty3d: 1.0,					random3d: 0.4164961105305933,		constant3d: 1.0]
+]
+```

--- a/src/test/templates/net/imagej/ops/features/haralick/HaralickFeaturesTest.vm
+++ b/src/test/templates/net/imagej/ops/features/haralick/HaralickFeaturesTest.vm
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.haralick;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import net.imagej.ops.OpRef;
+import net.imagej.ops.features.AbstractFeatureTest;
+import net.imagej.ops.image.cooccurrencematrix.MatrixOrientation2D;
+import net.imagej.ops.image.cooccurrencematrix.MatrixOrientation3D;
+import net.imglib2.type.numeric.real.DoubleType;
+
+/**
+ * Testing implementations of {@link HaralickFeature}
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+public class HaralickFeaturesTest extends AbstractFeatureTest {
+
+#foreach ($op in $ops)
+	@Test
+	public void test${op.iface}() {
+		// empty
+		assertEquals("${op.label} empty 2d", ${op.empty2d}, this.ops.haralick().${op.label}(this.empty, 8, 1,
+			MatrixOrientation2D.HORIZONTAL).get(), SMALL_DELTA);
+		assertEquals("${op.label} empty 3d", ${op.empty3d}, this.ops.haralick().${op.label}(this.empty3d, 8, 1,
+			MatrixOrientation3D.HORIZONTAL_DIAGONAL).get(), SMALL_DELTA);
+
+		// constant
+		assertEquals("${op.label} constant 2d", ${op.constant2d}, this.ops.haralick().${op.label}(this.constant,
+			8, 1, MatrixOrientation2D.HORIZONTAL).get(), SMALL_DELTA);
+		assertEquals("${op.label} constant 3d", ${op.constant3d}, this.ops.haralick().${op.label}(this.constant3d,
+			8, 1, MatrixOrientation3D.HORIZONTAL_DIAGONAL).get(), SMALL_DELTA);
+
+		// random
+		assertEquals("${op.label} random 2d", ${op.random2d}, this.ops.haralick().${op.label}(
+			this.random, 8, 1, MatrixOrientation2D.HORIZONTAL).get(), SMALL_DELTA);
+		assertEquals("${op.label} random 3d", ${op.random3d}, this.ops.haralick().${op.label}(
+			this.random3d, 8, 1, MatrixOrientation3D.HORIZONTAL_DIAGONAL).get(),
+			SMALL_DELTA);
+	}
+#end
+}


### PR DESCRIPTION
### NOT MEANT TO BE MERGED, YET ###

Missing:
* [ ] Quick review
* [ ] Question: Are "nested" namespaces supported?
* [ ] Add/Finalize test (since now only a test was added to demonstrate API usage)

@ctrueden I started implementing a much simpler version of features. To illustrate the idea I implemented the so called Haralick-Features. The main idea is: I cache the results of a `op.run(...)` within a special `FeatureOpService`. In the case of features, we don't even need a very smart cache, as the results of the computation have to fit in memory anyway. However, we can simply delete this `FeatureOpService` as soon as the `DefaultOpService` supports caching and nearly no code will change (besides the code e.g. in the `HaralickFeatureSet`, where we have to remove the `FeatureOpService`). Like this I was also able to provide a very nice API in the `HaralickNamespace` such that features can be calculated individually. Again, as soon as `OpService` supports caching, even the evaluation of these features will be smart and redundant computations are avoided implicitly. 

Does this make sense? If you like the idea/workaround I will add _all_ other features as soon as possible!

Christian