### PR TITLE
add image moments.

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -42,6 +42,7 @@ import net.imagej.ops.create.CreateNamespace;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
 import net.imagej.ops.filter.FilterNamespace;
 import net.imagej.ops.image.ImageNamespace;
+import net.imagej.ops.imagemoments.ImageMomentsNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
 import net.imagej.ops.math.MathNamespace;
@@ -584,6 +585,11 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 		return namespace(StatsNamespace.class);
 	}
 
+	@Override
+	public ImageMomentsNamespace imagemoments() {
+		return namespace(ImageMomentsNamespace.class);
+	}
+	
 	@Override
 	public ThreadNamespace thread() {
 		return namespace(ThreadNamespace.class);

--- a/src/main/java/net/imagej/ops/OpService.java
+++ b/src/main/java/net/imagej/ops/OpService.java
@@ -40,6 +40,7 @@ import net.imagej.ops.create.CreateNamespace;
 import net.imagej.ops.deconvolve.DeconvolveNamespace;
 import net.imagej.ops.filter.FilterNamespace;
 import net.imagej.ops.image.ImageNamespace;
+import net.imagej.ops.imagemoments.ImageMomentsNamespace;
 import net.imagej.ops.labeling.LabelingNamespace;
 import net.imagej.ops.logic.LogicNamespace;
 import net.imagej.ops.math.MathNamespace;
@@ -397,6 +398,9 @@ public interface OpService extends PTService<Op>, ImageJService {
 
 	/** Gateway into ops of the "stats" namespace. */
 	StatsNamespace stats();
+	
+	/** Gateway into ops of the "image moments" namespace. */
+	ImageMomentsNamespace imagemoments();
 
 	/** Gateway into ops of the "thread" namespace. */
 	ThreadNamespace thread();

--- a/src/main/java/net/imagej/ops/imagemoments/AbstractImageMomentOp.java
+++ b/src/main/java/net/imagej/ops/imagemoments/AbstractImageMomentOp.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+
+import net.imagej.ops.AbstractHybridOp;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.OpService;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+/**
+ * Abstract {@link ImageMomentOp}. Provides {@link OpService} and create the
+ * output.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+public abstract class AbstractImageMomentOp<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractHybridOp<IterableInterval<I>, O> implements
+	ImageMomentOp<IterableInterval<I>, O>, Contingent
+{
+
+	@Parameter(type = ItemIO.INPUT)
+	protected OpService ops;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public O createOutput(IterableInterval<I> input) {
+		return (O) new DoubleType();
+	}
+
+	@Override
+	public boolean conforms() {
+		return 2 == getInput().numDimensions();
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/ImageMomentOp.java
+++ b/src/main/java/net/imagej/ops/imagemoments/ImageMomentOp.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments;
+
+import net.imagej.ops.HybridOp;
+
+/**
+ * marker interface for image moment ops.
+ *
+ * @author Daniel Seebacher, University of Konstanz
+ */
+public interface ImageMomentOp<I, O> extends HybridOp<I, O> {
+	// NB: marker interface
+}

--- a/src/main/java/net/imagej/ops/imagemoments/ImageMomentsNamespace.java
+++ b/src/main/java/net/imagej/ops/imagemoments/ImageMomentsNamespace.java
@@ -1,0 +1,734 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.Namespace;
+import net.imagej.ops.OpMethod;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * The image moments namespace contains ops related to image moments.
+ *
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+@SuppressWarnings("unchecked")
+@Plugin(type = Namespace.class)
+public class ImageMomentsNamespace extends AbstractNamespace {
+
+	@OpMethod(ops = {
+		net.imagej.ops.imagemoments.centralmoments.IterableCentralMoment00.class,
+		net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment00.class })
+	public <I extends RealType<I>, O extends RealType<O>> O centralMoment00(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.CentralMoment00.class, in);
+		return result;
+	}
+
+	@OpMethod(ops = {
+		net.imagej.ops.imagemoments.centralmoments.IterableCentralMoment00.class,
+		net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment00.class })
+	public <I extends RealType<I>, O extends RealType<O>> O centralMoment00(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.CentralMoment00.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment01.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment01(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment01.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment01.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment01(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment01.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment02.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment02(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment02.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment02.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment02(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment02.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment03.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment03(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment03.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment03.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment03(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment03.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment10.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment10(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment10.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment10.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment10(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment10.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(ops = {
+		net.imagej.ops.imagemoments.centralmoments.IterableCentralMoment11.class,
+		net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment11.class })
+	public <I extends RealType<I>, O extends RealType<O>> O centralMoment11(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.CentralMoment11.class, in);
+		return result;
+	}
+
+	@OpMethod(ops = {
+		net.imagej.ops.imagemoments.centralmoments.IterableCentralMoment11.class,
+		net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment11.class })
+	public <I extends RealType<I>, O extends RealType<O>> O centralMoment11(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.CentralMoment11.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment12.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment12(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment12.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment12.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment12(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment12.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment20.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment20(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment20.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment20.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment20(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment20.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment21.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment21(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment21.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment21.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment21(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment21.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment30.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment30(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment30.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment30.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O centralMoment30(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment30.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment00.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment00(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment00.class,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment00.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment00(final O out,
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment00.class,
+				out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment01.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment01(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment01.class,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment01.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment01(final O out,
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment01.class,
+				out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment10.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment10(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment10.class,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment10.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment10(final O out,
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment10.class,
+				out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment11.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment11(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment11.class,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.moments.DefaultMoment11.class)
+	public <I extends RealType<I>, O extends RealType<O>> O moment11(final O out,
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment11.class,
+				out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment02(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment02(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment03(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment03(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment11(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment11(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment12(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment12(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment20(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment20(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment21(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment21(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment30(
+			final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30.class,
+					in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30.class)
+	public
+		<I extends RealType<I>, O extends RealType<O>> O normalizedCentralMoment30(
+			final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops()
+				.run(
+					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30.class,
+					out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment1.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment1(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment1.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment1.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment1(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment1.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment2.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment2(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment2.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment2.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment2(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment2.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment3.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment3(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment3.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment3.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment3(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment3.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment4.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment4(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment4.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment4.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment4(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment4.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment5.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment5(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment5.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment5.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment5(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment5.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment6.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment6(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment6.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment6.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment6(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment6.class, out,
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment7.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment7(
+		final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment7.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.imagemoments.hu.DefaultHuMoment7.class)
+	public <I extends RealType<I>, O extends RealType<O>> O huMoment7(
+		final O out, final IterableInterval<I> in)
+	{
+		final O result =
+			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment7.class, out,
+				in);
+		return result;
+	}
+
+	// -- Named methods --
+	@Override
+	public String getName() {
+		return "imagemoments";
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment00.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment00.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment00;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment00}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment00.NAME,
+	label = "Image Moment: CentralMoment00")
+public class DefaultCentralMoment00<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment00
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		output.setReal(ops.imagemoments().moment00(input).getRealDouble());
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment01.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment01.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment01;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment01} directly.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment01.NAME,
+	label = "Image Moment: CentralMoment01", priority = Priority.FIRST_PRIORITY)
+public class DefaultCentralMoment01<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment01
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		output.setReal(0d);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment02.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment02.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment02;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment02}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment02.NAME,
+	label = "Image Moment: CentralMoment02")
+public class DefaultCentralMoment02<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment02
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment01 = ops.imagemoments().moment01(input).getRealDouble();
+		final double centerY = moment01 / moment00;
+
+		double centralmoment02 = 0;
+
+		final Cursor<I> it = input.localizingCursor();
+		while (it.hasNext()) {
+			it.fwd();
+			final double y = it.getDoublePosition(1) - centerY;
+			final double val = it.get().getRealDouble();
+
+			centralmoment02 += val * y * y;
+		}
+
+		output.setReal(centralmoment02);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment03.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment03.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment03;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment03} using
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment03.NAME,
+	label = "Image Moment: CentralMoment03")
+public class DefaultCentralMoment03<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment03
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment01 = ops.imagemoments().moment01(input).getRealDouble();
+		final double centerY = moment01 / moment00;
+
+		double centralmoment03 = 0;
+
+		final Cursor<I> it = input.localizingCursor();
+		while (it.hasNext()) {
+			it.fwd();
+			final double y = it.getDoublePosition(1) - centerY;
+			final double val = it.get().getRealDouble();
+
+			centralmoment03 += val * y * y * y;
+		}
+
+		output.setReal(centralmoment03);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment10.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment10.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment10;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment10} directly.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment10.NAME,
+	label = "Image Moment: CentralMoment10", priority = Priority.FIRST_PRIORITY)
+public class DefaultCentralMoment10<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment10
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		output.setReal(0d);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment11.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment11.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment11;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment11}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment11.NAME,
+	label = "Image Moment: CentralMoment11")
+public class DefaultCentralMoment11<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment11
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment01 = ops.imagemoments().moment01(input).getRealDouble();
+		final double moment10 = ops.imagemoments().moment10(input).getRealDouble();
+		final double moment11 = ops.imagemoments().moment11(input).getRealDouble();
+
+		final double centerX = moment10 / moment00;
+
+		output.setReal(moment11 - (centerX * moment01));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment12.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment12.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment12;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment12}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment12.NAME,
+	label = "Image Moment: CentralMoment12")
+public class DefaultCentralMoment12<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment12
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment01 = ops.imagemoments().moment01(input).getRealDouble();
+		final double moment10 = ops.imagemoments().moment10(input).getRealDouble();
+		final double centerX = moment10 / moment00;
+		final double centerY = moment01 / moment00;
+
+		double centralmoment12 = 0;
+
+		final Cursor<I> it = input.localizingCursor();
+		while (it.hasNext()) {
+			it.fwd();
+			final double x = it.getDoublePosition(0) - centerX;
+			final double y = it.getDoublePosition(1) - centerY;
+			final double val = it.get().getRealDouble();
+
+			centralmoment12 += val * x * y * y;
+		}
+
+		output.setReal(centralmoment12);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment20.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment20.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment20;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment20}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment20.NAME,
+	label = "Image Moment: CentralMoment20")
+public class DefaultCentralMoment20<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment20
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment10 = ops.imagemoments().moment10(input).getRealDouble();
+		final double centerX = moment10 / moment00;
+
+		double centralmoment20 = 0;
+
+		final Cursor<I> it = input.localizingCursor();
+		while (it.hasNext()) {
+			it.fwd();
+			final double x = it.getDoublePosition(0) - centerX;
+			final double val = it.get().getRealDouble();
+
+			centralmoment20 += val * x * x;
+		}
+
+		output.setReal(centralmoment20);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment21.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment21.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment21;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment21}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment21.NAME,
+	label = "Image Moment: CentralMoment21")
+public class DefaultCentralMoment21<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment21
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment01 = ops.imagemoments().moment01(input).getRealDouble();
+		final double moment10 = ops.imagemoments().moment10(input).getRealDouble();
+		final double centerX = moment10 / moment00;
+		final double centerY = moment01 / moment00;
+
+		double centralmoment21 = 0;
+
+		final Cursor<I> it = input.localizingCursor();
+		while (it.hasNext()) {
+			it.fwd();
+			final double x = it.getDoublePosition(0) - centerX;
+			final double y = it.getDoublePosition(1) - centerY;
+			final double val = it.get().getRealDouble();
+
+			centralmoment21 += val * x * x * y;
+		}
+
+		output.setReal(centralmoment21);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment30.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/DefaultCentralMoment30.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment30;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment30}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment30.NAME,
+	label = "Image Moment: CentralMoment30")
+public class DefaultCentralMoment30<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment30
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		final double moment00 = ops.imagemoments().moment00(input).getRealDouble();
+		final double moment10 = ops.imagemoments().moment10(input).getRealDouble();
+		final double centerX = moment10 / moment00;
+
+		double centralmoment30 = 0;
+
+		final Cursor<I> it = input.localizingCursor();
+		while (it.hasNext()) {
+			it.fwd();
+			final double x = it.getDoublePosition(0) - centerX;
+			final double val = it.get().getRealDouble();
+
+			centralmoment30 += val * x * x * x;
+		}
+
+		output.setReal(centralmoment30);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/IterableCentralMoment00.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/IterableCentralMoment00.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment00;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment00} directly.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment00.NAME,
+	label = "Image Moment: CentralMoment00", priority = Priority.FIRST_PRIORITY)
+public class IterableCentralMoment00<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment00
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+
+		double moment00 = 0;
+
+		Cursor<I> cur = input.localizingCursor();
+		while (cur.hasNext()) {
+			cur.fwd();
+			double val = cur.get().getRealDouble();
+			moment00 += val;
+		}
+
+		output.setReal(moment00);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/centralmoments/IterableCentralMoment11.java
+++ b/src/main/java/net/imagej/ops/imagemoments/centralmoments/IterableCentralMoment11.java
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.centralmoments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment11;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link CentralMoment11} directly.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = CentralMoment11.NAME,
+	label = "Image Moment: CentralMoment11", priority = Priority.FIRST_PRIORITY)
+public class IterableCentralMoment11<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements CentralMoment11
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double moment00 = 0d;
+		double moment01 = 0d;
+		double moment10 = 0d;
+		double moment11 = 0d;
+
+		Cursor<I> cursor = input.localizingCursor();
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			final double x = cursor.getDoublePosition(0);
+			final double y = cursor.getDoublePosition(1);
+			final double val = cursor.get().getRealDouble();
+
+			moment00 += val;
+			moment01 += y * val;
+			moment10 += x * val;
+			moment11 += x * y * val;
+		}
+
+		double centerx = moment10 / moment00;
+		output.setReal(moment11 - (centerx * moment01));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment1.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment1.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment1;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment1}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment1.NAME,
+	label = "Image Moment: HuMoment1")
+public class DefaultHuMoment1<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment1
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double n20 =
+			ops.imagemoments().normalizedCentralMoment20(input).getRealDouble();
+		double n02 =
+			ops.imagemoments().normalizedCentralMoment02(input).getRealDouble();
+
+		output.setReal(n20 + n02);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment2.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment2.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment2;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment2}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment2.NAME,
+	label = "Image Moment: HuMoment2")
+public class DefaultHuMoment2<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment2
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+
+		double n11 =
+			ops.imagemoments().normalizedCentralMoment11(input).getRealDouble();
+		double n20 =
+			ops.imagemoments().normalizedCentralMoment20(input).getRealDouble();
+		double n02 =
+			ops.imagemoments().normalizedCentralMoment02(input).getRealDouble();
+
+		output.setReal(Math.pow(n20 - n02, 2) - 4 * (Math.pow(n11, 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment3.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment3.java
@@ -1,0 +1,69 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment3;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment3}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment3.NAME,
+	label = "Image Moment: HuMoment3")
+public class DefaultHuMoment3<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment3
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double n30 =
+			ops.imagemoments().normalizedCentralMoment30(input).getRealDouble();
+		double n12 =
+			ops.imagemoments().normalizedCentralMoment12(input).getRealDouble();
+		double n21 =
+			ops.imagemoments().normalizedCentralMoment21(input).getRealDouble();
+		double n03 =
+			ops.imagemoments().normalizedCentralMoment03(input).getRealDouble();
+
+		output.setReal(Math.pow(n30 - 3 * n12, 2) + Math.pow(3 * n21 - n03, 2));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment4.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment4.java
@@ -1,0 +1,69 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment4;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment4}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment4.NAME,
+	label = "Image Moment: HuMoment4")
+public class DefaultHuMoment4<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment4
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double n30 =
+			ops.imagemoments().normalizedCentralMoment30(input).getRealDouble();
+		double n12 =
+			ops.imagemoments().normalizedCentralMoment12(input).getRealDouble();
+		double n21 =
+			ops.imagemoments().normalizedCentralMoment21(input).getRealDouble();
+		double n03 =
+			ops.imagemoments().normalizedCentralMoment03(input).getRealDouble();
+
+		output.setReal(Math.pow(n30 + n12, 2) + Math.pow(n21 + n03, 2));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment5.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment5.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment5;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment5}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment5.NAME,
+	label = "Image Moment: HuMoment5")
+public class DefaultHuMoment5<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment5
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double n03 =
+			ops.imagemoments().normalizedCentralMoment03(input).getRealDouble();
+		double n12 =
+			ops.imagemoments().normalizedCentralMoment12(input).getRealDouble();
+		double n21 =
+			ops.imagemoments().normalizedCentralMoment21(input).getRealDouble();
+		double n30 =
+			ops.imagemoments().normalizedCentralMoment30(input).getRealDouble();
+
+		output.setReal((n30 - 3 * n12) * (n30 + n12) *
+			(Math.pow(n30 + n12, 2) - 3 * Math.pow(n21 + n03, 2)) + (3 * n21 - n03) *
+			(n21 + n03) * (3 * Math.pow(n30 + n12, 2) - Math.pow(n21 + n03, 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment6.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment6.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment6;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment6}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment6.NAME,
+	label = "Image Moment: HuMoment6")
+public class DefaultHuMoment6<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment6
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double n02 =
+			ops.imagemoments().normalizedCentralMoment02(input).getRealDouble();
+		double n03 =
+			ops.imagemoments().normalizedCentralMoment03(input).getRealDouble();
+		double n11 =
+			ops.imagemoments().normalizedCentralMoment11(input).getRealDouble();
+		double n12 =
+			ops.imagemoments().normalizedCentralMoment12(input).getRealDouble();
+		double n20 =
+			ops.imagemoments().normalizedCentralMoment20(input).getRealDouble();
+		double n21 =
+			ops.imagemoments().normalizedCentralMoment21(input).getRealDouble();
+		double n30 =
+			ops.imagemoments().normalizedCentralMoment30(input).getRealDouble();
+
+		output.setReal((n20 - n02) *
+			(Math.pow(n30 + n12, 2) - Math.pow(n21 + n03, 2)) + 4 * n11 *
+			(n30 + n12) * (n21 + n03));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment7.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment7.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.hu;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.HuMoment7;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link HuMoment7}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = HuMoment7.NAME,
+	label = "Image Moment: HuMoment7")
+public class DefaultHuMoment7<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements HuMoment7
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double n03 =
+			ops.imagemoments().normalizedCentralMoment03(input).getRealDouble();
+		double n12 =
+			ops.imagemoments().normalizedCentralMoment12(input).getRealDouble();
+		double n21 =
+			ops.imagemoments().normalizedCentralMoment21(input).getRealDouble();
+		double n30 =
+			ops.imagemoments().normalizedCentralMoment30(input).getRealDouble();
+
+		output.setReal((3 * n21 - n03) * (n30 + n12) *
+			(Math.pow(n30 + n12, 2) - 3 * Math.pow(n21 + n03, 2)) - (n30 - 3 * n12) *
+			(n21 + n03) * (3 * Math.pow(n30 + n12, 2) - Math.pow(n21 + n03, 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment00.java
+++ b/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment00.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.moments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.Moment00;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link Moment00}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = Moment00.NAME,
+	label = "Image Moment: Moment00", priority = Priority.FIRST_PRIORITY)
+public class DefaultMoment00<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements Moment00
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+
+		double moment00 = 0;
+
+		Cursor<I> cur = input.localizingCursor();
+		while (cur.hasNext()) {
+			cur.fwd();
+			double val = cur.get().getRealDouble();
+			moment00 += val;
+		}
+
+		output.setReal(moment00);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment01.java
+++ b/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment01.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.moments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.Moment01;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link Moment01}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = Moment01.NAME,
+	label = "Image Moment: Moment01", priority = Priority.FIRST_PRIORITY)
+public class DefaultMoment01<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements Moment01
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+
+		double moment01 = 0;
+
+		Cursor<I> cur = input.localizingCursor();
+		while (cur.hasNext()) {
+			cur.fwd();
+			double y = cur.getDoublePosition(1);
+			double val = cur.get().getRealDouble();
+			moment01 += y * val;
+		}
+
+		output.setReal(moment01);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment10.java
+++ b/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment10.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.moments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.Moment10;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link Moment10}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = Moment10.NAME,
+	label = "Image Moment: Moment10", priority = Priority.FIRST_PRIORITY)
+public class DefaultMoment10<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements Moment10
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+
+		double moment10 = 0;
+
+		Cursor<I> cur = input.localizingCursor();
+		while (cur.hasNext()) {
+			cur.fwd();
+			double x = cur.getDoublePosition(0);
+			double val = cur.get().getRealDouble();
+			moment10 += x * val;
+		}
+
+		output.setReal(moment10);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment11.java
+++ b/src/main/java/net/imagej/ops/imagemoments/moments/DefaultMoment11.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.moments;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.Moment11;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link Moment11}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = Moment11.NAME,
+	label = "Image Moment: Moment11", priority = Priority.FIRST_PRIORITY)
+public class DefaultMoment11<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements Moment11
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+
+		double moment11 = 0;
+
+		Cursor<I> cur = input.localizingCursor();
+		while (cur.hasNext()) {
+			cur.fwd();
+			double x = cur.getDoublePosition(0);
+			double y = cur.getDoublePosition(1);
+			double val = cur.get().getRealDouble();
+			moment11 += x * y * val;
+		}
+
+		output.setReal(moment11);
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment02;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment02}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment02.NAME,
+	label = "Image Moment: NormalizedCentralMoment02")
+public class DefaultNormalizedCentralMoment02<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment02
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment02 =
+			ops.imagemoments().centralMoment02(input).getRealDouble();
+
+		output.setReal(centralMoment02 /
+			Math.pow(centralMoment00, 1 + ((0 + 2) / 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment03;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment03}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment03.NAME,
+	label = "Image Moment: NormalizedCentralMoment03")
+public class DefaultNormalizedCentralMoment03<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment03
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment03 =
+			ops.imagemoments().centralMoment03(input).getRealDouble();
+
+		output.setReal(centralMoment03 /
+			Math.pow(centralMoment00, 1 + ((0 + 3) / 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment11;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment11}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment11.NAME,
+	label = "Image Moment: NormalizedCentralMoment11")
+public class DefaultNormalizedCentralMoment11<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment11
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment11 =
+			ops.imagemoments().centralMoment11(input).getRealDouble();
+
+		output.setReal(centralMoment11 /
+			Math.pow(centralMoment00, 1 + ((1 + 1) / 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment12;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment12}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment12.NAME,
+	label = "Image Moment: NormalizedCentralMoment12")
+public class DefaultNormalizedCentralMoment12<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment12
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment12 =
+			ops.imagemoments().centralMoment12(input).getRealDouble();
+
+		output.setReal(centralMoment12 /
+			Math.pow(centralMoment00, 1 + ((1 + 2) / 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment20;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment20}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment20.NAME,
+	label = "Image Moment: NormalizedCentralMoment20")
+public class DefaultNormalizedCentralMoment20<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment20
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment20 =
+			ops.imagemoments().centralMoment20(input).getRealDouble();
+
+		output.setReal(centralMoment20 /
+			Math.pow(centralMoment00, 1 + ((2 + 0) / 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment21;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment21}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment21.NAME,
+	label = "Image Moment: NormalizedCentralMoment21")
+public class DefaultNormalizedCentralMoment21<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment21
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment21 =
+			ops.imagemoments().centralMoment21(input).getRealDouble();
+
+		output.setReal(centralMoment21 /
+			Math.pow(centralMoment00, 1 + ((2 + 1) / 2)));
+	}
+}

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments.normalizedcentralmoments;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment30;
+import net.imagej.ops.imagemoments.AbstractImageMomentOp;
+import net.imagej.ops.imagemoments.ImageMomentOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link Op} to calculate the {@link NormalizedCentralMoment30}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = ImageMomentOp.class, name = NormalizedCentralMoment30.NAME,
+	label = "Image Moment: NormalizedCentralMoment30")
+public class DefaultNormalizedCentralMoment30<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractImageMomentOp<I, O> implements NormalizedCentralMoment30
+{
+
+	@Override
+	public void compute(final IterableInterval<I> input, final O output) {
+		double centralMoment00 =
+			ops.imagemoments().centralMoment00(input).getRealDouble();
+		double centralMoment30 =
+			ops.imagemoments().centralMoment30(input).getRealDouble();
+
+		output.setReal(centralMoment30 /
+			Math.pow(centralMoment00, 1 + ((3 + 0) / 2)));
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -179,6 +179,36 @@ namespaces = ```
 		[name: "shanbhag",         iface: "Shanbhag"],
 		[name: "triangle",         iface: "Triangle"],
 		[name: "yen",              iface: "Yen"]
+	]],
+	[name: "imagemoments", iface: "ImageMoments", ops: [
+		[name: "moment00",	iface: "Moment00"],
+		[name: "moment01",	iface: "Moment01"],
+		[name: "moment10",	iface: "Moment10"],
+		[name: "moment11",	iface: "Moment11"],
+		[name: "centralMoment00",	iface: "CentralMoment00"],
+		[name: "centralMoment01",	iface: "CentralMoment01"],
+		[name: "centralMoment10",	iface: "CentralMoment10"],
+		[name: "centralMoment11",	iface: "CentralMoment11"],
+		[name: "centralMoment20",	iface: "CentralMoment20"],
+		[name: "centralMoment02",	iface: "CentralMoment02"],
+		[name: "centralMoment21",	iface: "CentralMoment21"],
+		[name: "centralMoment12",	iface: "CentralMoment12"],
+		[name: "centralMoment30",	iface: "CentralMoment30"],
+		[name: "centralMoment03",	iface: "CentralMoment03"],
+		[name: "normalizedCentralMoment11",	iface: "NormalizedCentralMoment11"],
+		[name: "normalizedCentralMoment20",	iface: "NormalizedCentralMoment20"],
+		[name: "normalizedCentralMoment02",	iface: "NormalizedCentralMoment02"],
+		[name: "normalizedCentralMoment21",	iface: "NormalizedCentralMoment21"],
+		[name: "normalizedCentralMoment12",	iface: "NormalizedCentralMoment12"],
+		[name: "normalizedCentralMoment30",	iface: "NormalizedCentralMoment30"],
+		[name: "normalizedCentralMoment03",	iface: "NormalizedCentralMoment03"],
+		[name: "huMoment1",	iface: "HuMoment1"],
+		[name: "huMoment2",	iface: "HuMoment2"],
+		[name: "huMoment3",	iface: "HuMoment3"],
+		[name: "huMoment4",	iface: "HuMoment4"],
+		[name: "huMoment5",	iface: "HuMoment5"],
+		[name: "huMoment6",	iface: "HuMoment6"],
+		[name: "huMoment7",	iface: "HuMoment7"]
 	]]
 ]
 ```

--- a/src/test/java/net/imagej/ops/imagemoments/ImageMomentsNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/imagemoments/ImageMomentsNamespaceTest.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments;
+
+import net.imagej.ops.AbstractNamespaceTest;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ImageMomentsNamespace}.
+ *
+ * @author Daniel Seebacher, University of Konstanz.
+ */
+public class ImageMomentsNamespaceTest extends AbstractNamespaceTest {
+
+	/**
+	 * Tests that the ops of the {@code stats} namespace have corresponding
+	 * type-safe Java method signatures declared in the
+	 * {@link ImageMomentsNamespace} class.
+	 */
+	@Test
+	public void testCompleteness() {
+		assertComplete("imagemoments", ImageMomentsNamespace.class);
+	}
+
+}

--- a/src/test/java/net/imagej/ops/imagemoments/ImageMomentsTest.java
+++ b/src/test/java/net/imagej/ops/imagemoments/ImageMomentsTest.java
@@ -1,0 +1,181 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.imagemoments;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Ops.ImageMoments;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment02;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment03;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment11;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment12;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment20;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment21;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment30;
+import net.imagej.ops.Ops.ImageMoments.HuMoment1;
+import net.imagej.ops.Ops.ImageMoments.HuMoment2;
+import net.imagej.ops.Ops.ImageMoments.HuMoment3;
+import net.imagej.ops.Ops.ImageMoments.HuMoment4;
+import net.imagej.ops.Ops.ImageMoments.HuMoment5;
+import net.imagej.ops.Ops.ImageMoments.HuMoment6;
+import net.imagej.ops.Ops.ImageMoments.HuMoment7;
+import net.imagej.ops.Ops.ImageMoments.Moment00;
+import net.imagej.ops.Ops.ImageMoments.Moment01;
+import net.imagej.ops.Ops.ImageMoments.Moment10;
+import net.imagej.ops.Ops.ImageMoments.Moment11;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment02;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment03;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment11;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment12;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment20;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment21;
+import net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment30;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+/**
+ * Tests {@link ImageMoments}.
+ * 
+ * @author Daniel Seebacher
+ */
+public class ImageMomentsTest extends AbstractOpTest {
+
+	private static Img<UnsignedByteType> img;
+
+	@BeforeClass
+	public static void createImg() {
+
+		Img<UnsignedByteType> tmp =
+			ArrayImgs.unsignedBytes(new long[] { 100, 100 });
+
+		Random rand = new Random(1234567890L);
+		final Cursor<UnsignedByteType> cursor = tmp.cursor();
+		while (cursor.hasNext()) {
+			cursor.next().set(rand.nextInt((int) tmp.firstElement().getMaxValue()));
+		}
+
+		img = tmp;
+	}
+
+	/**
+	 * Test the Moment Ops.
+	 */
+	@Test
+	public void testMoments() {
+
+		assertEquals(Moment00.NAME, 1277534.0, ops.imagemoments().moment00(img)
+			.getRealDouble(), 1e-3);
+		assertEquals(Moment10.NAME, 6.3018047E7, ops.imagemoments().moment10(img)
+			.getRealDouble(), 1e-3);
+		assertEquals(Moment01.NAME, 6.3535172E7, ops.imagemoments().moment01(img)
+			.getRealDouble(), 1e-3);
+		assertEquals(Moment11.NAME, 3.12877962E9, ops.imagemoments().moment11(img)
+			.getRealDouble(), 1e-3);
+	}
+
+	/**
+	 * Test the Central Moment Ops.
+	 */
+	@Test
+	public void testCentralMoments() {
+		assertEquals(CentralMoment11.NAME, -5275876.956702232, ops.imagemoments()
+			.centralMoment11(img).getRealDouble(), 1e-3);
+		assertEquals(CentralMoment02.NAME, 1.0694469880269928E9, ops.imagemoments()
+			.centralMoment02(img).getRealDouble(), 1e-3);
+		assertEquals(CentralMoment20.NAME, 1.0585772432642083E9, ops.imagemoments()
+			.centralMoment20(img).getRealDouble(), 1e-3);
+		assertEquals(CentralMoment12.NAME, 5478324.271270752, ops.imagemoments()
+			.centralMoment12(img).getRealDouble(), 1e-3);
+		assertEquals(CentralMoment21.NAME, -2.1636455685491943E8, ops
+			.imagemoments().centralMoment21(img).getRealDouble(), 1e-3);
+		assertEquals(CentralMoment30.NAME, 1.735560232991333E8, ops.imagemoments()
+			.centralMoment30(img).getRealDouble(), 1e-3);
+		assertEquals(CentralMoment03.NAME, -4.0994213161157227E8, ops
+			.imagemoments().centralMoment03(img).getRealDouble(), 1e-3);
+	}
+
+	/**
+	 * Test the Normalized Central Moment Ops.
+	 */
+	@Test
+	public void testNormalizedCentralMoments() {
+		assertEquals(NormalizedCentralMoment11.NAME, -3.2325832933879204E-6, ops
+			.imagemoments().normalizedCentralMoment11(img).getRealDouble(), 1e-3);
+
+		assertEquals(NormalizedCentralMoment02.NAME, 6.552610106398286E-4, ops
+			.imagemoments().normalizedCentralMoment02(img).getRealDouble(), 1e-3);
+
+		assertEquals(NormalizedCentralMoment20.NAME, 6.486010078361372E-4, ops
+			.imagemoments().normalizedCentralMoment20(img).getRealDouble(), 1e-3);
+
+		assertEquals(NormalizedCentralMoment12.NAME, 2.969727272701925E-9, ops
+			.imagemoments().normalizedCentralMoment12(img).getRealDouble(), 1e-3);
+
+		assertEquals(NormalizedCentralMoment21.NAME, -1.1728837022440002E-7, ops
+			.imagemoments().normalizedCentralMoment21(img).getRealDouble(), 1e-3);
+
+		assertEquals(NormalizedCentralMoment30.NAME, 9.408242926327751E-8, ops
+			.imagemoments().normalizedCentralMoment30(img).getRealDouble(), 1e-3);
+
+		assertEquals(NormalizedCentralMoment03.NAME, -2.22224218245127E-7, ops
+			.imagemoments().normalizedCentralMoment03(img).getRealDouble(), 1e-3);
+	}
+
+	/**
+	 * Test the Hu Moment Ops.
+	 */
+	@Test
+	public void testHuMoments() {
+		assertEquals(HuMoment1.NAME, 0.001303862018475966, ops.imagemoments()
+			.huMoment1(img).getRealDouble(), 1e-3);
+		assertEquals(HuMoment2.NAME, 8.615401633994056e-11, ops.imagemoments()
+			.huMoment2(img).getRealDouble(), 1e-3);
+		assertEquals(HuMoment3.NAME, 2.406124306990366e-14, ops.imagemoments()
+			.huMoment3(img).getRealDouble(), 1e-3);
+		assertEquals(HuMoment4.NAME, 1.246879188175627e-13, ops.imagemoments()
+			.huMoment4(img).getRealDouble(), 1e-3);
+		assertEquals(HuMoment5.NAME, -6.610443880647384e-27, ops.imagemoments()
+			.huMoment5(img).getRealDouble(), 1e-3);
+		assertEquals(HuMoment6.NAME, 1.131019166855569e-18, ops.imagemoments()
+			.huMoment6(img).getRealDouble(), 1e-3);
+		assertEquals(HuMoment7.NAME, 1.716256940536518e-27, ops.imagemoments()
+			.huMoment7(img).getRealDouble(), 1e-3);
+	}
+
+}


### PR DESCRIPTION
pretty big commit. image moments were added to Ops.list and the namespace was added to OpService and DefaultOpService.
the whole implementation is in the net.imagej.ops.imagemoments package and the tests are in the net.imagej.ops.imagemoments.ImageMomentsTest class.


@dietzc  do you mind taking a look? also could you format the imagemoments packages in src/main and src/test?