### PR TITLE
Refactor default create img

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Try this Jython script in ImageJ's
 
 # create a new blank image
 from jarray import array
+from net.imglib2.type.numeric.real import DoubleType
 dims = array([150, 100], 'l')
-blank = ij.op().create().img(dims)
+blank = ij.op().create().img(dims, DoubleType())
 
 # fill in the image with a sinusoid using a formula
 formula = "10 * (Math.cos(0.3*p[0]) + Math.sin(0.3*p[1]))"
@@ -58,10 +59,10 @@ sinusoid = ij.op().image().equation(blank, formula)
 ij.op().math().add(sinusoid, 13.0)
 
 # generate a gradient image using a formula
-gradient = ij.op().image().equation(ij.op().create().img(dims), "p[0]+p[1]")
+gradient = ij.op().image().equation(ij.op().create().img(dims, DoubleType()), "p[0]+p[1]")
 
 # add the two images
-composite = ij.op().create().img(dims)
+composite = ij.op().create().img(dims, DoubleType())
 ij.op().math().add(composite, sinusoid, gradient)
 
 # display the images

--- a/src/main/java/net/imagej/ops/create/AbstractCreateKernelImg.java
+++ b/src/main/java/net/imagej/ops/create/AbstractCreateKernelImg.java
@@ -67,18 +67,18 @@ abstract public class AbstractCreateKernelImg<V extends Type<V>, W extends Type<
 
 		// no factory and no type
 		if ((fac == null) && (outType == null)) {
-			output = (Img<V>) ops.create().img(dims, defaultType, defaultFactory);
+			output = (Img<V>) ops.create().img(dims, defaultFactory, defaultType);
 		}
 		// type but no factory
 		else if ((fac == null) && (outType != null)) {
-			output = (Img<V>) ops.create().img(dims, outType, defaultFactory);
+			output = (Img<V>) ops.create().img(dims, defaultFactory, outType);
 		}
 		// factory but no type
 		else if ((fac != null) && (outType == null)) {
 			output = (Img<V>) ops.create().img(dims, defaultType, fac);
 		}
 		else {
-			output = (Img<V>) ops.create().img(dims, outType, fac);
+			output = (Img<V>) ops.create().img(dims, fac, outType);
 		}
 
 	}

--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -30,13 +30,14 @@
 
 package net.imagej.ops.create;
 
+import org.scijava.plugin.Plugin;
+
 import net.imagej.ImgPlus;
 import net.imagej.ImgPlusMetadata;
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
-import net.imagej.ops.create.img.CreateImgFromInterval;
 import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.img.Img;
@@ -47,9 +48,6 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.IntegerType;
-
-import org.scijava.plugin.Plugin;
-import org.scijava.util.ArrayUtils;
 
 /**
  * The create namespace contains ops that create objects.
@@ -146,19 +144,6 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.create.imgFactory.DefaultCreateImgFactory.class)
-	public
-		<T extends NativeType<T>> ImgFactory<T> imgFactory(final Dimensions dims,
-			final T outType)
-	{
-		@SuppressWarnings("unchecked")
-		final ImgFactory<T> result =
-			(ImgFactory<T>) ops().run(
-				net.imagej.ops.create.imgFactory.DefaultCreateImgFactory.class, dims,
-				outType);
-		return result;
-	}
-
 	// -- imgLabeling --
 
 	@OpMethod(op = net.imagej.ops.Ops.Create.ImgLabeling.class)
@@ -169,68 +154,28 @@ public class CreateNamespace extends AbstractNamespace {
 	@OpMethod(
 		op = net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class)
 	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Dimensions dims)
+		final Dimensions dims, final T type)
 	{
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims);
+				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims, type);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class)
 	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Dimensions dims, final T outType)
+		final Dimensions dims, final ImgFactory<T> fac, final T outType)
 	{
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
 				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
-				outType);
+				fac, outType);
 		return result;
 	}
-
-	@OpMethod(
-		op = net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class)
-	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Dimensions dims, final T outType, final ImgFactory<T> fac)
-	{
-		@SuppressWarnings("unchecked")
-		final ImgLabeling<L, T> result =
-			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
-				outType, fac);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class)
-	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Dimensions dims, final T outType, final ImgFactory<T> fac,
-		final int maxNumLabelSets)
-	{
-		@SuppressWarnings("unchecked")
-		final ImgLabeling<L, T> result =
-			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
-				outType, fac, maxNumLabelSets);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
-	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Interval interval)
-	{
-		@SuppressWarnings("unchecked")
-		final ImgLabeling<L, T> result =
-			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
-				interval);
-		return result;
-	}
-
+	
 	@OpMethod(
 		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
 	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
@@ -243,33 +188,19 @@ public class CreateNamespace extends AbstractNamespace {
 				interval, outType);
 		return result;
 	}
-
+	
 	@OpMethod(
-		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
-	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Interval interval, final T outType, final ImgFactory<T> fac)
-	{
-		@SuppressWarnings("unchecked")
-		final ImgLabeling<L, T> result =
-			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
-				interval, outType, fac);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
-	public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
-		final Interval interval, final T outType, final ImgFactory<T> fac,
-		final int maxNumLabelSets)
-	{
-		@SuppressWarnings("unchecked")
-		final ImgLabeling<L, T> result =
-			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
-				interval, outType, fac, maxNumLabelSets);
-		return result;
-	}
+			op = net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class)
+		public <L, T extends IntegerType<T>> ImgLabeling<L, T> imgLabeling(
+			final Interval interval, final ImgFactory<T> fac, final T outType)
+		{
+			@SuppressWarnings("unchecked")
+			final ImgLabeling<L, T> result =
+				(ImgLabeling<L, T>) ops().run(
+					net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+					interval, fac, outType);
+			return result;
+		}
 
 	// -- imgPlus --
 

--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -36,6 +36,7 @@ import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
+import net.imagej.ops.create.img.CreateImgFromInterval;
 import net.imglib2.Dimensions;
 import net.imglib2.Interval;
 import net.imglib2.img.Img;
@@ -70,28 +71,6 @@ public class CreateNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Create.Img.class, args);
 	}
 
-	/**
-	 * Helper method for {@link #img(Object...)} to ensure {@code int} varargs are
-	 * not expanded. Necessary because a {@code Long[]} is also an
-	 * {@code Object[]}. See https://github.com/imagej/imagej-ops/pull/115
-	 */
-	public Object img(final Integer... dims) {
-		int[] ints = new int[dims.length];
-		for (int i=0; i<ints.length; i++) ints[i] = dims[i];
-		return img(ints);
-	}
-
-	/**
-	 * Helper method for {@link #img(Object...)} to ensure {@code long} varargs
-	 * are not expanded. Necessary because a {@code Long[]} is also an
-	 * {@code Object[]}. See https://github.com/imagej/imagej-ops/pull/115
-	 */
-	public Object img(final Long... dims) {
-		long[] longs = new long[dims.length];
-		for (int i=0; i<longs.length; i++) longs[i] = dims[i];
-		return img(longs);
-	}
-
 	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromImg.class)
 	public <T extends NativeType<T>> Img<T> img(final Img<T> input) {
 		@SuppressWarnings("unchecked")
@@ -100,49 +79,28 @@ public class CreateNamespace extends AbstractNamespace {
 				input);
 		return result;
 	}
-
+	
 	@OpMethod(op = net.imagej.ops.create.img.DefaultCreateImg.class)
-	public <T> Img<T> img(final Dimensions dims) {
+	public <T extends Type<T>> Img<T> img(final Dimensions dims,
+			final ImgFactory<T> fac, final T outType) {
+		@SuppressWarnings("unchecked")
+		final Img<T> result = (Img<T>) ops().run(
+				net.imagej.ops.create.img.DefaultCreateImg.class, dims,
+				fac, outType);
+		return result;
+	}
+	
+	@OpMethod(op = net.imagej.ops.create.img.DefaultCreateImg.class)
+	public <T extends Type<T>> Img<T> img(final Dimensions dims, final T type) {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
-			(Img<T>) ops()
-				.run(net.imagej.ops.create.img.DefaultCreateImg.class, dims);
+			(Img<T>) ops().run(net.imagej.ops.create.img.DefaultCreateImg.class, dims, type);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.create.img.DefaultCreateImg.class)
-	public <T> Img<T> img(final Dimensions dims, final T outType) {
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.img.DefaultCreateImg.class,
-				dims, outType);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.create.img.DefaultCreateImg.class)
-	public <T> Img<T> img(final Dimensions dims, final T outType,
-		final ImgFactory<T> fac)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.img.DefaultCreateImg.class,
-				dims, outType, fac);
-		return result;
-	}
 
 	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
-	public <T extends Type<T>> Img<T> img(final Interval interval) {
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
-				interval);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
-	public <T extends Type<T>> Img<T>
-		img(final Interval interval, final T outType)
-	{
+	public <T extends Type<T>> Img<T> img(final Interval interval, final T outType) {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
@@ -152,12 +110,12 @@ public class CreateNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.create.img.CreateImgFromInterval.class)
 	public <T extends Type<T>> Img<T> img(final Interval interval,
-		final T outType, final ImgFactory<T> fac)
+			final ImgFactory<T> fac, final T outType)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(net.imagej.ops.create.img.CreateImgFromInterval.class,
-				interval, outType, fac);
+				interval, fac, outType);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/create/img/CreateImgFromImg.java
+++ b/src/main/java/net/imagej/ops/create/img/CreateImgFromImg.java
@@ -30,17 +30,16 @@
 
 package net.imagej.ops.create.img;
 
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
 import net.imagej.ops.AbstractFunctionOp;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
-import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
 
 /**
  * Create an {@link Img} from another {@link Img} implementation using its
@@ -51,7 +50,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.Img.class, name = Ops.Create.Img.NAME,
 	priority = Priority.HIGH_PRIORITY)
-public class CreateImgFromImg<T extends NativeType<T>> extends
+public class CreateImgFromImg<T extends Type<T>> extends
 	AbstractFunctionOp<Img<T>, Img<T>> implements Ops.Create.Img
 {
 
@@ -61,7 +60,7 @@ public class CreateImgFromImg<T extends NativeType<T>> extends
 	@Override
 	public Img<T> compute(final Img<T> input) {
 		return ops.create().img(getInput(),
-			getInput().firstElement().createVariable(), getInput().factory());
+				getInput().factory(), getInput().firstElement().createVariable());
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/img/CreateImgFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/img/CreateImgFromInterval.java
@@ -69,15 +69,15 @@ public class CreateImgFromInterval<T extends Type<T>> implements
 	private Interval interval;
 
 	@Parameter(required = false)
-	private T outType;
-
-	@Parameter(required = false)
 	private ImgFactory<T> fac;
+
+	@Parameter
+	private T outType;
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public void run() {
-		output = (Img<T>) ops.run(DefaultCreateImg.class, interval, outType, fac);
+		output = (Img<T>) ops.run(DefaultCreateImg.class, interval, fac, outType);
 		long[] min = new long[interval.numDimensions()];
 		interval.min(min);
 

--- a/src/main/java/net/imagej/ops/create/img/DefaultCreateImg.java
+++ b/src/main/java/net/imagej/ops/create/img/DefaultCreateImg.java
@@ -1,3 +1,4 @@
+
 /*
  * #%L
  * ImageJ software for multidimensional image processing and analysis.
@@ -30,84 +31,53 @@
 
 package net.imagej.ops.create.img;
 
-import net.imagej.ops.OpService;
-import net.imagej.ops.Ops;
-import net.imagej.ops.Output;
-import net.imglib2.Dimensions;
-import net.imglib2.exception.IncompatibleTypeException;
-import net.imglib2.img.Img;
-import net.imglib2.img.ImgFactory;
-import net.imglib2.type.NativeType;
-
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Output;
+import net.imglib2.Dimensions;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.type.Type;
+
 /**
- * Default implementation of the "create.img" op.
+ * Creates an {@link Img} of a type from {@link Dimensions}. If no
+ * {@link ImgFactory} is provided a new one is created.
  *
- * @author Daniel Seebacher (University of Konstanz)
  * @author Tim-Oliver Buchholz (University of Konstanz)
  * @param <T>
  */
 @Plugin(type = Ops.Create.Img.class, name = Ops.Create.Img.NAME)
-public class DefaultCreateImg<T> implements
-	Ops.Create.Img, Output<Img<T>>
-{
-
-	@Parameter
-	private OpService ops;
+public class DefaultCreateImg<T extends Type<T>>
+		implements
+			Ops.Create.Img,
+			Output<Img<T>> {
 
 	@Parameter(type = ItemIO.OUTPUT)
 	private Img<T> output;
 
-	@Parameter
+	@Parameter(type = ItemIO.INPUT)
 	private Dimensions dims;
 
-	@Parameter(required = false)
-	private T outType;
+	@Parameter(type = ItemIO.INPUT, required = false)
+	private ImgFactory<T> factory;
 
-	@Parameter(required = false)
-	private ImgFactory<T> fac;
+	@Parameter(type = ItemIO.INPUT)
+	private T type;
+
+	@Parameter
+	private OpService ops;
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public void run() {
-		// FIXME: not guaranteed to be a T unless a Class<T> is given.
-		if (outType == null) {
-			// HACK: For Java 6 compiler.
-			@SuppressWarnings("rawtypes")
-			final NativeType o = ops.create().nativeType();
-			final T result = (T) o;
-			outType = result;
+		if (factory == null) {
+			factory = (ImgFactory<T>) ops.create().imgFactory(dims, type);
 		}
-
-		if (fac == null) {
-			if (dims instanceof Img) {
-				final Img<?> inImg = ((Img<?>) dims);
-				if (inImg.firstElement().getClass().isInstance(outType)) {
-					fac = (ImgFactory<T>) inImg.factory();
-				}
-				else {
-					try {
-						// HACK: For Java 6 compiler.
-						final Object o = inImg.factory().imgFactory(outType);
-						final ImgFactory<T> result = (ImgFactory<T>) o;
-						fac = result;
-					}
-					catch (final IncompatibleTypeException e) {
-						// FIXME: outType may not be a NativeType, but imgFactory needs one.
-						fac = (ImgFactory<T>) ops.create().imgFactory(dims, outType);
-					}
-				}
-			}
-			else {
-				// FIXME: outType may not be a NativeType, but imgFactory needs one.
-				fac = (ImgFactory<T>) ops.create().imgFactory(dims, outType);
-			}
-		}
-
-		output = fac.create(dims, outType);
+		output = factory.create(dims, type);
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/img/DefaultCreateImg.java
+++ b/src/main/java/net/imagej/ops/create/img/DefaultCreateImg.java
@@ -75,7 +75,7 @@ public class DefaultCreateImg<T extends Type<T>>
 	@Override
 	public void run() {
 		if (factory == null) {
-			factory = (ImgFactory<T>) ops.create().imgFactory(dims, type);
+			factory = (ImgFactory<T>) ops.create().imgFactory(dims);
 		}
 		output = factory.create(dims, type);
 	}

--- a/src/main/java/net/imagej/ops/create/imgFactory/DefaultCreateImgFactory.java
+++ b/src/main/java/net/imagej/ops/create/imgFactory/DefaultCreateImgFactory.java
@@ -65,17 +65,9 @@ public class DefaultCreateImgFactory<T extends NativeType<T>> implements
 	@Parameter(required = false)
 	private Dimensions dims;
 
-	@Parameter(required = false)
-	private T outType;
-
 	@Override
 	public void run() {
-		if (outType == null) {
-			outType = ops.create().<T> nativeType();
-		}
-
-		output =
-			(dims == null || Intervals.numElements(dims) <= Integer.MAX_VALUE)
+		output = (dims == null || Intervals.numElements(dims) <= Integer.MAX_VALUE)
 				? new ArrayImgFactory<T>() : new CellImgFactory<T>();
 	}
 

--- a/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
@@ -83,7 +83,7 @@ public class CreateImgLabelingFromInterval<L, T extends IntegerType<T>>
 			outType = (T) ops.create().integerType(maxNumLabelSets);
 		}
 
-		output = new ImgLabeling<L, T>(ops.create().img(interval, outType, fac));
+		output = new ImgLabeling<L, T>(ops.create().img(interval, fac, outType));
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
@@ -65,24 +65,15 @@ public class CreateImgLabelingFromInterval<L, T extends IntegerType<T>>
 
 	@Parameter
 	private Interval interval;
-
-	@Parameter(required = false)
-	private T outType;
-
+	
 	@Parameter(required = false)
 	private ImgFactory<T> fac;
 
-	@Parameter(required = false)
-	private int maxNumLabelSets;
+	@Parameter
+	private T outType;
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void run() {
-
-		if (outType == null) {
-			outType = (T) ops.create().integerType(maxNumLabelSets);
-		}
-
 		output = new ImgLabeling<L, T>(ops.create().img(interval, fac, outType));
 	}
 

--- a/src/main/java/net/imagej/ops/create/imgLabeling/DefaultCreateImgLabeling.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/DefaultCreateImgLabeling.java
@@ -81,7 +81,7 @@ public class DefaultCreateImgLabeling<L, T extends IntegerType<T>> implements
 			outType = (T) ops.create().integerType(maxNumLabelSets);
 		}
 
-		output = new ImgLabeling<L, T>(ops.create().img(dims, outType, fac));
+		output = new ImgLabeling<L, T>(ops.create().img(dims, fac, outType));
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/imgLabeling/DefaultCreateImgLabeling.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/DefaultCreateImgLabeling.java
@@ -65,22 +65,13 @@ public class DefaultCreateImgLabeling<L, T extends IntegerType<T>> implements
 	private Dimensions dims;
 
 	@Parameter(required = false)
-	private T outType;
-
-	@Parameter(required = false)
 	private ImgFactory<T> fac;
 
-	@Parameter(required = false)
-	private int maxNumLabelSets;
+	@Parameter
+	private T outType;
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void run() {
-
-		if (outType == null) {
-			outType = (T) ops.create().integerType(maxNumLabelSets);
-		}
-
 		output = new ImgLabeling<L, T>(ops.create().img(dims, fac, outType));
 	}
 

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
@@ -83,7 +83,7 @@ public class DefaultDoG<T extends NumericType<T> & NativeType<T>>
 		final RandomAccessibleInterval<T> input)
 	{
 		// HACK: Make Java 6 javac compiler happy.
-		return (RandomAccessibleInterval<T>) ops.create().<T> img(input);
+		return ops.create().<T> img(input, Util.getTypeFromInterval(input));
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoGSingleSigmas.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoGSingleSigmas.java
@@ -39,6 +39,7 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
+import net.imglib2.util.Util;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -78,7 +79,7 @@ public class DefaultDoGSingleSigmas<T extends NumericType<T> & NativeType<T>>
 		final RandomAccessibleInterval<T> input)
 	{
 		// HACK: Make Java 6 javac compiler happy.
-		return (RandomAccessibleInterval<T>) ops.create().<T> img(input);
+		return ops.create().<T> img(input, Util.getTypeFromInterval(input));
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/labeling/cca/DefaultCCA.java
+++ b/src/main/java/net/imagej/ops/labeling/cca/DefaultCCA.java
@@ -41,6 +41,7 @@ import net.imglib2.algorithm.labeling.ConnectedComponents;
 import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.util.Intervals;
 
 import org.scijava.plugin.Parameter;
@@ -90,7 +91,7 @@ public class DefaultCCA<T extends IntegerType<T>, L, I extends IntegerType<I>>
 		createOutput(final RandomAccessibleInterval<T> input)
 	{
 		// HACK: For Java 6 compiler.
-		return ops.create().<L, I> imgLabeling(input);
+		return (ImgLabeling<L, I>) ops.create().<L, IntType> imgLabeling(input, new IntType());
 	}
 
 	@Override

--- a/src/test/java/net/imagej/ops/create/CreateImgPlusTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgPlusTest.java
@@ -33,6 +33,7 @@ package net.imagej.ops.create;
 import static org.junit.Assert.assertEquals;
 import net.imagej.ImgPlus;
 import net.imagej.ops.AbstractOpTest;
+import net.imglib2.type.logic.BitType;
 
 import org.junit.Test;
 
@@ -48,6 +49,6 @@ public class CreateImgPlusTest extends AbstractOpTest {
 	@Test
 	public void createImgPlusTest() {
 		assertEquals(ops.create().imgPlus(
-			ops.create().img(new long[] { 10, 9, 8 })).getClass(), ImgPlus.class);
+			ops.create().img(new long[] { 10, 9, 8 }, new BitType())).getClass(), ImgPlus.class);
 	}
 }

--- a/src/test/java/net/imagej/ops/create/CreateImgTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgTest.java
@@ -84,7 +84,7 @@ public class CreateImgTest extends AbstractOpTest {
 			}
 
 			// create img
-			final Img<?> img = (Img<?>) ops.create().img(new FinalInterval(min, max));
+			final Img<DoubleType> img = (Img<DoubleType>) ops.create().img(new FinalInterval(min, max), new DoubleType());
 
 			assertArrayEquals("Image Minimum:", min, Intervals.minAsLongArray(img));
 			assertArrayEquals("Image Maximum:", max, Intervals.maxAsLongArray(img));
@@ -103,14 +103,13 @@ public class CreateImgTest extends AbstractOpTest {
 
 			// between 2 and 10 pixels per dimensions
 			for (int j = 0; j < dim.length; j++) {
-				dim[j] = randomGenerator.nextInt(9) + 2;
+				dim[j] = (long)randomGenerator.nextInt(9) + 2;
 			}
 
 			// create img
-			final Img<?> img = (Img<?>) ops.create().img(dim);
+			final Img<DoubleType> img = (Img<DoubleType>) ops.create().img(dim, new DoubleType());
 
-			assertArrayEquals("Image Dimensions:", dim, Intervals
-				.dimensionsAsLongArray(img));
+			assertArrayEquals("Image Dimensions:", dim, Intervals.dimensionsAsLongArray(img));
 		}
 	}
 
@@ -118,7 +117,7 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testImgFromImg() {
 		// create img
 		final Img<ByteType> img =
-			ops.create().img(new FinalDimensions(1), new ByteType());
+			(Img<ByteType>) ops.create().img(new FinalDimensions(1), new ByteType());
 		final Img<ByteType> newImg = ops.create().img(img);
 
 		// should both be ByteType. New Img shouldn't be DoubleType (default)
@@ -132,11 +131,11 @@ public class CreateImgTest extends AbstractOpTest {
 		final long[] dim = new long[] { 10, 10, 10 };
 
 		assertEquals("Image Factory: ", ArrayImgFactory.class, ((Img<?>) ops
-			.create().img(dim, null, new ArrayImgFactory<DoubleType>())).factory()
+			.create().img(dim, new ArrayImgFactory<DoubleType>(), new DoubleType())).factory()
 			.getClass());
 
 		assertEquals("Image Factory: ", CellImgFactory.class, ((Img<?>) ops
-			.create().img(dim, null, new CellImgFactory<DoubleType>())).factory()
+			.create().img(dim, new CellImgFactory<DoubleType>(), new DoubleType())).factory()
 			.getClass());
 
 	}
@@ -169,8 +168,8 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testCreateFromImgSameType() {
 
 		final Img<ByteType> input = PlanarImgs.bytes(10, 10, 10);
-		final Img<?> res =
-			ops.create().img(input, input.firstElement().createVariable());
+		final Img<ByteType> res =
+			ops.create().img(input);
 
 		assertEquals("Image Type: ", ByteType.class, res.firstElement().getClass());
 		assertArrayEquals("Image Dimensions: ", Intervals
@@ -183,7 +182,7 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testCreateFromImgDifferentType() {
 
 		final Img<ByteType> input = PlanarImgs.bytes(10, 10, 10);
-		final Img<?> res = ops.create().img(input, new ShortType());
+		final Img<?> res = (Img<?>) ops.create().img(input, input.factory(), new ShortType());
 
 		assertEquals("Image Type: ", ShortType.class, res.firstElement().getClass());
 		assertArrayEquals("Image Dimensions: ", Intervals
@@ -209,39 +208,4 @@ public class CreateImgTest extends AbstractOpTest {
 		assertEquals("Image Factory: ", ArrayImgFactory.class, res.factory()
 			.getClass());
 	}
-
-	/**
-	 * A simple test to ensure {@link Integer} arrays are not eaten by the varargs
-	 * when passed as the only argument.
-	 */
-	@Test
-	public void testCreateFromIntegerArray() {
-
-		final Integer[] dims = new Integer[] {25, 25, 10};
-
-		final Img<?> res = (Img<?>) ops.create().img(dims);
-
-		for (int i=0; i<dims.length; i++) {
-			assertEquals("Image Dimension " + i + ": ", dims[i].longValue(), res
-				.dimension(i));
-		}
-	}
-
-	/**
-	 * A simple test to ensure {@link Long} arrays are not eaten by the varargs
-	 * when passed as the only argument.
-	 */
-	@Test
-	public void testCreateFromLongArray() {
-
-		final Long[] dims = new Long[] {25l, 25l, 10l};
-
-		final Img<?> res = (Img<?>) ops.create().img(dims);
-
-		for (int i=0; i<dims.length; i++) {
-			assertEquals("Image Dimension " + i + ": ", dims[i].longValue(), res
-				.dimension(i));
-		}
-	}
-
 }

--- a/src/test/java/net/imagej/ops/create/CreateLabelingTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateLabelingTest.java
@@ -73,8 +73,8 @@ public class CreateLabelingTest extends AbstractOpTest {
 
 			// create imglabeling
 			@SuppressWarnings("unchecked")
-			final ImgLabeling<String, ?> img =
-				(ImgLabeling<String, ?>) ops.create().imgLabeling(dim);
+			final ImgLabeling<String, IntType> img =
+				(ImgLabeling<String, IntType>) ops.create().imgLabeling(dim, new IntType());
 
 			assertArrayEquals("Labeling Dimensions:", dim, Intervals
 				.dimensionsAsLongArray(img));
@@ -88,13 +88,13 @@ public class CreateLabelingTest extends AbstractOpTest {
 		final long[] dim = new long[] { 10, 10, 10 };
 
 		assertEquals("Labeling Factory: ", ArrayImgFactory.class,
-			((Img<?>) ((ImgLabeling<String, ?>) ops.create().imgLabeling(dim,
-				null, new ArrayImgFactory<IntType>())).getIndexImg()).factory()
+			((Img<?>) ((ImgLabeling<String, IntType>) ops.create().imgLabeling(dim,
+				new ArrayImgFactory<IntType>(), new IntType())).getIndexImg()).factory()
 				.getClass());
 
 		assertEquals("Labeling Factory: ", CellImgFactory.class,
-			((Img<?>) ((ImgLabeling<String, ?>) ops.create().imgLabeling(dim,
-				null, new CellImgFactory<IntType>())).getIndexImg()).factory()
+			((Img<?>) ((ImgLabeling<String, IntType>) ops.create().imgLabeling(dim,
+				new CellImgFactory<IntType>(), new IntType())).getIndexImg()).factory()
 				.getClass());
 
 	}
@@ -120,7 +120,7 @@ public class CreateLabelingTest extends AbstractOpTest {
 
 		final ImgLabeling<I, ?> imgLabeling =
 			((ImgLabeling<I, ?>) ops.create().imgLabeling(new long[] { 10,
-				10, 10 }));
+				10, 10 }, new IntType()));
 		imgLabeling.cursor().next().add(type);
 		return imgLabeling;
 	}


### PR DESCRIPTION
Hi @ctrueden and @dietzc I refactored DefaultCreateImg #183.

Now DefaultCreateImg requires some Dimensions and a Type as input parameters. The ImgFactory is an optional parameter. 

The image type has to be passed as an argument if a new image is created. I think this is the way to go because if someone creates a new image from scratch the type of the image should be set by the caller and not by Ops. 

I hope this is what you had in mind. If not I will refactor again.

