### PR TITLE
Fixed bug in NormalizeRealTypeComputer

### DIFF
--- a/src/main/java/net/imagej/ops/image/normalize/NormalizeRealTypeComputer.java
+++ b/src/main/java/net/imagej/ops/image/normalize/NormalizeRealTypeComputer.java
@@ -55,7 +55,10 @@ class NormalizeRealTypeComputer<T extends RealType<T>> extends
 	{
 		double tmp = 0.0;
 		
-		if (sourceMin == null || sourceMax == null) {
+		if (sourceMin != null && sourceMax != null) {
+			this.sourceMin = sourceMin.getRealDouble();
+			tmp = sourceMax.getRealDouble();
+		} else {
 			final Pair<T,T> minMax = ops.stats().minMax(input);
 			if (sourceMin == null) {
 				this.sourceMin = minMax.getA().getRealDouble();
@@ -69,11 +72,8 @@ class NormalizeRealTypeComputer<T extends RealType<T>> extends
 			else {
 				tmp = sourceMax.getRealDouble();
 			}
-		} else {
-			this.sourceMin = sourceMin.getRealDouble();
-			tmp = sourceMax.getRealDouble();
 		}
-		
+
 		if (targetMax == null) {
 			this.targetMax = input.firstElement().getMaxValue();
 		}

--- a/src/main/java/net/imagej/ops/image/normalize/NormalizeRealTypeComputer.java
+++ b/src/main/java/net/imagej/ops/image/normalize/NormalizeRealTypeComputer.java
@@ -54,7 +54,7 @@ class NormalizeRealTypeComputer<T extends RealType<T>> extends
 		final IterableInterval<T> input)
 	{
 		double tmp = 0.0;
-
+		
 		if (sourceMin == null || sourceMax == null) {
 			final Pair<T,T> minMax = ops.stats().minMax(input);
 			if (sourceMin == null) {
@@ -69,7 +69,11 @@ class NormalizeRealTypeComputer<T extends RealType<T>> extends
 			else {
 				tmp = sourceMax.getRealDouble();
 			}
+		} else {
+			this.sourceMin = sourceMin.getRealDouble();
+			tmp = sourceMax.getRealDouble();
 		}
+		
 		if (targetMax == null) {
 			this.targetMax = input.firstElement().getMaxValue();
 		}


### PR DESCRIPTION
I have tried to normalize an input image to the [0.0, 1.0] range with `opService.image().normalize(output, input, min, max, new DoubleType(0.0), new DoubleType(1.0));`. This wasn't very successful, since `tmp` is not correctly set, when both `sourceMin` and `sourceMax` are provided (as in my case) which in turn sets `factor` to `Double.INFINITY`.

I am not sure if that is desired behavior or not. In any case, this PR fixes the issue for me..