### PR TITLE
Add op to generate Poisson noise

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -83,6 +83,24 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	// -- addPoissonNoise --
+
+	@OpMethod(op = net.imagej.ops.Ops.Filter.AddPoissonNoise.class)
+	public Object addPoissonNoise(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Filter.AddPoissonNoise.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class)
+	public <I extends RealType<I>, O extends RealType<O>> O addPoissonNoise(final O out,
+		final I in, final Random rng)
+	{
+		@SuppressWarnings("unchecked")
+		final O result =
+			(O) ops().run(net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class, out,
+				in, rng);
+		return result;
+	}
+
 	// -- convolve --
 
 	/** Executes the "convolve" operation on the given arguments. */

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -31,8 +31,6 @@
 package net.imagej.ops.filter;
 
 import java.util.List;
-import java.util.Random;
-
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.ComputerOp;
 import net.imagej.ops.FunctionOp;
@@ -74,12 +72,24 @@ public class FilterNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.filter.addNoise.AddNoiseRealType.class)
 	public <I extends RealType<I>, O extends RealType<O>> O addNoise(final O out,
 		final I in, final double rangeMin, final double rangeMax,
-		final double rangeStdDev, final Random rng)
+		final double rangeStdDev)
 	{
 		@SuppressWarnings("unchecked")
 		final O result =
 			(O) ops().run(net.imagej.ops.filter.addNoise.AddNoiseRealType.class, out,
-				in, rangeMin, rangeMax, rangeStdDev, rng);
+				in, rangeMin, rangeMax, rangeStdDev);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.addNoise.AddNoiseRealType.class)
+	public <I extends RealType<I>, O extends RealType<O>> O addNoise(final O out,
+		final I in, final double rangeMin, final double rangeMax,
+		final double rangeStdDev, final long seed)
+	{
+		@SuppressWarnings("unchecked")
+		final O result =
+			(O) ops().run(net.imagej.ops.filter.addNoise.AddNoiseRealType.class, out,
+				in, rangeMin, rangeMax, rangeStdDev, seed);
 		return result;
 	}
 
@@ -92,12 +102,23 @@ public class FilterNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class)
 	public <I extends RealType<I>, O extends RealType<O>> O addPoissonNoise(final O out,
-		final I in, final Random rng)
+		final I in)
 	{
 		@SuppressWarnings("unchecked")
 		final O result =
 			(O) ops().run(net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class, out,
-				in, rng);
+				in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class)
+	public <I extends RealType<I>, O extends RealType<O>> O addPoissonNoise(final O out,
+		final I in, final long seed)
+	{
+		@SuppressWarnings("unchecked")
+		final O result =
+			(O) ops().run(net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class, out,
+				in, seed);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/addNoise/AddNoiseRealType.java
+++ b/src/main/java/net/imagej/ops/filter/addNoise/AddNoiseRealType.java
@@ -57,11 +57,22 @@ public class AddNoiseRealType<I extends RealType<I>, O extends RealType<O>>
 	@Parameter
 	private double rangeStdDev;
 
-	@Parameter
+	@Parameter(required = false)
+	private long seed = 0xabcdef1234567890L;
+	
 	private Random rng;
 
+	public long getSeed() {
+		return seed;
+	}
+	
+	public void setSeed(final long seed) {
+		this.seed = seed;
+	}
+	
 	@Override
 	public void compute(final I input, final O output) {
+		if (rng == null) rng = new Random(seed);
 		int i = 0;
 		do {
 			final double newVal =

--- a/src/main/java/net/imagej/ops/filter/addPoissonNoise/AddPoissonNoiseRealType.java
+++ b/src/main/java/net/imagej/ops/filter/addPoissonNoise/AddPoissonNoiseRealType.java
@@ -54,11 +54,22 @@ import org.scijava.plugin.Plugin;
 public class AddPoissonNoiseRealType<I extends RealType<I>, O extends RealType<O>>
 	extends AbstractComputerOp<I, O> implements Ops.Filter.AddPoissonNoise
 {
-	@Parameter
+	@Parameter(required = false)
+	private long seed = 0xabcdef1234567890L;
+	
 	private Random rng;
 
+	public long getSeed() {
+		return seed;
+	}
+	
+	public void setSeed(final long seed) {
+		this.seed = seed;
+	}
+	
 	@Override
 	public void compute(final I input, final O output) {
+		if (rng == null) rng = new Random(seed);
 		double l = Math.exp(-(input.getRealDouble()));
 		int k = 0;
 		double p = 1;

--- a/src/main/java/net/imagej/ops/filter/addPoissonNoise/AddPoissonNoiseRealType.java
+++ b/src/main/java/net/imagej/ops/filter/addPoissonNoise/AddPoissonNoiseRealType.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.addPoissonNoise;
+
+import java.util.Random;
+
+import net.imagej.ops.AbstractComputerOp;
+import net.imagej.ops.Ops;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Sets the real component of an output real number to a real number sampled from
+ * a Poisson distribution with lambda of the input real number.
+ * <p>
+ * Implementation according to:
+ * <p>D. E. Knuth.<br/>
+ * Art of Computer Programming, Volume 2: Seminumerical Algorithms (3rd Edition).<br/>
+ * Addison-Wesley Professional, November 1997
+ *  
+ * @author Jan Eglinger
+ */
+@Plugin(type = Ops.Filter.AddPoissonNoise.class, name = Ops.Filter.AddPoissonNoise.NAME)
+public class AddPoissonNoiseRealType<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractComputerOp<I, O> implements Ops.Filter.AddPoissonNoise
+{
+	@Parameter
+	private Random rng;
+
+	@Override
+	public void compute(final I input, final O output) {
+		double l = Math.exp(-(input.getRealDouble()));
+		int k = 0;
+		double p = 1;
+		do {
+			k++;
+			p *= rng.nextDouble();
+		} while (p >= l);
+		output.setReal(k-1);
+		return;
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -43,6 +43,7 @@ namespaces = ```
 	]],
 	[name: "filter", iface: "Filter", ops: [
 		[name: "addNoise",           iface: "AddNoise"],
+		[name: "addPoissonNoise",    iface: "AddPoissonNoise"],
 		[name: "convolve",           iface: "Convolve"],
 		[name: "correlate",          iface: "Correlate"],
 		[name: "fft",                iface: "FFT"],

--- a/src/test/java/net/imagej/ops/ReadmeExampleTest.java
+++ b/src/test/java/net/imagej/ops/ReadmeExampleTest.java
@@ -63,11 +63,11 @@ public class ReadmeExampleTest {
 		// extract the example script
 		final File readme = new File("README.md");
 		final String contents = new String(FileUtils.readFile(readme), "UTF-8");
-		final String telltale = "```python\n";
+		final String telltale = String.format("```python%n");
 		final int begin = contents.indexOf(telltale) + telltale.length();
 		assertTrue(begin > telltale.length());
 		assertTrue(contents.indexOf(telltale, begin) < 0);
-		final int end = contents.indexOf("```\n", begin);
+		final int end = contents.indexOf(String.format("```%n"), begin);
 		assertTrue(end > 0);
 		final String snippet = contents.substring(begin, end);
 		assertTrue(snippet.startsWith("# @ImageJ ij"));


### PR DESCRIPTION
This enables adding noise to an image as shown in this groovy snippet:

    // @OpService ops
    // @UIService ui
    // @Dataset inputData

    import net.imglib2.type.numeric.real.DoubleType

    
    // execute the filter.addPoissonNoise op on every pixel of an image
    noiseOp = ops.op("filter.addPoissonNoise", DoubleType.class, DoubleType.class)
    ops.run("map", inputData, inputData, noiseOp)
    ui.show("noisy image", inputData)
