### PR TITLE
Non circulant fixes

### DIFF
--- a/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
@@ -50,6 +50,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
+import org.scijava.app.StatusService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 
@@ -67,6 +68,9 @@ import org.scijava.plugin.Parameter;
 public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends AbstractFFTFilterRAI<I, O, K, C>
 {
+
+	@Parameter(required=false)
+	private StatusService status;
 
 	/**
 	 * Max number of iterations to perform
@@ -234,6 +238,10 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 	protected void performIterations() {
 		for (int i = 0; i < maxIterations; i++) {
+
+			if (status != null) {
+				status.showProgress(i, maxIterations);
+			}
 			performIteration();
 			createReblurred();
 			if (getAccelerate()) {

--- a/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
@@ -135,7 +135,8 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 		initialize();
 
-		performIterations(maxIterations);
+		performIterations();
+
 
 	}
 
@@ -174,40 +175,21 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 		// if non-circulant decon mode create image for normalization
 		if (nonCirculant) {
-			normalization =
-				getImgFactory().create(raiExtendedEstimate, outType.createVariable());
+			normalization = getImgFactory().create(raiExtendedEstimate, outType
+				.createVariable());
 
 			this.CreateNormalizationImageSemiNonCirculant();
 		}
 
-		// set first guess of estimate
-		// TODO: implement logic for various first guesses.
-		// for now just set to original image
-		Cursor<O> c = Views.iterable(raiExtendedEstimate).cursor();
-		Cursor<I> cIn = Views.iterable(getRAIExtendedInput()).cursor();
-
-		while (c.hasNext()) {
-			c.fwd();
-			cIn.fwd();
-			c.get().setReal(cIn.get().getRealFloat());
-		}
-
-		// TODO: see if we still need to unmask values outside fft space
-		/*		// fft space can be slightly larger then the object space so so use a mask
-			// to get
-			// rid of any values outside the object space.
-			// StaticFunctions.InPlaceMultiply(normalization, mask);
-			*/
-
 		createReblurred();
 
 		if (getAccelerate()) {
-			accelerator = new VectorAccelerator(this.getImgFactory());
+			accelerator = new VectorAccelerator<O>(this.getImgFactory());
 		}
 
 	}
 
-	void performIterations(int maxIterations) {
+	protected void performIterations() {
 		for (int i = 0; i < maxIterations; i++) {
 			performIteration();
 			createReblurred();

--- a/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
@@ -141,6 +141,7 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 		performIterations();
 
+		postProcess();
 	}
 
 	/**
@@ -246,6 +247,33 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 		// perform convolution -- kernel FFT should allready exist
 		ops().filter().convolve(raiExtendedEstimate, null, getFFTInput(),
 			getFFTKernel(), raiExtendedReblurred, true, false);
+	}
+
+	/**
+	 * postProcess TODO: review this function
+	 */
+	protected void postProcess() {
+
+		if (getNonCirculant() == true) {
+
+			long[] start = new long[k.numDimensions()];
+			long[] end = new long[k.numDimensions()];
+
+			for (int d = 0; d < k.numDimensions(); d++) {
+				start[d] = (getRAIExtendedEstimate().dimension(d) - k.dimension(d)) / 2;
+				end[d] = start[d] + k.dimension(d) - 1;
+			}
+
+			Img<O> temp = ops().create().img(getNormalization());
+
+			copy2(getRAIExtendedEstimate(), temp);
+
+			RandomAccessibleInterval<O> temp2 = ops().image().crop(
+				getRAIExtendedEstimate(), new FinalInterval(start, end));
+
+			copy2(temp2, getOutput());
+
+		}
 	}
 
 	/**

--- a/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
@@ -35,6 +35,7 @@ import net.imagej.ops.deconvolve.accelerate.VectorAccelerator;
 import net.imagej.ops.filter.correlate.CorrelateFFTRAI;
 import net.imglib2.Cursor;
 import net.imglib2.Dimensions;
+import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
@@ -49,6 +50,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
+import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 
 /**

--- a/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
@@ -126,6 +126,8 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 
 	private Img<O> reblurred;
 
+	private Img<O> estimate;
+
 	// Normalization factor for edge handling (see
 	// http://bigwww.epfl.ch/deconvolution/challenge2013/index.html?p=doc_math_rl)
 	private Img<O> normalization = null;

--- a/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
+++ b/src/main/java/net/imagej/ops/filter/IterativeFFTFilterRAI.java
@@ -377,4 +377,35 @@ public abstract class IterativeFFTFilterRAI<I extends RealType<I>, O extends Rea
 		return accelerator;
 	}
 
+	// TODO replace with op
+	protected void copy2(RandomAccessibleInterval<O> input,
+		RandomAccessibleInterval<O> output)
+	{
+
+		final Cursor<O> cursorInput = Views.iterable(input).cursor();
+		final Cursor<O> cursorOutput = Views.iterable(output).cursor();
+
+		while (cursorInput.hasNext()) {
+			cursorInput.fwd();
+			cursorOutput.fwd();
+
+			cursorOutput.get().set(cursorInput.get());
+		}
+	}
+
+	// TODO replace with op
+	protected <T extends RealType<T>> void inPlaceMultiply(
+		final Img<T> inputOutput, final Img<T> input)
+	{
+		final Cursor<T> cursorInputOutput = inputOutput.cursor();
+		final Cursor<T> cursorInput = input.cursor();
+
+		while (cursorInputOutput.hasNext()) {
+			cursorInputOutput.fwd();
+			cursorInput.fwd();
+			cursorInputOutput.get().mul(cursorInput.get());
+		}
+
+	}
+
 }


### PR DESCRIPTION
This pull requests implements some fixes to the non-circulant Richardson Lucy algorithm described here:

http://bigwww.epfl.ch/deconvolution/challenge/index.html?p=documentation/theory/richardsonlucy/

It also adds a couple of temporary math utilities (the deconvolution ops should be refactored once all the math functions needed are implemented as Ops). 

Also, we now use the log service to update the iteration number.    