### PR TITLE
Local Phansalkar thresholding

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -487,6 +487,16 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class)
+	public <T extends RealType<T>> BitType localPhansalkar(final BitType out,
+		final Pair<T, Iterable<T>> in, final double k, final double r)
+	{
+		final BitType result =
+			(BitType) ops().run(net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class,
+				out, in, k, r);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxEntropy.class)
 	public Object maxEntropy(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Threshold.MaxEntropy.class, args);

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -497,6 +497,26 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class)
+	public <T extends RealType<T>> BitType localPhansalkar(final BitType out,
+		final Pair<T, Iterable<T>> in, final double k)
+	{
+		final BitType result =
+			(BitType) ops().run(net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class,
+				out, in, k);
+		return result;
+	}
+	
+	@OpMethod(op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class)
+	public <T extends RealType<T>> BitType localPhansalkar(final BitType out,
+		final Pair<T, Iterable<T>> in)
+	{
+		final BitType result =
+			(BitType) ops().run(net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class,
+				out, in);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxEntropy.class)
 	public Object maxEntropy(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Threshold.MaxEntropy.class, args);

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -49,6 +49,7 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 	@Parameter
 	private OpService ops;
 
+	// FIXME: Faster calculation of mean and std-dev
 	private ComputerOp<Iterable<T>, DoubleType> mean;
 	private ComputerOp<Iterable<T>, DoubleType> stdDeviation;
 

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -40,10 +40,10 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 	implements Ops.Threshold.LocalPhansalkar
 {
 
-	@Parameter
+	@Parameter(required = false)
 	private double k = 0.25;
 
-	@Parameter
+	@Parameter(required = false)
 	private double r = 0.5;
 
 	@Parameter

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -58,8 +58,8 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 
 	@Override
 	public void initialize() {
-		mean = ops().computer(Mean.class, new DoubleType(), in().getB());
-		stdDeviation = ops().computer(StdDev.class, new DoubleType(), in().getB());
+		mean = ops().computer(Mean.class, DoubleType.class, in().getB());
+		stdDeviation = ops().computer(StdDev.class, DoubleType.class, in().getB());
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -1,0 +1,73 @@
+package net.imagej.ops.threshold.localPhansalkar;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.stats.mean.MeanOp;
+import net.imagej.ops.stats.variance.VarianceOp;
+import net.imagej.ops.threshold.LocalThresholdMethod;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Pair;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This is a modification of Sauvola's thresholding method to deal with low
+ * contrast images.
+ * 
+ * Phansalskar N. et al. Adaptive local thresholding for detection of nuclei in
+ * diversity stained cytology images. International Conference on Communications
+ * and Signal Processing (ICCSP), 2011, // 218 - 220.
+ * 
+ * In this method, the threshold t = mean*(1+p*exp(-q*mean)+k*((stdev/r)-1))
+ * 
+ * Phansalkar recommends k = 0.25, r = 0.5, p = 2 and q = 10. In the current
+ * implementation, the values of p and q are fixed.
+ * 
+ * Implemented from Phansalkar's paper description by G. Landini.
+ * 
+ * @author Stefan Helfrich <s.helfrich@fz-juelich.de>
+ */
+@Plugin(type = Ops.Threshold.LocalPhansalkar.class, name = Ops.Threshold.LocalPhansalkar.NAME)
+public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod<T>
+	implements Ops.Threshold.LocalPhansalkar
+{
+
+	@Parameter
+	private double k = 0.25;
+
+	@Parameter
+	private double r = 0.5;
+
+	@Parameter
+	private OpService ops;
+
+	private MeanOp<Iterable<T>, DoubleType> mean;
+	private VarianceOp<T, DoubleType> var;
+
+	private double p = 2.0;
+	private double q = 10.0;
+	
+	@Override
+	public void compute(final Pair<T, Iterable<T>> input, final BitType output) {
+		if (mean == null) {
+			mean = ops.op(MeanOp.class, DoubleType.class, input.getB());
+		}
+		if (var == null) {
+			var = ops.op(VarianceOp.class, DoubleType.class, input.getB());
+		}
+		
+		final DoubleType meanValue = new DoubleType();
+		mean.compute(input.getB(), meanValue);
+		
+		final DoubleType varianceValue = new DoubleType();
+		var.compute(input.getB(), varianceValue);
+		
+		double threshold = meanValue.get() * (1.0d + p * Math.exp(-q * meanValue.get()) + k * ((Math.sqrt(varianceValue.get())/r) - 1.0));
+		
+		output.set(input.getA().getRealDouble() >= threshold);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -5,7 +5,6 @@ import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Ops.Stats.Mean;
 import net.imagej.ops.Ops.Stats.StdDev;
-import net.imagej.ops.stats.DefaultMean;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
@@ -19,16 +18,20 @@ import org.scijava.plugin.Plugin;
  * This is a modification of Sauvola's thresholding method to deal with low
  * contrast images.
  * 
- * Phansalskar N. et al. Adaptive local thresholding for detection of nuclei in
- * diversity stained cytology images. International Conference on Communications
- * and Signal Processing (ICCSP), 2011, // 218 - 220.
- * 
- * In this method, the threshold t = mean*(1+p*exp(-q*mean)+k*((stdev/r)-1))
+ * In this algorithm the threshold is computed as t =
+ * mean*(1+p*exp(-q*mean)+k*((stdev/r)-1)) for an image that is normalized to
+ * [0, 1].
  * 
  * Phansalkar recommends k = 0.25, r = 0.5, p = 2 and q = 10. In the current
- * implementation, the values of p and q are fixed.
+ * implementation, the values of p and q are fixed but can be implemented as
+ * additional parameters.
  * 
- * Implemented from Phansalkar's paper description by G. Landini.
+ * Originally implemented from Phansalkar's paper description by G. Landini
+ * (http://fiji.sc/Auto_Local_Threshold#Phansalkar).
+ * 
+ * Phansalskar N. et al. Adaptive local thresholding for detection of nuclei in
+ * diversity stained cytology images. International Conference on Communications
+ * and Signal Processing (ICCSP), 2011, 218 - 220.
  * 
  * @author Stefan Helfrich <s.helfrich@fz-juelich.de>
  */

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -1,10 +1,11 @@
 package net.imagej.ops.threshold.localPhansalkar;
 
+import net.imagej.ops.ComputerOp;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
-import net.imagej.ops.stats.mean.MeanOp;
-import net.imagej.ops.stats.stdDev.StdDev;
-import net.imagej.ops.stats.variance.VarianceOp;
+import net.imagej.ops.Ops.Stats.Mean;
+import net.imagej.ops.Ops.Stats.StdDev;
+import net.imagej.ops.stats.DefaultMean;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
@@ -45,20 +46,20 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 	@Parameter
 	private OpService ops;
 
-	private MeanOp<Iterable<T>, DoubleType> mean;
-	private StdDev<T, DoubleType> stdDeviation;
+	private ComputerOp<Iterable<T>, DoubleType> mean;
+	private ComputerOp<Iterable<T>, DoubleType> stdDeviation;
 
 	private double p = 2.0;
 	private double q = 10.0;
-	
+
+	@Override
+	public void initialize() {
+		mean = ops().computer(Mean.class, new DoubleType(), in().getB());
+		stdDeviation = ops().computer(StdDev.class, new DoubleType(), in().getB());
+	}
+
 	@Override
 	public void compute(final Pair<T, Iterable<T>> input, final BitType output) {
-		if (mean == null) {
-			mean = ops.op(MeanOp.class, DoubleType.class, input.getB());
-		}
-		if (stdDeviation == null) {
-			stdDeviation = ops.op(StdDev.class, DoubleType.class, input.getB());
-		}
 
 		final DoubleType meanValue = new DoubleType();
 		mean.compute(input.getB(), meanValue);

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -3,6 +3,7 @@ package net.imagej.ops.threshold.localPhansalkar;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.stats.mean.MeanOp;
+import net.imagej.ops.stats.stdDev.StdDev;
 import net.imagej.ops.stats.variance.VarianceOp;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
@@ -45,7 +46,7 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 	private OpService ops;
 
 	private MeanOp<Iterable<T>, DoubleType> mean;
-	private VarianceOp<T, DoubleType> var;
+	private StdDev<T, DoubleType> stdDeviation;
 
 	private double p = 2.0;
 	private double q = 10.0;
@@ -55,17 +56,17 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 		if (mean == null) {
 			mean = ops.op(MeanOp.class, DoubleType.class, input.getB());
 		}
-		if (var == null) {
-			var = ops.op(VarianceOp.class, DoubleType.class, input.getB());
+		if (stdDeviation == null) {
+			stdDeviation = ops.op(StdDev.class, DoubleType.class, input.getB());
 		}
-		
+
 		final DoubleType meanValue = new DoubleType();
 		mean.compute(input.getB(), meanValue);
-		
-		final DoubleType varianceValue = new DoubleType();
-		var.compute(input.getB(), varianceValue);
-		
-		double threshold = meanValue.get() * (1.0d + p * Math.exp(-q * meanValue.get()) + k * ((Math.sqrt(varianceValue.get())/r) - 1.0));
+
+		final DoubleType stdDevValue = new DoubleType();
+		stdDeviation.compute(input.getB(), stdDevValue);
+
+		double threshold = meanValue.get() * (1.0d + p * Math.exp(-q * meanValue.get()) + k * ((stdDevValue.get()/r) - 1.0));
 		
 		output.set(input.getA().getRealDouble() >= threshold);
 	}

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -1,3 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 package net.imagej.ops.threshold.localPhansalkar;
 
 import net.imagej.ops.ComputerOp;

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -299,6 +299,7 @@ namespaces = ```
 		[name: "localMedian",                 iface: "LocalMedian"],
 		[name: "localMidGrey",                iface: "LocalMidGrey"],
 		[name: "localNiblack",                iface: "LocalNiblack"],
+		[name: "localPhansalkar",             iface: "LocalPhansalkar"],
 		[name: "maxEntropy",                  iface: "MaxEntropy"],
 		[name: "maxLikelihood",               iface: "MaxLikelihood"],
 		[name: "mean",                        iface: "Mean"],

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -206,7 +206,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalPhansalkar.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, null), 0.0, 0.0),
+				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -99,6 +99,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.threshold().localMidGrey(out, in, 1.0);
 		ops.threshold().localNiblack(out, in, 1.0, 2.0);
 		ops.threshold().localPhansalkar(out, in, 0.25, 0.5);
+		ops.threshold().localPhansalkar(out, in);
 	}
 
 	/**

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -43,6 +43,7 @@ import net.imagej.ops.threshold.localMean.LocalMean;
 import net.imagej.ops.threshold.localMedian.LocalMedian;
 import net.imagej.ops.threshold.localMidGrey.LocalMidGrey;
 import net.imagej.ops.threshold.localNiblack.LocalNiblack;
+import net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
@@ -97,6 +98,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.threshold().localMedian(out, in, 1.0);
 		ops.threshold().localMidGrey(out, in, 1.0);
 		ops.threshold().localNiblack(out, in, 1.0, 2.0);
+		ops.threshold().localPhansalkar(out, in, 0.25, 0.5);
 	}
 
 	/**
@@ -193,6 +195,22 @@ public class LocalThresholdTest extends AbstractOpTest {
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
 		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalPhansalkar
+	 */
+	@Test
+	public void testLocalPhansalkar() {
+		ops.threshold().apply(
+			out,
+			in,
+			ops.op(LocalPhansalkar.class, BitType.class,
+				new ValuePair<ByteType, Iterable<ByteType>>(null, null), 0.0, 0.0),
+			new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
 	}
 
 }


### PR DESCRIPTION
This is an Ops implementation of Phansalkar's local thresholding method as originally implemented by Gabriel Landini in the `Auto_Local_Threshold` plugin of IJ1 (http://fiji.sc/Auto_Local_Threshold#Phansalkar).

Currently, the input is not checked for correct normalization to the [0, 1] range. Is that something that should be added in the Op itself?