### PR TITLE
Local Sauvola thresholding

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -517,8 +517,8 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.threshold.sauvola.Sauvola.class)
-	public <T extends RealType<T>> BitType sauvola(final BitType out,
+	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvola.class)
+	public <T extends RealType<T>> BitType localSauvola(final BitType out,
 		final Pair<T, Iterable<T>> in, final double k, final double r)
 	{
 		final BitType result =

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -517,6 +517,16 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.threshold.sauvola.Sauvola.class)
+	public <T extends RealType<T>> BitType sauvola(final BitType out,
+		final Pair<T, Iterable<T>> in, final double k, final double r, final boolean doIwhite)
+	{
+		final BitType result =
+			(BitType) ops().run(net.imagej.ops.threshold.sauvola.Sauvola.class,
+				out, in, k, r, doIwhite);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxEntropy.class)
 	public Object maxEntropy(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Threshold.MaxEntropy.class, args);
@@ -1170,7 +1180,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 				in);
 		return result;
 	}
-
+	
 	// -- Named methods --
 
 	@Override

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -526,6 +526,26 @@ public class ThresholdNamespace extends AbstractNamespace {
 				out, in, k, r);
 		return result;
 	}
+	
+	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvola.class)
+	public <T extends RealType<T>> BitType localSauvola(final BitType out,
+		final Pair<T, Iterable<T>> in, final double k)
+	{
+		final BitType result =
+			(BitType) ops().run(net.imagej.ops.threshold.localSauvola.LocalSauvola.class,
+				out, in, k);
+		return result;
+	}
+	
+	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvola.class)
+	public <T extends RealType<T>> BitType localSauvola(final BitType out,
+		final Pair<T, Iterable<T>> in)
+	{
+		final BitType result =
+			(BitType) ops().run(net.imagej.ops.threshold.localSauvola.LocalSauvola.class,
+				out, in);
+		return result;
+	}
 
 	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxEntropy.class)
 	public Object maxEntropy(final Object... args) {

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -519,11 +519,11 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.threshold.sauvola.Sauvola.class)
 	public <T extends RealType<T>> BitType sauvola(final BitType out,
-		final Pair<T, Iterable<T>> in, final double k, final double r, final boolean doIwhite)
+		final Pair<T, Iterable<T>> in, final double k, final double r)
 	{
 		final BitType result =
 			(BitType) ops().run(net.imagej.ops.threshold.sauvola.Sauvola.class,
-				out, in, k, r, doIwhite);
+				out, in, k, r);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -522,7 +522,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final Pair<T, Iterable<T>> in, final double k, final double r)
 	{
 		final BitType result =
-			(BitType) ops().run(net.imagej.ops.threshold.sauvola.Sauvola.class,
+			(BitType) ops().run(net.imagej.ops.threshold.localSauvola.LocalSauvola.class,
 				out, in, k, r);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -73,6 +73,7 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	@Parameter
 	private OpService ops;
 
+	// FIXME: Faster calculation of mean and std-dev.
 	private ComputerOp<Iterable<T>, DoubleType> mean;
 	private ComputerOp<Iterable<T>, DoubleType> stdDeviation;
 

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -1,4 +1,4 @@
-package net.imagej.ops.threshold.sauvola;
+package net.imagej.ops.threshold.localSauvola;
 
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
@@ -23,9 +23,9 @@ import org.scijava.plugin.Plugin;
  * 
  * @author Stefan Helfrich <s.helfrich@fz-juelich.de>
  */
-@Plugin(type = Ops.Threshold.Sauvola.class, name = Ops.Threshold.Sauvola.NAME)
-public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
-	implements Ops.Threshold.Sauvola
+@Plugin(type = Ops.Threshold.LocalSauvola.class, name = Ops.Threshold.LocalSauvola.NAME)
+public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
+	implements Ops.Threshold.LocalSauvola
 {
 
 	@Parameter

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -64,10 +64,10 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	implements Ops.Threshold.LocalSauvola
 {
 
-	@Parameter
+	@Parameter(required = false)
 	private double k = 0.5d;
 
-	@Parameter
+	@Parameter(required = false)
 	private double r = 0.5d;
 
 	@Parameter

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -15,11 +15,16 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * This is a modification of Niblack's thresholding method.
+ * This is a modification of Niblack's thresholding method. In contrast to the
+ * recommendation on parameters in the publication, this implementation operates
+ * on normalized images (to the [0, 1] range). Hence, the r parameter defaults
+ * to half the possible standard deviation in a normalized image, namely 0.5
+ * 
  * Sauvola J. and Pietaksinen M. (2000) "Adaptive Document Image Binarization"
  * Pattern Recognition, 33(2): 225-236
+ * 
  * http://www.ee.oulu.fi/mvg/publications/show_pdf.php?ID=24
- * Ported to ImageJ plugin from E Celebi's fourier_0.8 routines.
+ * 
  * Original ImageJ1 implementation by Gabriel Landini.
  * 
  * @author Stefan Helfrich <s.helfrich@fz-juelich.de>
@@ -33,7 +38,7 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	private double k = 0.5d;
 
 	@Parameter
-	private double r = 128.0d;
+	private double r = 0.5d;
 
 	@Parameter
 	private OpService ops;
@@ -49,8 +54,7 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	
 	@Override
 	public void compute(final Pair<T, Iterable<T>> input, final BitType output) {
-		// Sauvola recommends K_VALUE = 0.5 and R_VALUE = 128.
-		
+
 		final DoubleType meanValue = new DoubleType();
 		mean.compute(input.getB(), meanValue);
 		

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -1,3 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 package net.imagej.ops.threshold.localSauvola;
 
 import net.imagej.ops.ComputerOp;

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -51,18 +51,18 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 		mean = ops().computer(Mean.class, new DoubleType(), in().getB());
 		stdDeviation = ops().computer(StdDev.class, new DoubleType(), in().getB());
 	}
-	
+
 	@Override
 	public void compute(final Pair<T, Iterable<T>> input, final BitType output) {
 
 		final DoubleType meanValue = new DoubleType();
 		mean.compute(input.getB(), meanValue);
-		
+
 		final DoubleType stdDevValue = new DoubleType();
 		stdDeviation.compute(input.getB(), stdDevValue);
-		
+
 		double threshold = meanValue.get() * (1.0d + k * ((Math.sqrt(stdDevValue.get())/r) - 1.0));
-		
+
 		output.set(input.getA().getRealDouble() >= threshold);
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -78,8 +78,8 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 
 	@Override
 	public void initialize() {
-		mean = ops().computer(Mean.class, new DoubleType(), in().getB());
-		stdDeviation = ops().computer(StdDev.class, new DoubleType(), in().getB());
+		mean = ops().computer(Mean.class, DoubleType.class, in().getB());
+		stdDeviation = ops().computer(StdDev.class, DoubleType.class, in().getB());
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
@@ -34,9 +34,6 @@ public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	private double r = 128.0d;
 
 	@Parameter
-	boolean doIwhite = true;
-	
-	@Parameter
 	private OpService ops;
 
 	private MeanOp<Iterable<T>, DoubleType> mean;
@@ -61,12 +58,7 @@ public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 		
 		double threshold = meanValue.get() * (1.0d + k * ((Math.sqrt(varianceValue.get())/r) - 1.0));
 		
-		if (doIwhite){
-			output.set(input.pixel.getRealDouble() > threshold);
-		}
-		else {
-			output.set(input.pixel.getRealDouble() < threshold);
-		}
+		output.set(input.getA().getRealDouble() >= threshold);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
@@ -1,0 +1,78 @@
+package net.imagej.ops.threshold.sauvola;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.stats.mean.MeanOp;
+import net.imagej.ops.stats.variance.VarianceOp;
+import net.imagej.ops.threshold.LocalThresholdMethod;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import ij.IJ;
+import ij.ImagePlus;
+import ij.plugin.filter.RankFilters;
+import ij.process.ImageConverter;
+import ij.process.ImageProcessor;
+
+/**
+ * TODO Documentation
+ * 
+ * @author Stefan Helfrich <s.helfrich@fz-juelich.de>
+ */
+@Plugin(type = Ops.Threshold.Sauvola.class, name = Ops.Threshold.Sauvola.NAME)
+public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
+	implements Ops.Threshold.Sauvola
+{
+
+	@Parameter
+	private double k = 0.5d;
+	
+	@Parameter
+	private double r = 128.0d;
+
+	@Parameter
+	boolean doIwhite = true;
+	
+	@Parameter
+	private OpService ops;
+
+	private MeanOp<Iterable<T>, DoubleType> mean;
+	private VarianceOp<T, DoubleType> var;
+
+	@Override
+	public void compute(final Pair<T> input, final BitType output) {
+		// Sauvola recommends K_VALUE = 0.5 and R_VALUE = 128.
+		// This is a modification of Niblack's thresholding method.
+		// Sauvola J. and Pietaksinen M. (2000) "Adaptive Document Image Binarization"
+		// Pattern Recognition, 33(2): 225-236
+		// http://www.ee.oulu.fi/mvg/publications/show_pdf.php?ID=24
+		// Ported to ImageJ plugin from E Celebi's fourier_0.8 routines
+		// This version uses a circular local window, instead of a rectagular one		
+		if (mean == null) {
+			mean = ops.op(MeanOp.class, DoubleType.class, input.neighborhood);
+		}
+		if (var == null) {
+			var = ops.op(VarianceOp.class, DoubleType.class, input.neighborhood);
+		}
+		
+		final DoubleType meanValue = new DoubleType();
+		mean.compute(input.neighborhood, meanValue);
+		
+		final DoubleType varianceValue = new DoubleType();
+		var.compute(input.neighborhood, varianceValue);
+		
+		double threshold = meanValue.get() * (1.0d + k * ((Math.sqrt(varianceValue.get())/r) - 1.0));
+		
+		if (doIwhite){
+			output.set(input.pixel.getRealDouble() > threshold);
+		}
+		else {
+			output.set(input.pixel.getRealDouble() < threshold);
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
@@ -12,14 +12,13 @@ import net.imglib2.type.numeric.real.DoubleType;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-import ij.IJ;
-import ij.ImagePlus;
-import ij.plugin.filter.RankFilters;
-import ij.process.ImageConverter;
-import ij.process.ImageProcessor;
-
 /**
- * TODO Documentation
+ * This is a modification of Niblack's thresholding method.
+ * Sauvola J. and Pietaksinen M. (2000) "Adaptive Document Image Binarization"
+ * Pattern Recognition, 33(2): 225-236
+ * http://www.ee.oulu.fi/mvg/publications/show_pdf.php?ID=24
+ * Ported to ImageJ plugin from E Celebi's fourier_0.8 routines.
+ * Original ImageJ1 implementation by Gabriel Landini.
  * 
  * @author Stefan Helfrich <s.helfrich@fz-juelich.de>
  */
@@ -46,12 +45,7 @@ public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	@Override
 	public void compute(final Pair<T> input, final BitType output) {
 		// Sauvola recommends K_VALUE = 0.5 and R_VALUE = 128.
-		// This is a modification of Niblack's thresholding method.
-		// Sauvola J. and Pietaksinen M. (2000) "Adaptive Document Image Binarization"
-		// Pattern Recognition, 33(2): 225-236
-		// http://www.ee.oulu.fi/mvg/publications/show_pdf.php?ID=24
-		// Ported to ImageJ plugin from E Celebi's fourier_0.8 routines
-		// This version uses a circular local window, instead of a rectagular one		
+
 		if (mean == null) {
 			mean = ops.op(MeanOp.class, DoubleType.class, input.neighborhood);
 		}

--- a/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/sauvola/Sauvola.java
@@ -8,6 +8,7 @@ import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -29,7 +30,7 @@ public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 
 	@Parameter
 	private double k = 0.5d;
-	
+
 	@Parameter
 	private double r = 128.0d;
 
@@ -40,21 +41,21 @@ public class Sauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	private VarianceOp<T, DoubleType> var;
 
 	@Override
-	public void compute(final Pair<T> input, final BitType output) {
+	public void compute(final Pair<T, Iterable<T>> input, final BitType output) {
 		// Sauvola recommends K_VALUE = 0.5 and R_VALUE = 128.
 
 		if (mean == null) {
-			mean = ops.op(MeanOp.class, DoubleType.class, input.neighborhood);
+			mean = ops.op(MeanOp.class, DoubleType.class, input.getB());
 		}
 		if (var == null) {
-			var = ops.op(VarianceOp.class, DoubleType.class, input.neighborhood);
+			var = ops.op(VarianceOp.class, DoubleType.class, input.getB());
 		}
 		
 		final DoubleType meanValue = new DoubleType();
-		mean.compute(input.neighborhood, meanValue);
+		mean.compute(input.getB(), meanValue);
 		
 		final DoubleType varianceValue = new DoubleType();
-		var.compute(input.neighborhood, varianceValue);
+		var.compute(input.getB(), varianceValue);
 		
 		double threshold = meanValue.get() * (1.0d + k * ((Math.sqrt(varianceValue.get())/r) - 1.0));
 		

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -313,7 +313,6 @@ namespaces = ```
 		[name: "shanbhag",                    iface: "Shanbhag"],
 		[name: "triangle",                    iface: "Triangle"],
 		[name: "yen",                         iface: "Yen"],
-		[name: "sauvola",                     iface: "Sauvola"],
 	]],
 	[name: "zernike", iface: "Zernike", ops: [
 		[name: "magnitude",                iface: "Magnitude"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -300,6 +300,7 @@ namespaces = ```
 		[name: "localMidGrey",                iface: "LocalMidGrey"],
 		[name: "localNiblack",                iface: "LocalNiblack"],
 		[name: "localPhansalkar",             iface: "LocalPhansalkar"],
+		[name: "localSauvola",                iface: "LocalSauvola"],
 		[name: "maxEntropy",                  iface: "MaxEntropy"],
 		[name: "maxLikelihood",               iface: "MaxLikelihood"],
 		[name: "mean",                        iface: "Mean"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -312,6 +312,7 @@ namespaces = ```
 		[name: "shanbhag",                    iface: "Shanbhag"],
 		[name: "triangle",                    iface: "Triangle"],
 		[name: "yen",                         iface: "Yen"],
+		[name: "sauvola",                     iface: "Sauvola"],
 	]],
 	[name: "zernike", iface: "Zernike", ops: [
 		[name: "magnitude",                iface: "Magnitude"],

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -102,6 +102,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.threshold().localPhansalkar(out, in, 0.25, 0.5);
 		ops.threshold().localPhansalkar(out, in);
 		ops.threshold().localSauvola(out, in, 0.5, 0.5);
+		ops.threshold().localSauvola(out, in);
 	}
 
 	/**

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -43,11 +43,8 @@ import net.imagej.ops.threshold.localMean.LocalMean;
 import net.imagej.ops.threshold.localMedian.LocalMedian;
 import net.imagej.ops.threshold.localMidGrey.LocalMidGrey;
 import net.imagej.ops.threshold.localNiblack.LocalNiblack;
-<<<<<<< HEAD
 import net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar;
-=======
 import net.imagej.ops.threshold.localSauvola.LocalSauvola;
->>>>>>> Added tests for LocalSauvola
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
@@ -104,7 +101,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.threshold().localNiblack(out, in, 1.0, 2.0);
 		ops.threshold().localPhansalkar(out, in, 0.25, 0.5);
 		ops.threshold().localPhansalkar(out, in);
-		ops.threshold().localSauvola(out, in, 0.5, 128.0);
+		ops.threshold().localSauvola(out, in, 0.5, 0.5);
 	}
 
 	/**

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -43,7 +43,11 @@ import net.imagej.ops.threshold.localMean.LocalMean;
 import net.imagej.ops.threshold.localMedian.LocalMedian;
 import net.imagej.ops.threshold.localMidGrey.LocalMidGrey;
 import net.imagej.ops.threshold.localNiblack.LocalNiblack;
+<<<<<<< HEAD
 import net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar;
+=======
+import net.imagej.ops.threshold.localSauvola.LocalSauvola;
+>>>>>>> Added tests for LocalSauvola
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
@@ -100,6 +104,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.threshold().localNiblack(out, in, 1.0, 2.0);
 		ops.threshold().localPhansalkar(out, in, 0.25, 0.5);
 		ops.threshold().localPhansalkar(out, in);
+		ops.threshold().localSauvola(out, in, 0.5, 128.0);
 	}
 
 	/**
@@ -208,8 +213,24 @@ public class LocalThresholdTest extends AbstractOpTest {
 			in,
 			ops.op(LocalPhansalkar.class, BitType.class,
 				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
-			new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+				new RectangleShape(3, false),
+				new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**	 
+	 * @see LocalSauvola
+	 */
+	@Test
+	public void testLocalSauvola() {
+		ops.threshold().apply(
+			out,
+			in,
+			ops.op(LocalSauvola.class, BitType.class,
+				new ValuePair<ByteType, Iterable<ByteType>>(null, null), 0.0, 0.0),
+				new RectangleShape(3, false),
+				new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
 		assertEquals(out.firstElement().get(), false);
 	}

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -213,8 +213,8 @@ public class LocalThresholdTest extends AbstractOpTest {
 			in,
 			ops.op(LocalPhansalkar.class, BitType.class,
 				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
-				new RectangleShape(3, false),
-				new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+			new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
 		assertEquals(out.firstElement().get(), false);
 	}
@@ -228,9 +228,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalSauvola.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, null), 0.0, 0.0),
-				new RectangleShape(3, false),
-				new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
+			new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
 		assertEquals(out.firstElement().get(), false);
 	}


### PR DESCRIPTION
This is an Ops implementation of Sauvola's local thresholding method as originally implemented by Gabriel Landini in the Auto_Local_Threshold plugin of IJ1 (http://fiji.sc/Auto_Local_Threshold#Phansalkar).

Open questions:
- Currently, the input is not checked for correct normalization to the [0, 1] range. Is that something that should be added in the Op itself?
- How to properly handle two optional parameters in the (Threshold)Namespace if they cannot be discriminated by type (and hence different method signatures); see https://github.com/imagej/imagej-ops/pull/225#issuecomment-143161603 and following