### PR TITLE
Add fusion op to fuse (overlapping) RAI's

### DIFF
--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -184,6 +184,27 @@ public class ImageNamespace extends AbstractNamespace {
 				net.imagej.ops.image.equation.DefaultEquation.class, out, in);
 		return result;
 	}
+	
+	// -- fusion --
+	
+	@OpMethod(op = net.imagej.ops.image.fusion.MinFusion.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<T> fuseMin(final RandomAccessibleInterval<T> in,
+			final RandomAccessibleInterval<T> in2, final long... offset) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(net.imagej.ops.image.fusion.MinFusion.class, in, in2, offset);
+		return result;
+	}
+	
+	
+	@OpMethod(op = net.imagej.ops.image.fusion.MaxFusion.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<T> fuseMax(final RandomAccessibleInterval<T> in, 
+			final RandomAccessibleInterval<T> in2, final long... offset) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(net.imagej.ops.image.fusion.MaxFusion.class, in, in2, offset);
+		return result;
+	}
 
 	// -- histogram --
 

--- a/src/main/java/net/imagej/ops/image/fusion/AbstractFusionOp.java
+++ b/src/main/java/net/imagej/ops/image/fusion/AbstractFusionOp.java
@@ -1,0 +1,104 @@
+package net.imagej.ops.image.fusion;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+
+import net.imagej.ops.AbstractFunctionOp;
+import net.imagej.ops.OpService;
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+public abstract class AbstractFusionOp<T extends RealType<T>>
+		extends AbstractFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
+
+	@Parameter(type = ItemIO.INPUT)
+	protected RandomAccessibleInterval<T> in2;
+
+	@Parameter(type = ItemIO.INPUT)
+	protected long[] offset;
+
+	@Parameter
+	protected OpService ops;
+
+	@Override
+	public RandomAccessibleInterval<T> compute(RandomAccessibleInterval<T> in1) {
+		FinalInterval outInterval = calculateOutputSize(in1, in2, offset);
+
+		// extend img1 with the value the selected op needs to calculate the
+		// fusion
+		T extensionValue = getExtensionValue(in2.randomAccess().get().createVariable());
+		RandomAccess<T> img1 = Views.extendValue(in1, extensionValue).randomAccess();
+
+		// extend in2 with the same criteria and move
+		// in2 such that in1 and in2 have the same point in their origin
+		RandomAccess<T> img2 = Views.offset(Views.extendValue(in2, extensionValue), offset).randomAccess();
+
+		@SuppressWarnings("unchecked")
+		T type = (T) ops.create().nativeType(img1.get().getClass());
+		Img<T> outImg = ops.create().img(outInterval, type);
+		Cursor<T> outCursor = outImg.localizingCursor();
+		long[] pos = new long[outImg.numDimensions()];
+		long[] img1Pos = new long[outImg.numDimensions()];
+		long[] img2Pos = new long[outImg.numDimensions()];
+		while (outCursor.hasNext()) {
+			outCursor.fwd();
+			outCursor.localize(pos);
+
+			// moving cursor positions according to the offset, otherwise we
+			// miss the real origin in certain situations
+			img1Pos = updatePosition(pos, offset);
+			img2Pos = updatePosition(pos, offset);
+
+			img1.setPosition(img1Pos);
+			img2.setPosition(img2Pos);
+
+			T img1Value = img1.get();
+			T img2Value = img2.get();
+
+			outCursor.get().set(getPixelValue(img1Value, img2Value));
+		}
+		return outImg;
+	}
+
+	private FinalInterval calculateOutputSize(RandomAccessibleInterval<T> input1, RandomAccessibleInterval<T> input2,
+			long[] offset) {
+		long[] outImgsize = new long[input1.numDimensions()];
+		for (int i = 0; i < input1.numDimensions(); i++) {
+			outImgsize[i] = input1.dimension(i) + input2.dimension(i) - (input1.dimension(i) - Math.abs(offset[i]));
+		}
+
+		FinalInterval outInterval = Intervals.createMinMax(0, 0, outImgsize[0], outImgsize[1]);
+		return outInterval;
+	}
+
+	private long[] updatePosition(long[] currentPosition, long[] offset) {
+		long[] newPosition = new long[currentPosition.length];
+		newPosition[0] = currentPosition[0];
+		newPosition[1] = currentPosition[1];
+
+		if (offset[0] > -1) {
+			newPosition[0] -= offset[0];
+		}
+		if (offset[1] > -1) {
+			newPosition[1] -= offset[1];
+		}
+		return newPosition;
+	}
+
+	public abstract T getPixelValue(T in1, T in2);
+
+	/**
+	 * Sets the parameter to the value the
+	 * 
+	 * @param type
+	 *            a T which shall hold the extension
+	 * @return the T set to the extension value
+	 */
+	public abstract T getExtensionValue(T type);
+}

--- a/src/main/java/net/imagej/ops/image/fusion/MaxFusion.java
+++ b/src/main/java/net/imagej/ops/image/fusion/MaxFusion.java
@@ -1,0 +1,27 @@
+package net.imagej.ops.image.fusion;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Image.FuseMax;
+import net.imglib2.type.numeric.RealType;
+
+@Plugin(type=Ops.Image.FuseMax.class, name=Ops.Image.FuseMax.NAME)
+public class MaxFusion<T extends RealType<T>> extends AbstractFusionOp<T> implements FuseMax {
+
+	@Override
+	public T getPixelValue(T in1, T in2) {
+        if (in1.compareTo(in2) > 0) {
+            return in1;
+        } else {
+            return in2;
+        }
+	}
+
+	@Override
+	public T getExtensionValue(T in) {
+		in.setZero();
+		return in;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/image/fusion/MinFusion.java
+++ b/src/main/java/net/imagej/ops/image/fusion/MinFusion.java
@@ -1,0 +1,26 @@
+package net.imagej.ops.image.fusion;
+
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Image.FuseMin;
+import net.imglib2.type.numeric.RealType;
+
+@Plugin(type = Ops.Image.FuseMin.class, name = Ops.Image.FuseMin.NAME)
+public class MinFusion<T extends RealType<T>> extends AbstractFusionOp<T>implements FuseMin {
+
+	@Override
+	public T getPixelValue(T in1, T in2) {
+		if (in1.compareTo(in2) < 0) {
+			return in1;
+		} else {
+			return in2;
+		}
+	}
+
+	@Override
+	public T getExtensionValue(T in) {
+		in.setReal(in.getMaxValue());
+		return in;
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -86,7 +86,9 @@ namespaces = ```
 		[name: "invert",             iface: "Invert"],
 		[name: "normalize",          iface: "Normalize",           aliases: ["norm"]],
 		[name: "project",            iface: "Project"],
-		[name: "scale",              iface: "Scale",               aliases: ["resize"]]
+		[name: "scale",              iface: "Scale",               aliases: ["resize"]],
+		[name: "fuseMin",            iface: "FuseMin"],
+		[name: "fuseMax",            iface: "FuseMax"],
 	]],
 	[name: "labeling",   iface: "Labeling", ops: [
 		[name: "cca",                iface: "CCA",                 aliases: ["connectedComponents", "connectedComponentAnalysis"]]


### PR DESCRIPTION
Provides two fusion methods:
- Fuse max (the larger pixel value is used, images are extended with zero)
- Fuse min (the smaller pixel value is used, images are extended with max value)

Images can be arranged arbitrary, the fusion type is for overlapping images and describes which pixel is used. 

Currently only works on 2d images, but could be extended to more.
Created by @EikeHeinz  and me.
