### PR TITLE
Fix copyimg bug

### DIFF
--- a/src/main/java/net/imagej/ops/copy/CopyImg.java
+++ b/src/main/java/net/imagej/ops/copy/CopyImg.java
@@ -76,7 +76,7 @@ public class CopyImg<T extends NativeType<T>> extends
 
 	@Override
 	public void compute(final Img<T> input, final Img<T> output) {
-		copyComputer.compute(output, input);
+		copyComputer.compute(input, output);
 	}
 
 	@Override

--- a/src/test/java/net/imagej/ops/copy/CopyImgTest.java
+++ b/src/test/java/net/imagej/ops/copy/CopyImgTest.java
@@ -69,32 +69,51 @@ public class CopyImgTest extends AbstractOpTest {
 
 	@Test
 	public void copyImgNoOutputTest() {
+		Img<DoubleType> inputCopy = input.factory().create(input, input.firstElement());
+		copy(input, inputCopy);
+		
 		@SuppressWarnings("unchecked")
 		RandomAccessibleInterval<DoubleType> output = (RandomAccessibleInterval<DoubleType>) ops
 				.run(CopyImg.class, input);
 
 		Cursor<DoubleType> inc = input.localizingCursor();
+		RandomAccess<DoubleType> inCopyRA = inputCopy.randomAccess();
 		RandomAccess<DoubleType> outRA = output.randomAccess();
 
 		while (inc.hasNext()) {
 			inc.fwd();
+			inCopyRA.setPosition(inc);
 			outRA.setPosition(inc);
 			assertEquals(inc.get().get(), outRA.get().get(), 0.0);
+			assertEquals(inc.get().get(), inCopyRA.get().get(), 0.0);
 		}
 	}
 
 	@Test
 	public void copyImgWithOutputTest() {
+		Img<DoubleType> inputCopy = input.factory().create(input, input.firstElement());
+		copy(input, inputCopy);
+		
 		Img<DoubleType> output = input.factory().create(input,
 				input.firstElement());
 
 		ops.run(CopyImg.class, output, input);
 
 		final Cursor<DoubleType> inc = input.cursor();
+		final Cursor<DoubleType> inCopyc = inputCopy.cursor();
 		final Cursor<DoubleType> outc = output.cursor();
 
 		while (inc.hasNext()) {
 			assertEquals(inc.next().get(), outc.next().get(), 0.0);
+			assertEquals(inc.get().get(), inCopyc.next().get(), 0.0);
+		}
+	}
+
+	private void copy(Img<DoubleType> from, Img<DoubleType> to) {
+		final Cursor<DoubleType> fromc = from.cursor();
+		final Cursor<DoubleType> toc = to.cursor();
+		while (fromc.hasNext()) {
+			toc.next().set(fromc.next().get());
 		}
 	}
 }

--- a/src/test/java/net/imagej/ops/copy/CopyImgTest.java
+++ b/src/test/java/net/imagej/ops/copy/CopyImgTest.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imagej.ops.copy;
 
 import static org.junit.Assert.assertEquals;
@@ -46,17 +47,17 @@ import org.junit.Test;
 
 /**
  * Test {@link CopyImg}.
- * 
- * @author Tim-Oliver Buchholz, University of Konstanz
  *
+ * @author Tim-Oliver Buchholz, University of Konstanz
  */
 public class CopyImgTest extends AbstractOpTest {
+
 	private Img<DoubleType> input;
 
 	@Before
 	public void createData() {
-		input = new ArrayImgFactory<DoubleType>().create(
-				new int[] { 120, 100 }, new DoubleType());
+		input = new ArrayImgFactory<DoubleType>().create(new int[] { 120, 100 },
+			new DoubleType());
 
 		final Random r = new Random(System.currentTimeMillis());
 
@@ -69,16 +70,17 @@ public class CopyImgTest extends AbstractOpTest {
 
 	@Test
 	public void copyImgNoOutputTest() {
-		Img<DoubleType> inputCopy = input.factory().create(input, input.firstElement());
+		final Img<DoubleType> inputCopy = input.factory().create(input, input
+			.firstElement());
 		copy(input, inputCopy);
-		
-		@SuppressWarnings("unchecked")
-		RandomAccessibleInterval<DoubleType> output = (RandomAccessibleInterval<DoubleType>) ops
-				.run(CopyImg.class, input);
 
-		Cursor<DoubleType> inc = input.localizingCursor();
-		RandomAccess<DoubleType> inCopyRA = inputCopy.randomAccess();
-		RandomAccess<DoubleType> outRA = output.randomAccess();
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<DoubleType> output =
+			(RandomAccessibleInterval<DoubleType>) ops.run(CopyImg.class, input);
+
+		final Cursor<DoubleType> inc = input.localizingCursor();
+		final RandomAccess<DoubleType> inCopyRA = inputCopy.randomAccess();
+		final RandomAccess<DoubleType> outRA = output.randomAccess();
 
 		while (inc.hasNext()) {
 			inc.fwd();
@@ -91,11 +93,12 @@ public class CopyImgTest extends AbstractOpTest {
 
 	@Test
 	public void copyImgWithOutputTest() {
-		Img<DoubleType> inputCopy = input.factory().create(input, input.firstElement());
+		final Img<DoubleType> inputCopy = input.factory().create(input, input
+			.firstElement());
 		copy(input, inputCopy);
-		
-		Img<DoubleType> output = input.factory().create(input,
-				input.firstElement());
+
+		final Img<DoubleType> output = input.factory().create(input, input
+			.firstElement());
 
 		ops.run(CopyImg.class, output, input);
 
@@ -109,7 +112,7 @@ public class CopyImgTest extends AbstractOpTest {
 		}
 	}
 
-	private void copy(Img<DoubleType> from, Img<DoubleType> to) {
+	private void copy(final Img<DoubleType> from, final Img<DoubleType> to) {
 		final Cursor<DoubleType> fromc = from.cursor();
 		final Cursor<DoubleType> toc = to.cursor();
 		while (fromc.hasNext()) {


### PR DESCRIPTION
@ctrueden @dietzc There is a small bug in the CopyImg Op. Its compute() method copy the output into the input, Since the unit test only checks the equality between the latest copy of the input and output, so the bug is not detected. Now I modify the unit test so that I first copy the input by iteration, and then compare the output to the copy-by-iteration input.