### PR TITLE
Remove unnecessary parameter of OpService

### DIFF
--- a/src/main/java/net/imagej/ops/commands/threshold/GlobalThresholder.java
+++ b/src/main/java/net/imagej/ops/commands/threshold/GlobalThresholder.java
@@ -56,9 +56,6 @@ public class GlobalThresholder<T extends RealType<T>> extends AbstractOp {
     @Parameter
     private ComputeThreshold<ImgPlus<T>,T> method;
 
-    @Parameter
-    private OpService ops;
-
     // should not be Dataset, DisplayService, ...
     @Parameter
     private ImgPlus<T> in;
@@ -72,10 +69,10 @@ public class GlobalThresholder<T extends RealType<T>> extends AbstractOp {
 
     @Override
     public void run() {
-        Op threshold = ops.op("threshold", out, in, method);
+        Op threshold = ops().op("threshold", out, in, method);
 
         // TODO actually map axes to int array
-        ops.slicewise(out, in, threshold, new int[]{0, 1});
+        ops().slicewise(out, in, threshold, new int[]{0, 1});
     }
     
     // TODO call otsu: out = ops.run(GlobalThresholder.class, ops.ops(Otsu...),in).

--- a/src/main/java/net/imagej/ops/copy/CopyImg.java
+++ b/src/main/java/net/imagej/ops/copy/CopyImg.java
@@ -34,13 +34,11 @@ import net.imagej.ops.AbstractHybridOp;
 import net.imagej.ops.ComputerOp;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.FunctionOp;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Intervals;
 
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -53,9 +51,6 @@ import org.scijava.plugin.Plugin;
 @Plugin(type = Ops.Copy.Img.class)
 public class CopyImg<T extends NativeType<T>> extends
 		AbstractHybridOp<Img<T>, Img<T>> implements Ops.Copy.Img, Contingent {
-
-	@Parameter
-	private OpService ops;
 	
 	private ComputerOp<Iterable<T>, Iterable<T>> copyComputer;
 
@@ -64,7 +59,7 @@ public class CopyImg<T extends NativeType<T>> extends
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
-		copyComputer = (ComputerOp)ops.computer(CopyIterableInterval.class, in(), in());
+		copyComputer = (ComputerOp)ops().computer(CopyIterableInterval.class, in(), in());
 		createFunc = (FunctionOp) ops().function(Ops.Create.Img.class, Img.class, 
 				in());
 	}

--- a/src/main/java/net/imagej/ops/copy/CopyImgLabeling.java
+++ b/src/main/java/net/imagej/ops/copy/CopyImgLabeling.java
@@ -33,7 +33,6 @@ package net.imagej.ops.copy;
 import net.imagej.ops.AbstractHybridOp;
 import net.imagej.ops.ComputerOp;
 import net.imagej.ops.Contingent;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.roi.labeling.ImgLabeling;
@@ -43,7 +42,6 @@ import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -56,9 +54,6 @@ import org.scijava.plugin.Plugin;
 public class CopyImgLabeling<T extends IntegerType<T> & NativeType<T>, L>
 		extends AbstractHybridOp<ImgLabeling<L, T>, ImgLabeling<L, T>>
 		implements Ops.Copy.ImgLabeling, Contingent {
-
-	@Parameter
-	private OpService ops;
 	
 	
 	private ComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> raiCopyOp;
@@ -73,7 +68,7 @@ public class CopyImgLabeling<T extends IntegerType<T> & NativeType<T>, L>
 	
 	@Override
 	public ImgLabeling<L, T> createOutput(final ImgLabeling<L, T> input) {
-		return ops.create().imgLabeling(input);
+		return ops().create().imgLabeling(input);
 	}
 
 	

--- a/src/main/java/net/imagej/ops/copy/CopyLabelingMapping.java
+++ b/src/main/java/net/imagej/ops/copy/CopyLabelingMapping.java
@@ -34,13 +34,11 @@ import java.util.List;
 import java.util.Set;
 
 import net.imagej.ops.AbstractHybridOp;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imglib2.roi.labeling.LabelingMapping;
 import net.imglib2.roi.labeling.LabelingMapping.SerialisationAccess;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -55,12 +53,9 @@ public class CopyLabelingMapping<L> extends
 		AbstractHybridOp<LabelingMapping<L>, LabelingMapping<L>> implements
 		Ops.Copy.LabelingMapping {
 
-	@Parameter
-	private OpService ops;
-
 	@Override
 	public LabelingMapping<L> createOutput(final LabelingMapping<L> input) {
-		return ops.create().labelingMapping(input.numSets());
+		return ops().create().labelingMapping(input.numSets());
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultMarchingCubes.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultMarchingCubes.java
@@ -73,9 +73,6 @@ public class DefaultMarchingCubes<T extends BooleanType<T>> extends
 	private VertexInterpolator interpolatorClass =
 		new BitTypeVertexInterpolator();
 
-	@Parameter
-	private OpService ops;
-
 	@SuppressWarnings({ "unchecked" })
 	@Override
 	public DefaultMesh compute(final RandomAccessibleInterval<T> input) {

--- a/src/main/java/net/imagej/ops/help/HelpForNamespace.java
+++ b/src/main/java/net/imagej/ops/help/HelpForNamespace.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpInfo;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 
 import org.scijava.Priority;
@@ -53,14 +52,11 @@ import org.scijava.plugin.Plugin;
 public class HelpForNamespace extends AbstractHelp {
 
 	@Parameter
-	private OpService ops;
-
-	@Parameter
 	private Namespace namespace;
 
 	@Override
 	public void run() {
-		final Collection<OpInfo> allOps = ops.infos();
+		final Collection<OpInfo> allOps = ops().infos();
 		final List<OpInfo> requestedOps = new ArrayList<OpInfo>();
 
 		for (final OpInfo info : allOps) {

--- a/src/main/java/net/imagej/ops/image/project/DefaultProjectParallel.java
+++ b/src/main/java/net/imagej/ops/image/project/DefaultProjectParallel.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import net.imagej.ops.AbstractComputerOp;
 import net.imagej.ops.ComputerOp;
 import net.imagej.ops.Contingent;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.ChunkerOp;
@@ -56,9 +55,6 @@ public class DefaultProjectParallel<T, V> extends
 {
 
 	@Parameter
-	private OpService opService;
-
-	@Parameter
 	private ComputerOp<Iterable<T>, V> method;
 
 	// dimension which will be projected
@@ -69,7 +65,7 @@ public class DefaultProjectParallel<T, V> extends
 	public void compute(final RandomAccessibleInterval<T> input,
 		final IterableInterval<V> output)
 	{
-		opService.run(ChunkerOp.class, new CursorBasedChunk() {
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
 			public void

--- a/src/main/java/net/imagej/ops/map/MapIterableToIterableParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableToIterableParallel.java
@@ -32,7 +32,6 @@ package net.imagej.ops.map;
 
 import net.imagej.ops.ComputerOp;
 import net.imagej.ops.Contingent;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.ChunkerOp;
@@ -41,7 +40,6 @@ import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -57,9 +55,6 @@ public class MapIterableToIterableParallel<A, B> extends
 	AbstractMapComputer<A, B, IterableInterval<A>, IterableInterval<B>> implements
 	Contingent, Parallel
 {
-
-	@Parameter
-	private OpService opService;
 
 	@Override
 	public boolean conforms() {
@@ -81,7 +76,7 @@ public class MapIterableToIterableParallel<A, B> extends
 				"Input and Output do not have the same iteration order!");
 		}
 
-		opService.run(ChunkerOp.class, new CursorBasedChunk() {
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
 			public void execute(final int startIndex, final int stepSize,

--- a/src/main/java/net/imagej/ops/map/MapIterableToRAIParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableToRAIParallel.java
@@ -31,7 +31,6 @@
 package net.imagej.ops.map;
 
 import net.imagej.ops.ComputerOp;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.ChunkerOp;
@@ -42,7 +41,6 @@ import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -58,14 +56,11 @@ public class MapIterableToRAIParallel<A, B> extends
 	implements Parallel
 {
 
-	@Parameter
-	private OpService opService;
-
 	@Override
 	public void compute(final IterableInterval<A> input,
 		final RandomAccessibleInterval<B> output)
 	{
-		opService.run(ChunkerOp.class, new CursorBasedChunk() {
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
 			public void execute(final int startIndex, final int stepSize,

--- a/src/main/java/net/imagej/ops/map/MapParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapParallel.java
@@ -31,7 +31,6 @@
 package net.imagej.ops.map;
 
 import net.imagej.ops.ComputerOp;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.ChunkerOp;
@@ -40,7 +39,6 @@ import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -54,12 +52,9 @@ public class MapParallel<A> extends
 	AbstractMapInplace<A, IterableInterval<A>> implements Parallel
 {
 
-	@Parameter
-	private OpService opService;
-
 	@Override
 	public void compute(final IterableInterval<A> arg) {
-		opService.run(ChunkerOp.class, new CursorBasedChunk() {
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
 			public void execute(final int startIndex, final int stepSize,

--- a/src/main/java/net/imagej/ops/threshold/localMean/LocalMean.java
+++ b/src/main/java/net/imagej/ops/threshold/localMean/LocalMean.java
@@ -31,7 +31,6 @@
 package net.imagej.ops.threshold.localMean;
 
 import net.imagej.ops.ComputerOp;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
@@ -55,15 +54,12 @@ public class LocalMean<T extends RealType<T>> extends LocalThresholdMethod<T>
 
 	@Parameter
 	private double c;
-
-	@Parameter
-	private OpService ops;
 	
 	private ComputerOp<Iterable<T>, DoubleType> mean;
 
 	@Override
 	public void initialize() {
-			mean =  ops.computer(Ops.Stats.Mean.class, DoubleType.class, in().getB());
+			mean =  ops().computer(Ops.Stats.Mean.class, DoubleType.class, in().getB());
 	}
 	
 	@Override

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -76,9 +76,6 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 	@Parameter(required = false)
 	private double r = 0.5;
 
-	@Parameter
-	private OpService ops;
-
 	// FIXME: Faster calculation of mean and std-dev
 	private ComputerOp<Iterable<T>, DoubleType> mean;
 	private ComputerOp<Iterable<T>, DoubleType> stdDeviation;

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -70,9 +70,6 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 	@Parameter(required = false)
 	private double r = 0.5d;
 
-	@Parameter
-	private OpService ops;
-
 	// FIXME: Faster calculation of mean and std-dev.
 	private ComputerOp<Iterable<T>, DoubleType> mean;
 	private ComputerOp<Iterable<T>, DoubleType> stdDeviation;

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
@@ -73,9 +73,6 @@ public final class ConstantToArrayImageP {
 	 */
 	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY#if ($type.name == "Double") + 11#else + 10#end)
 	public static class ${op.name}${type.name} extends AbstractOp implements $iface {
-		
-		@Parameter
-		private OpService opService;
 
 		@Parameter(type = ItemIO.BOTH)
 		private ArrayImg<${type.name}Type, ${type.name}Array> image;
@@ -86,7 +83,7 @@ public final class ConstantToArrayImageP {
 		@Override
 		public void run() {
 			final ${type.primitive}[] data = image.update(null).getCurrentStorageArray();
-			opService.run(ChunkerOp.class, new Chunk() {
+			ops().run(ChunkerOp.class, new Chunk() {
 
 				@Override
 				public void execute(final int startIndex, final int stepSize,

--- a/src/test/java/net/imagej/ops/thread/RunDefaultChunker.java
+++ b/src/test/java/net/imagej/ops/thread/RunDefaultChunker.java
@@ -31,7 +31,6 @@ package net.imagej.ops.thread;
 
 import net.imagej.ops.AbstractComputerOp;
 import net.imagej.ops.Op;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.CursorBasedChunk;
 import net.imagej.ops.thread.chunker.DefaultChunker;
@@ -40,7 +39,6 @@ import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 @Plugin(type = Op.class, name = "test.chunker",
@@ -50,15 +48,12 @@ public class RunDefaultChunker<A extends RealType<A>> extends
 	Parallel
 {
 
-	@Parameter
-	private OpService opService;
-
 
 	@Override
 	public void compute(final IterableInterval<A> input,
 		final IterableInterval<A> output)
 	{
-		opService.run(DefaultChunker.class, new CursorBasedChunk() {
+		ops().run(DefaultChunker.class, new CursorBasedChunk() {
 
 			@Override
 			public void

--- a/src/test/java/net/imagej/ops/thread/RunDefaultChunkerArray.java
+++ b/src/test/java/net/imagej/ops/thread/RunDefaultChunkerArray.java
@@ -31,13 +31,11 @@ package net.imagej.ops.thread;
 
 import net.imagej.ops.AbstractComputerOp;
 import net.imagej.ops.Op;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.Chunk;
 import net.imagej.ops.thread.chunker.DefaultChunker;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 @Plugin(type = Op.class, name = "test.chunker",
@@ -45,13 +43,10 @@ import org.scijava.plugin.Plugin;
 public class RunDefaultChunkerArray<A> extends AbstractComputerOp<A[], A[]>
 	implements Parallel
 {
-
-	@Parameter
-	private OpService opService;
 	
 	@Override
 	public void compute(final A[] input, final A[] output) {
-		opService.run(DefaultChunker.class, new Chunk() {
+		ops().run(DefaultChunker.class, new Chunk() {
 
 			@Override
 			public void

--- a/src/test/java/net/imagej/ops/thread/RunInterleavedChunker.java
+++ b/src/test/java/net/imagej/ops/thread/RunInterleavedChunker.java
@@ -31,7 +31,6 @@ package net.imagej.ops.thread;
 
 import net.imagej.ops.AbstractComputerOp;
 import net.imagej.ops.Op;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.ChunkerInterleaved;
 import net.imagej.ops.thread.chunker.CursorBasedChunk;
@@ -40,7 +39,6 @@ import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 @Plugin(type = Op.class, name = "test.chunker",
@@ -49,15 +47,12 @@ public class RunInterleavedChunker<A extends RealType<A>> extends
 	AbstractComputerOp<IterableInterval<A>, IterableInterval<A>> implements
 	Parallel
 {
-
-	@Parameter
-	private OpService opService;
 	
 	@Override
 	public void compute(final IterableInterval<A> input,
 		final IterableInterval<A> output)
 	{
-		opService.run(ChunkerInterleaved.class, new CursorBasedChunk() {
+		ops().run(ChunkerInterleaved.class, new CursorBasedChunk() {
 
 			@Override
 			public void

--- a/src/test/java/net/imagej/ops/thread/RunInterleavedChunkerArray.java
+++ b/src/test/java/net/imagej/ops/thread/RunInterleavedChunkerArray.java
@@ -31,13 +31,11 @@ package net.imagej.ops.thread;
 
 import net.imagej.ops.AbstractComputerOp;
 import net.imagej.ops.Op;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Parallel;
 import net.imagej.ops.thread.chunker.Chunk;
 import net.imagej.ops.thread.chunker.ChunkerInterleaved;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 @Plugin(type = Op.class, name = "test.chunker",
@@ -45,13 +43,10 @@ import org.scijava.plugin.Plugin;
 public class RunInterleavedChunkerArray<A> extends
 	AbstractComputerOp<A[], A[]> implements Parallel
 {
-
-	@Parameter
-	private OpService opService;
 	
 	@Override
 	public void compute(final A[] input, final A[] output) {
-		opService.run(ChunkerInterleaved.class, new Chunk() {
+		ops().run(ChunkerInterleaved.class, new Chunk() {
 
 			@Override
 			public void


### PR DESCRIPTION
This commit removes all the parameter of OpService that can be replaced by calling ops() instead. The import is modified accordingly in each class.