### PR TITLE
Fix bug in benchmark tests

### DIFF
--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -86,7 +86,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void fTtestAddConstantToImage() {
-		ops.run(new ConstantToImageFunctional.Add<ByteType>(), out, in,
+		ops.run(ConstantToImageFunctional.Add.class, out, in,
 			new ByteType((byte) 10));
 	}
 
@@ -98,17 +98,17 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void inTestAddConstantToImageInPlace() {
-		ops.run(new ConstantToImageInPlace.Add<ByteType>(), in, new ByteType(
+		ops.run(ConstantToImageInPlace.Add.class, in, new ByteType(
 			(byte) 10));
 	}
 
 	@Test
 	public void inTestAddConstantToArrayByteImage() {
-		ops.run(new ConstantToArrayImage.AddByte(), in, (byte) 10);
+		ops.run(ConstantToArrayImage.AddByte.class, in, (byte) 10);
 	}
 
 	@Test
 	public void inTestAddConstantToArrayByteImageP() {
-		ops.run(new ConstantToArrayImageP.AddByte(), in, (byte) 10);
+		ops.run(ConstantToArrayImageP.AddByte.class, in, (byte) 10);
 	}
 }

--- a/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
@@ -80,32 +80,32 @@ public class MappersBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void pixelWiseTestMapper() {
-		ops.run(new MapIterableIntervalToRAI<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(MapIterableIntervalToRAI.class, out, in, addConstant);
 	}
 
 	@Test
 	public void pixelWiseTestMapperII() {
-		ops.run(new MapIterableIntervalToIterableInterval<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(MapIterableIntervalToIterableInterval.class, out, in, addConstant);
 	}
 
 	@Test
 	public void pixelWiseTestThreadedMapper() {
-		ops.run(new MapIterableIntervalToRAIParallel<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(MapIterableIntervalToRAIParallel.class, out, in, addConstant);
 	}
 
 	@Test
 	public void pixelWiseTestThreadedMapperII() {
-		ops.run(new MapIterableIntervalToIterableIntervalParallel<ByteType, ByteType>(),
+		ops.run(MapIterableIntervalToIterableIntervalParallel.class,
 			out, in, addConstant, out);
 	}
 
 	@Test
 	public void pixelWiseTestMapperInplace() {
-		ops.run(new MapIterableInplace<ByteType>(), in, addConstantInplace);
+		ops.run(MapIterableInplace.class, in, addConstantInplace);
 	}
 
 	@Test
 	public void pixelWiseTestThreadedMapperInplace() {
-		ops.run(new MapIterableIntervalInplaceParallel<ByteType>(), in.copy(), addConstantInplace);
+		ops.run(MapIterableIntervalInplaceParallel.class, in.copy(), addConstantInplace);
 	}
 }


### PR DESCRIPTION
The benchmark tests are out of date, and therefore in many places they
run Ops using constructors, which causes problems.