### PR TITLE
Rename MapIterableToRAIParallel

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -540,7 +540,7 @@ public interface OpEnvironment extends Contextual {
 		IterableInterval<A> in, ComputerOp<A, B> op);
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.map.MapIterableToRAIParallel.class,
+	@OpMethod(ops = { net.imagej.ops.map.MapIterableIntervalToRAIParallel.class,
 		net.imagej.ops.map.MapIterableIntervalToRAI.class })
 	<A, B> RandomAccessibleInterval<B> map(RandomAccessibleInterval<B> out,
 		IterableInterval<A> in, ComputerOp<A, B> op);

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalToRAIParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalToRAIParallel.java
@@ -51,7 +51,7 @@ import org.scijava.plugin.Plugin;
  * @param <B> mapped from {@code <A>}
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 2)
-public class MapIterableToRAIParallel<A, B> extends
+public class MapIterableIntervalToRAIParallel<A, B> extends
 	AbstractMapComputer<A, B, IterableInterval<A>, RandomAccessibleInterval<B>>
 	implements Parallel
 {

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -34,7 +34,7 @@ import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 
 import net.imagej.ops.map.MapIterableToIterableParallel;
-import net.imagej.ops.map.MapIterableToRAIParallel;
+import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
 import net.imagej.ops.map.MapParallel;
 import net.imagej.ops.math.ConstantToArrayImage;
 import net.imagej.ops.math.ConstantToArrayImageP;
@@ -80,7 +80,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void fTestDefaultMapperP() {
-		ops.run(MapIterableToRAIParallel.class, out, in, ops.op(
+		ops.run(MapIterableIntervalToRAIParallel.class, out, in, ops.op(
 			NumericTypeBinaryMath.Add.class, null, NumericType.class, new ByteType((byte) 10)));
 	}
 

--- a/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
@@ -39,7 +39,7 @@ import net.imagej.ops.map.MapIterableInplace;
 import net.imagej.ops.map.MapIterableIntervalToIterableInterval;
 import net.imagej.ops.map.MapIterableIntervalToRAI;
 import net.imagej.ops.map.MapIterableToIterableParallel;
-import net.imagej.ops.map.MapIterableToRAIParallel;
+import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
 import net.imagej.ops.map.MapParallel;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.NumericType;
@@ -53,7 +53,7 @@ import org.junit.rules.TestRule;
 /**
  * Benchmarking various implementations of mappers. Benchmarked since now:
  * {@link MapIterableIntervalToRAI}, {@link MapIterableIntervalToIterableInterval},
- * {@link MapIterableToRAIParallel}, {@link MapIterableToIterableParallel}
+ * {@link MapIterableIntervalToRAIParallel}, {@link MapIterableToIterableParallel}
  * 
  * @author Christian Dietz (University of Konstanz)
  */
@@ -90,7 +90,7 @@ public class MappersBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void pixelWiseTestThreadedMapper() {
-		ops.run(new MapIterableToRAIParallel<ByteType, ByteType>(), out, in, addConstant);
+		ops.run(new MapIterableIntervalToRAIParallel<ByteType, ByteType>(), out, in, addConstant);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
+++ b/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
@@ -44,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Testing multi threaded implementation ({@link MapIterableToRAIParallel} and
+ * Testing multi threaded implementation ({@link MapIterableIntervalToRAIParallel} and
  * {@link MapIterableToIterableParallel}) of the mappers. Assumption: Naive Implementation of
  * {@link MapIterableIntervalToRAI} works fine.
  * 
@@ -82,7 +82,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 	public void testFunctionMapIIRAIP() {
 
 		final Op functional =
-			ops.op(MapIterableToRAIParallel.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableIntervalToRAIParallel.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();


### PR DESCRIPTION
One of this Map's input type is actually IterableInterval instead of
Iterable, so its name is changed to MapIterableIntervalToRAIParallel.