### PR TITLE
Rename MapIterableIntervalInplaceParallel

### DIFF
--- a/src/main/java/net/imagej/ops/AbstractOpEnvironment.java
+++ b/src/main/java/net/imagej/ops/AbstractOpEnvironment.java
@@ -497,7 +497,7 @@ public abstract class AbstractOpEnvironment extends AbstractContextual
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<A> result =
-			(IterableInterval<A>) run(net.imagej.ops.map.MapIterableInplaceParallel.class, arg, op);
+			(IterableInterval<A>) run(net.imagej.ops.map.MapIterableIntervalInplaceParallel.class, arg, op);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -530,7 +530,7 @@ public interface OpEnvironment extends Contextual {
 		ComputerOp<A, B> op, B type);
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.map.MapIterableInplaceParallel.class)
+	@OpMethod(op = net.imagej.ops.map.MapIterableIntervalInplaceParallel.class)
 	<A> IterableInterval<A> map(IterableInterval<A> arg, InplaceOp<A> op);
 
 	/** Executes the "map" operation on the given arguments. */

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalInplaceParallel.java
@@ -48,7 +48,7 @@ import org.scijava.plugin.Plugin;
  * @param <A> mapped on <A>
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 5)
-public class MapIterableInplaceParallel<A> extends
+public class MapIterableIntervalInplaceParallel<A> extends
 	AbstractMapInplace<A, IterableInterval<A>> implements Parallel
 {
 

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -35,7 +35,7 @@ import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 
 import net.imagej.ops.map.MapIterableToIterableParallel;
 import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
-import net.imagej.ops.map.MapIterableInplaceParallel;
+import net.imagej.ops.map.MapIterableIntervalInplaceParallel;
 import net.imagej.ops.math.ConstantToArrayImage;
 import net.imagej.ops.math.ConstantToArrayImageP;
 import net.imagej.ops.math.ConstantToImageFunctional;
@@ -92,7 +92,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void inTestDefaultInplaceMapperP() {
-		ops.run(MapIterableInplaceParallel.class, in, ops.op(
+		ops.run(MapIterableIntervalInplaceParallel.class, in, ops.op(
 			AddConstantInplace.class, NumericType.class, new ByteType((byte) 10)));
 	}
 

--- a/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
@@ -40,7 +40,7 @@ import net.imagej.ops.map.MapIterableIntervalToIterableInterval;
 import net.imagej.ops.map.MapIterableIntervalToRAI;
 import net.imagej.ops.map.MapIterableToIterableParallel;
 import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
-import net.imagej.ops.map.MapIterableInplaceParallel;
+import net.imagej.ops.map.MapIterableIntervalInplaceParallel;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -106,6 +106,6 @@ public class MappersBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void pixelWiseTestThreadedMapperInplace() {
-		ops.run(new MapIterableInplaceParallel<ByteType>(), in.copy(), addConstantInplace);
+		ops.run(new MapIterableIntervalInplaceParallel<ByteType>(), in.copy(), addConstantInplace);
 	}
 }

--- a/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
+++ b/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
@@ -119,7 +119,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 		final Cursor<ByteType> cursor1 = in.copy().cursor();
 		final Cursor<ByteType> cursor2 = in.cursor();
 
-		final Op functional = ops.op(MapIterableInplaceParallel.class, in, new AddOneInplace());
+		final Op functional = ops.op(MapIterableIntervalInplaceParallel.class, in, new AddOneInplace());
 		functional.run();
 
 		while (cursor1.hasNext()) {


### PR DESCRIPTION
The old name of this MapOp is MapIterableInplaceParallel, but it actually accepts input of type IterableInterval.

This is not actually the parallel version of [MapIterableInplace](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/map/MapIterableInplace.java), since we cannot do parallel computing using `Iterable`, which could not `jumpFwd`.

This is actually the parallel version of `MapIterableIntervalInplace`, which does not exist since it can be safely run with `MapIterableInplace` with better performance.