### PR TITLE
Fix name of MapIterableIntervalToIterableIntervalParallel

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -534,7 +534,7 @@ public interface OpEnvironment extends Contextual {
 	<A> IterableInterval<A> map(IterableInterval<A> arg, InplaceOp<A> op);
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.map.MapIterableToIterableParallel.class,
+	@OpMethod(ops = { net.imagej.ops.map.MapIterableIntervalToIterableIntervalParallel.class,
 		net.imagej.ops.map.MapIterableIntervalToIterableInterval.class })
 	<A, B> IterableInterval<B> map(IterableInterval<B> out,
 		IterableInterval<A> in, ComputerOp<A, B> op);

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalToIterableIntervalParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalToIterableIntervalParallel.java
@@ -51,7 +51,7 @@ import org.scijava.plugin.Plugin;
  * @param <B> mapped from {@code <A>}
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 3)
-public class MapIterableToIterableParallel<A, B> extends
+public class MapIterableIntervalToIterableIntervalParallel<A, B> extends
 	AbstractMapComputer<A, B, IterableInterval<A>, IterableInterval<B>> implements
 	Contingent, Parallel
 {

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -33,7 +33,7 @@ package net.imagej.ops.benchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 
-import net.imagej.ops.map.MapIterableToIterableParallel;
+import net.imagej.ops.map.MapIterableIntervalToIterableIntervalParallel;
 import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
 import net.imagej.ops.map.MapIterableIntervalInplaceParallel;
 import net.imagej.ops.math.ConstantToArrayImage;
@@ -74,7 +74,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void fTestIterableIntervalMapperP() {
-		ops.run(MapIterableToIterableParallel.class, out, in, ops.op(
+		ops.run(MapIterableIntervalToIterableIntervalParallel.class, out, in, ops.op(
 			NumericTypeBinaryMath.Add.class, null, NumericType.class, new ByteType((byte) 10)));
 	}
 

--- a/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
@@ -38,7 +38,7 @@ import net.imagej.ops.Ops;
 import net.imagej.ops.map.MapIterableInplace;
 import net.imagej.ops.map.MapIterableIntervalToIterableInterval;
 import net.imagej.ops.map.MapIterableIntervalToRAI;
-import net.imagej.ops.map.MapIterableToIterableParallel;
+import net.imagej.ops.map.MapIterableIntervalToIterableIntervalParallel;
 import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
 import net.imagej.ops.map.MapIterableIntervalInplaceParallel;
 import net.imglib2.img.Img;
@@ -53,7 +53,7 @@ import org.junit.rules.TestRule;
 /**
  * Benchmarking various implementations of mappers. Benchmarked since now:
  * {@link MapIterableIntervalToRAI}, {@link MapIterableIntervalToIterableInterval},
- * {@link MapIterableIntervalToRAIParallel}, {@link MapIterableToIterableParallel}
+ * {@link MapIterableIntervalToRAIParallel}, {@link MapIterableIntervalToIterableIntervalParallel}
  * 
  * @author Christian Dietz (University of Konstanz)
  */
@@ -95,7 +95,7 @@ public class MappersBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void pixelWiseTestThreadedMapperII() {
-		ops.run(new MapIterableToIterableParallel<ByteType, ByteType>(),
+		ops.run(new MapIterableIntervalToIterableIntervalParallel<ByteType, ByteType>(),
 			out, in, addConstant, out);
 	}
 

--- a/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
+++ b/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 
 /**
  * Testing multi threaded implementation ({@link MapIterableIntervalToRAIParallel} and
- * {@link MapIterableToIterableParallel}) of the mappers. Assumption: Naive Implementation of
+ * {@link MapIterableIntervalToIterableIntervalParallel}) of the mappers. Assumption: Naive Implementation of
  * {@link MapIterableIntervalToRAI} works fine.
  * 
  * @author Christian Dietz (University of Konstanz)
@@ -100,7 +100,7 @@ public class ThreadedMapTest extends AbstractOpTest {
 	public void testFunctionMapIIP() {
 
 		final Op functional =
-			ops.op(MapIterableToIterableParallel.class, out, in, new AddOneFunctional());
+			ops.op(MapIterableIntervalToIterableIntervalParallel.class, out, in, new AddOneFunctional());
 		functional.run();
 
 		final Cursor<ByteType> cursor1 = in.cursor();


### PR DESCRIPTION
All the other Map implementations are named based on their input and
output types. Let's do the same for this one.