### PR TITLE
Array test

### DIFF
--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -72,7 +72,8 @@ public abstract class AbstractOpTest {
 
 	/** Subclasses can override to create a context with different services. */
 	protected Context createContext() {
-		return new Context(OpService.class, OpMatchingService.class, CacheService.class);
+		return new Context(OpService.class, OpMatchingService.class,
+			CacheService.class);
 	}
 
 	/** Sets up a SciJava context with {@link OpService}. */
@@ -149,8 +150,8 @@ public abstract class AbstractOpTest {
 	}
 
 	public Img<UnsignedByteType>
-	generateRandomlyFilledUnsignedByteTestImgWithSeed(final long[] dims,
-		long tempSeed)
+		generateRandomlyFilledUnsignedByteTestImgWithSeed(final long[] dims,
+			long tempSeed)
 	{
 
 		Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(dims);
@@ -165,6 +166,7 @@ public abstract class AbstractOpTest {
 	}
 
 	public static class NoOp extends AbstractOp {
+
 		@Override
 		public void run() {
 			// NB: No implementation needed.

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -37,6 +37,7 @@ import net.imglib2.FinalInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -101,7 +102,7 @@ public abstract class AbstractOpTest {
 		return seed = 3170425 * seed + 132102;
 	}
 
-	public Img<ByteType> generateByteTestImg(final boolean fill,
+	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(final boolean fill,
 		final long... dims)
 	{
 		final byte[] array =
@@ -117,7 +118,7 @@ public abstract class AbstractOpTest {
 		return ArrayImgs.bytes(array, dims);
 	}
 
-	public Img<UnsignedByteType> generateUnsignedByteTestImg(final boolean fill,
+	public ArrayImg<UnsignedByteType, ByteArray> generateUnsignedByteArrayTestImg(final boolean fill,
 		final long... dims)
 	{
 		final byte[] array =

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -41,7 +41,8 @@ import net.imagej.ops.math.ConstantToArrayImageP;
 import net.imagej.ops.math.ConstantToImageFunctional;
 import net.imagej.ops.math.ConstantToImageInPlace;
 import net.imagej.ops.math.NumericTypeBinaryMath;
-import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.ByteType;
 
@@ -58,8 +59,8 @@ import org.junit.rules.TestRule;
 @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 1)
 public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
-	private Img<ByteType> in;
-	private Img<ByteType> out;
+	private ArrayImg<ByteType, ByteArray> in;
+	private ArrayImg<ByteType, ByteArray> out;
 
 	/** Needed for JUnit-Benchmarks */
 	@Rule
@@ -68,8 +69,8 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 	/** Sets up test images */
 	@Before
 	public void initImg() {
-		in = generateByteTestImg(true, 5000, 5000);
-		out = generateByteTestImg(false, 5000, 5000);
+		in = generateByteArrayTestImg(true, 5000, 5000);
+		out = generateByteArrayTestImg(false, 5000, 5000);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -74,14 +74,16 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void fTestIterableIntervalMapperP() {
-		ops.run(MapIterableIntervalToIterableIntervalParallel.class, out, in, ops.op(
-			NumericTypeBinaryMath.Add.class, null, NumericType.class, new ByteType((byte) 10)));
+		ops.run(MapIterableIntervalToIterableIntervalParallel.class, out, in, ops
+			.op(NumericTypeBinaryMath.Add.class, null, NumericType.class,
+				new ByteType((byte) 10)));
 	}
 
 	@Test
 	public void fTestDefaultMapperP() {
 		ops.run(MapIterableIntervalToRAIParallel.class, out, in, ops.op(
-			NumericTypeBinaryMath.Add.class, null, NumericType.class, new ByteType((byte) 10)));
+			NumericTypeBinaryMath.Add.class, null, NumericType.class, new ByteType(
+				(byte) 10)));
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -61,6 +61,8 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	private ArrayImg<ByteType, ByteArray> in;
 	private ArrayImg<ByteType, ByteArray> out;
+	private byte[] arrIn;
+	private byte[] arrOut;
 
 	/** Needed for JUnit-Benchmarks */
 	@Rule
@@ -71,6 +73,8 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 	public void initImg() {
 		in = generateByteArrayTestImg(true, 5000, 5000);
 		out = generateByteArrayTestImg(false, 5000, 5000);
+		arrIn = in.update(null).getCurrentStorageArray();
+		arrOut = in.update(null).getCurrentStorageArray();
 	}
 
 	@Test
@@ -113,5 +117,13 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 	@Test
 	public void inTestAddConstantToArrayByteImageP() {
 		ops.run(ConstantToArrayImageP.AddByte.class, in, (byte) 10);
+	}
+
+	@Test
+	public void testAddConstantToArrayByteImageDirect() {
+
+		for (int i = 0; i < arrIn.length; i++) {
+			arrOut[i] += arrIn[i] + 10;
+		}
 	}
 }

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -33,9 +33,9 @@ package net.imagej.ops.benchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 
+import net.imagej.ops.map.MapIterableIntervalInplaceParallel;
 import net.imagej.ops.map.MapIterableIntervalToIterableIntervalParallel;
 import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
-import net.imagej.ops.map.MapIterableIntervalInplaceParallel;
 import net.imagej.ops.math.ConstantToArrayImage;
 import net.imagej.ops.math.ConstantToArrayImageP;
 import net.imagej.ops.math.ConstantToImageFunctional;

--- a/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/MappersBenchmarkTest.java
@@ -73,8 +73,8 @@ public class MappersBenchmarkTest extends AbstractOpBenchmark {
 
 	@Before
 	public void initImg() {
-		in = generateByteTestImg(true, 1000, 1000);
-		out = generateByteTestImg(false, 1000, 1000);
+		in = generateByteArrayTestImg(true, 1000, 1000);
+		out = generateByteArrayTestImg(false, 1000, 1000);
 
 		addConstant =
 			ops.op(Ops.Math.Add.class, null, NumericType.class,

--- a/src/test/java/net/imagej/ops/cached/CachedOpEnvironmentTest.java
+++ b/src/test/java/net/imagej/ops/cached/CachedOpEnvironmentTest.java
@@ -73,8 +73,8 @@ public class CachedOpEnvironmentTest extends AbstractOpTest {
 
 		env = new CachedOpEnvironment(ops, customOps);
 
-		imgA = generateByteTestImg(true, new long[] { 10, 10 });
-		imgB = generateByteTestImg(true, new long[] { 10, 10 });
+		imgA = generateByteArrayTestImg(true, new long[] { 10, 10 });
+		imgB = generateByteArrayTestImg(true, new long[] { 10, 10 });
 
 		func = env.function(Ops.Stats.Min.class, DoubleType.class, imgA);
 		hybrid = env.hybrid(Ops.Stats.Min.class, DoubleType.class, imgA);

--- a/src/test/java/net/imagej/ops/filter/NonLinearFiltersTest.java
+++ b/src/test/java/net/imagej/ops/filter/NonLinearFiltersTest.java
@@ -82,8 +82,8 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Before
 	public void before() throws Exception {
-		in = generateByteTestImg(true, new long[] { 10, 10 });
-		out = generateByteTestImg(false, new long[] { 10, 10 });
+		in = generateByteArrayTestImg(true, new long[] { 10, 10 });
+		out = generateByteArrayTestImg(false, new long[] { 10, 10 });
 		shape = new RectangleShape(1, false);
 	}
 

--- a/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
+++ b/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
@@ -56,9 +56,9 @@ public class DoGTest extends AbstractOpTest {
 		final double[] sigmas2 = new double[] { 2, 2 };
 		final long[] dims = new long[] { 10, 10 };
 
-		final Img<ByteType> in = generateByteTestImg(true, dims);
-		final Img<ByteType> out1 = generateByteTestImg(false, dims);
-		final Img<ByteType> out2 = generateByteTestImg(false, dims);
+		final Img<ByteType> in = generateByteArrayTestImg(true, dims);
+		final Img<ByteType> out1 = generateByteArrayTestImg(false, dims);
+		final Img<ByteType> out2 = generateByteArrayTestImg(false, dims);
 
 		ops.filter().dog(out1, in, sigmas1, sigmas2);
 
@@ -78,7 +78,7 @@ public class DoGTest extends AbstractOpTest {
 	@Test
 	public void dogRAISingleSigmasTest() {
 		final RandomAccessibleInterval<ByteType> res =
-			ops.filter().dog(generateByteTestImg(true, new long[] { 10, 10 }), 1, 2);
+			ops.filter().dog(generateByteArrayTestImg(true, new long[] { 10, 10 }), 1, 2);
 
 		org.junit.Assert.assertNotNull(res);
 	}

--- a/src/test/java/net/imagej/ops/filter/gauss/GaussTest.java
+++ b/src/test/java/net/imagej/ops/filter/gauss/GaussTest.java
@@ -53,7 +53,7 @@ public class GaussTest extends AbstractOpTest {
 	@Test
 	public void gaussRegressionTest() {
 
-		final Img<ByteType> in = generateByteTestImg(true, new long[] { 10, 10 });
+		final Img<ByteType> in = generateByteArrayTestImg(true, new long[] { 10, 10 });
 		final Img<ByteType> out1 =
 			ops.create().img(in, Util.getTypeFromInterval(in));
 		final double sigma = 5;

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -48,7 +48,7 @@ public class InvertTest extends AbstractOpTest {
 	public void testInvertSigned() {
 
 		// signed type test
-		Img<ByteType> in = generateByteTestImg(true, 5, 5);
+		Img<ByteType> in = generateByteArrayTestImg(true, 5, 5);
 		Img<ByteType> out = in.factory().create(in, new ByteType());
 
 		ops.image().invert(out, in);
@@ -64,7 +64,7 @@ public class InvertTest extends AbstractOpTest {
 	public void testInvertUnsigned() {
 
 		// unsigned type test
-		Img<UnsignedByteType> in = generateUnsignedByteTestImg(true, 5, 5);
+		Img<UnsignedByteType> in = generateUnsignedByteArrayTestImg(true, 5, 5);
 		Img<UnsignedByteType> out = in.factory().create(in, new UnsignedByteType());
 
 		ops.image().invert(out, in);

--- a/src/test/java/net/imagej/ops/image/normalize/NormalizeTest.java
+++ b/src/test/java/net/imagej/ops/image/normalize/NormalizeTest.java
@@ -47,7 +47,7 @@ public class NormalizeTest extends AbstractOpTest {
 	@Test
 	public void testNormalize() {
 
-		Img<ByteType> in = generateByteTestImg(true, 5, 5);
+		Img<ByteType> in = generateByteArrayTestImg(true, 5, 5);
 		Img<ByteType> out = in.factory().create(in, new ByteType());
 
 		ops.image().normalize(out, in);

--- a/src/test/java/net/imagej/ops/image/project/ProjectTest.java
+++ b/src/test/java/net/imagej/ops/image/project/ProjectTest.java
@@ -54,7 +54,7 @@ public class ProjectTest extends AbstractOpTest {
 
 	@Before
 	public void initImg() {
-		in = generateUnsignedByteTestImg(false, 10, 10, 10);
+		in = generateUnsignedByteArrayTestImg(false, 10, 10, 10);
 
 		final RandomAccess<UnsignedByteType> randomAccess = in.randomAccess();
 
@@ -68,8 +68,8 @@ public class ProjectTest extends AbstractOpTest {
 			}
 		}
 
-		out1 = generateUnsignedByteTestImg(false, 10, 10);
-		out2 = generateUnsignedByteTestImg(false, 10, 10);
+		out1 = generateUnsignedByteArrayTestImg(false, 10, 10);
+		out2 = generateUnsignedByteArrayTestImg(false, 10, 10);
 
 		op = ops.op(Ops.Stats.Sum.class, RealType.class, out1);
 	}

--- a/src/test/java/net/imagej/ops/image/scale/ScaleImgTest.java
+++ b/src/test/java/net/imagej/ops/image/scale/ScaleImgTest.java
@@ -47,7 +47,7 @@ public class ScaleImgTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		Img<ByteType> in = generateByteTestImg(true, new long[] { 10, 10 });
+		Img<ByteType> in = generateByteArrayTestImg(true, new long[] { 10, 10 });
 		double[] scaleFactors = new double[] { 2, 2 };
 		Img<ByteType> out =
 			ops.image().scale(in, scaleFactors,

--- a/src/test/java/net/imagej/ops/join/JoinTest.java
+++ b/src/test/java/net/imagej/ops/join/JoinTest.java
@@ -59,8 +59,8 @@ public class JoinTest extends AbstractOpTest {
 	@Before
 	public void init() {
 		final long[] dims = new long[] { 10, 10 };
-		in = generateByteTestImg(false, dims);
-		out = generateByteTestImg(false, dims);
+		in = generateByteArrayTestImg(false, dims);
+		out = generateByteArrayTestImg(false, dims);
 		inplaceOp = ops.op(MapOp.class, Img.class, new AddOneInplace());
 		computerOp =
 			ops.op(MapOp.class, Img.class, Img.class, new AddOneComputer());

--- a/src/test/java/net/imagej/ops/loop/LoopTest.java
+++ b/src/test/java/net/imagej/ops/loop/LoopTest.java
@@ -60,8 +60,8 @@ public class LoopTest extends AbstractOpTest {
 	@Before
 	public void init() {
 		final long[] dims = new long[] { 10, 10 };
-		in = generateByteTestImg(false, dims);
-		out = generateByteTestImg(false, dims);
+		in = generateByteArrayTestImg(false, dims);
+		out = generateByteArrayTestImg(false, dims);
 		numIterations = 10;
 		functionalOp = ops.op(MapOp.class, out, in, new AddOneFunctional());
 		inplaceOp = ops.op(MapOp.class, in, new AddOneInplace());

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -59,9 +59,9 @@ public class MapTest extends AbstractOpTest {
 
 	@Before
 	public void initImg() {
-		in = generateByteTestImg(true, 10, 10);
-		out = generateByteTestImg(false, 10, 10);
-		outDiffDims = generateByteTestImg(false, 10, 10, 15);
+		in = generateByteArrayTestImg(true, 10, 10);
+		out = generateByteArrayTestImg(false, 10, 10);
+		outDiffDims = generateByteArrayTestImg(false, 10, 10, 15);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/map/MapViewTest.java
+++ b/src/test/java/net/imagej/ops/map/MapViewTest.java
@@ -56,7 +56,7 @@ public class MapViewTest extends AbstractOpTest {
 	@Before
 	public void init() {
 		final long[] dims = new long[] { 10, 10 };
-		in = generateByteTestImg(false, dims);
+		in = generateByteArrayTestImg(false, dims);
 		op =
 			ops.op(NumericTypeBinaryMath.Add.class, null, NumericType.class,
 				new ByteType((byte) 10));

--- a/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
+++ b/src/test/java/net/imagej/ops/map/ThreadedMapTest.java
@@ -57,8 +57,8 @@ public class ThreadedMapTest extends AbstractOpTest {
 
 	@Before
 	public void initImg() {
-		in = generateByteTestImg(true, 10, 10);
-		out = generateByteTestImg(false, 10, 10);
+		in = generateByteArrayTestImg(true, 10, 10);
+		out = generateByteArrayTestImg(false, 10, 10);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -58,8 +58,8 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 
 	@Before
 	public void initImg() {
-		in = generateByteTestImg(true, 11, 10);
-		out = generateByteTestImg(false, 11, 10);
+		in = generateByteArrayTestImg(true, 11, 10);
+		out = generateByteArrayTestImg(false, 11, 10);
 	}
 
 	/**

--- a/src/test/java/net/imagej/ops/slicewise/HypersliceTest.java
+++ b/src/test/java/net/imagej/ops/slicewise/HypersliceTest.java
@@ -161,7 +161,7 @@ public class HypersliceTest extends AbstractOpTest {
 		final int numSlices = 25;
 		final int numTimePoints = 5;
 
-		final Img<UnsignedByteType> testImage = generateUnsignedByteTestImg(
+		final Img<UnsignedByteType> testImage = generateUnsignedByteArrayTestImg(
 				true, xSize, ySize, numChannels, numSlices, numTimePoints);
 
 		final int[] axisIndices = new int[3];

--- a/src/test/java/net/imagej/ops/stats/MeanTest.java
+++ b/src/test/java/net/imagej/ops/stats/MeanTest.java
@@ -49,7 +49,7 @@ public class MeanTest extends AbstractOpTest {
 
 	@Test
 	public void testMean() {
-		final Img<ByteType> image = generateByteTestImg(true, 40, 50);
+		final Img<ByteType> image = generateByteArrayTestImg(true, 40, 50);
 		final DoubleType mean = new DoubleType();
 		ops.stats().mean(mean, image);
 

--- a/src/test/java/net/imagej/ops/thread/ChunkerBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/thread/ChunkerBenchmarkTest.java
@@ -117,8 +117,8 @@ public class ChunkerBenchmarkTest extends AbstractOpBenchmark {
 		if (size > 1024) {
 			assumeTrue(expensiveTestsEnabled);
 		}
-		in = generateByteTestImg(true, size, size);
-		out = generateByteTestImg(false, size, size);
+		in = generateByteArrayTestImg(true, size, size);
+		out = generateByteArrayTestImg(false, size, size);
 	}
 
 	private void generateByteArrays(int size) {

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -77,7 +77,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Before
 	public void before() throws Exception {
-		in = generateByteTestImg(true, new long[] { 10, 10 });
+		in = generateByteArrayTestImg(true, new long[] { 10, 10 });
 
 		out = in.factory().imgFactory(new BitType()).create(in, new BitType());
 	}


### PR DESCRIPTION
This pull request:

Adds a simple test that explicitly adds a constant to an array.  This is done to verify that ```ConstantToArrayImage``` is as fast as we expect. 

Changes ```AbstractOpTest``` to explicitly return array images when generating byte test images (the test images were allready ```ArrayImg```, just not returned as such).  In the future we can add functions to return ```PlanarImg``` and ```CellImg``` in order to explicitly run tests on these types. 