### PR TITLE
Image moment calculation edits

### DIFF
--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment2.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment2.java
@@ -76,6 +76,6 @@ public class DefaultHuMoment2<I extends RealType<I>, O extends RealType<O>>
 		double n20 = normalizedCentralMoment20Func.compute1(input).getRealDouble();
 		double n02 = normalizedCentralMoment02Func.compute1(input).getRealDouble();
 
-		output.setReal(Math.pow(n20 - n02, 2) - 4 * (Math.pow(n11, 2)));
+		output.setReal(Math.pow(n20 - n02, 2) + 4 * (Math.pow(n11, 2)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment02<I extends RealType<I>, O extends R
 		double centralMoment02 = centralMoment02Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment02 /
-			Math.pow(centralMoment00, 1 + ((0 + 2) / 2)));
+			Math.pow(centralMoment00, 1 + ((0 + 2) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment03<I extends RealType<I>, O extends R
 		double centralMoment03 = centralMoment03Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment03 /
-			Math.pow(centralMoment00, 1 + ((0 + 3) / 2)));
+			Math.pow(centralMoment00, 1 + ((0 + 3) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment11<I extends RealType<I>, O extends R
 		double centralMoment11 = centralMoment11Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment11 /
-			Math.pow(centralMoment00, 1 + ((1 + 1) / 2)));
+			Math.pow(centralMoment00, 1 + ((1 + 1) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment12<I extends RealType<I>, O extends R
 		double centralMoment12 = centralMoment12Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment12 /
-			Math.pow(centralMoment00, 1 + ((1 + 2) / 2)));
+			Math.pow(centralMoment00, 1 + ((1 + 2) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment20<I extends RealType<I>, O extends R
 		double centralMoment20 = centralMoment20Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment20 /
-			Math.pow(centralMoment00, 1 + ((2 + 0) / 2)));
+			Math.pow(centralMoment00, 1 + ((2 + 0) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment21<I extends RealType<I>, O extends R
 		double centralMoment21 = centralMoment21Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment21 /
-			Math.pow(centralMoment00, 1 + ((2 + 1) / 2)));
+			Math.pow(centralMoment00, 1 + ((2 + 1) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment30<I extends RealType<I>, O extends R
 		double centralMoment30 = centralMoment30Func.compute1(input).getRealDouble();
 
 		output.setReal(centralMoment30 /
-			Math.pow(centralMoment00, 1 + ((3 + 0) / 2)));
+			Math.pow(centralMoment00, 1 + ((3 + 0) / 2.0)));
 	}
 }


### PR DESCRIPTION
Found some discrepancies in image moment calcs HuMoment2 (sign change in equation) and the normalized central moments (integer division of exponent). Remaining discrepancies were due to Matlab numerical error. 
