### PR TITLE
Refactor math

### DIFF
--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -211,6 +211,15 @@ public class MathNamespace extends AbstractNamespace {
 		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
 		add(final O out, final I1 in1, final I2 in2)
 	{
+		final Class<?> outClass = out.getClass();
+		final Class<?> in1Class = in1.getClass();
+		final Class<?> in2Class = in2.getClass();
+		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
+			@SuppressWarnings("unchecked")
+			final O result = (O) ops().run(
+				net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out, in1, in2);
+			return result;
+		}
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Add.class,
 			out, in1, in2);
@@ -256,10 +265,22 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
-	public <T extends NumericType<T>> T add(final T out, final T in, final T b) {
+	public <
+		I1 extends NumericType<I1>, I2 extends NumericType<I2>, O extends NumericType<O>>
+		O add(final O out, final I1 in1, final I2 in2)
+	{
+		final Class<?> outClass = out.getClass();
+		final Class<?> in1Class = in1.getClass();
+		final Class<?> in2Class = in2.getClass();
+		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
+			@SuppressWarnings("unchecked")
+			final O result = (O) ops().run(
+				net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out, in1, in2);
+			return result;
+		}
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(
-			net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out, in, b);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Add.class, out, in1,
+			in2);
 		return result;
 	}
 
@@ -1221,6 +1242,16 @@ public class MathNamespace extends AbstractNamespace {
 		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
 		multiply(final O out, final I1 in1, final I2 in2)
 	{
+		final Class<?> outClass = out.getClass();
+		final Class<?> in1Class = in1.getClass();
+		final Class<?> in2Class = in2.getClass();
+		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
+			@SuppressWarnings("unchecked")
+			final O result = (O) ops().run(
+				net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, out, in1,
+				in2);
+			return result;
+		}
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
 			net.imagej.ops.math.RealBinaryMath.Multiply.class, out, in1, in2);
@@ -1266,12 +1297,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class)
-	public <T extends NumericType<T>> T multiply(final T out, final T in,
-		final T b)
+	public <
+		I1 extends NumericType<I1>, I2 extends NumericType<I2>, O extends NumericType<O>>
+		O multiply(final O out, final I1 in1, final I2 in2)
 	{
+		final Class<?> outClass = out.getClass();
+		final Class<?> in1Class = in1.getClass();
+		final Class<?> in2Class = in2.getClass();
+		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
+			@SuppressWarnings("unchecked")
+			final O result = (O) ops().run(
+				net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, out, in1,
+				in2);
+			return result;
+		}
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(
-			net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, out, in, b);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Multiply.class, out,
+			in1, in2);
 		return result;
 	}
 
@@ -1837,6 +1879,16 @@ public class MathNamespace extends AbstractNamespace {
 		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
 		subtract(final O out, final I1 in1, final I2 in2)
 	{
+		final Class<?> outClass = out.getClass();
+		final Class<?> in1Class = in1.getClass();
+		final Class<?> in2Class = in2.getClass();
+		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
+			@SuppressWarnings("unchecked")
+			final O result = (O) ops().run(
+				net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, out, in1,
+				in2);
+			return result;
+		}
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
 			net.imagej.ops.math.RealBinaryMath.Subtract.class, out, in1, in2);
@@ -1882,12 +1934,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class)
-	public <T extends NumericType<T>> T subtract(final T out, final T in,
-		final T b)
+	public <
+		I1 extends NumericType<I1>, I2 extends NumericType<I2>, O extends NumericType<O>>
+		O subtract(final O out, final I1 in1, final I2 in2)
 	{
+		final Class<?> outClass = out.getClass();
+		final Class<?> in1Class = in1.getClass();
+		final Class<?> in2Class = in2.getClass();
+		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
+			@SuppressWarnings("unchecked")
+			final O result = (O) ops().run(
+				net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, out, in1,
+				in2);
+			return result;
+		}
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(
-			net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, out, in, b);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Subtract.class, out,
+			in1, in2);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -227,12 +227,12 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.RealMath.Add.class)
-	public <I extends RealType<I>, O extends RealType<O>> RealType<O> add(
-		final RealType<O> out, final RealType<I> in, final double constant)
+	public <I extends RealType<I>, O extends RealType<O>> O add(final O out,
+		final I in, final double constant)
 	{
 		@SuppressWarnings("unchecked")
-		final RealType<O> result = (RealType<O>) ops().run(
-			net.imagej.ops.math.RealMath.Add.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Add.class, out,
+			in, constant);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -35,7 +35,6 @@ import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
 import net.imglib2.IterableInterval;
-import net.imglib2.IterableRealInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
@@ -108,7 +107,8 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Abs.class, args);
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyByte.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.MultiplyByte.class,
 		net.imagej.ops.math.ConstantToArrayImage.MultiplyByte.class })
 	public ArrayImg<ByteType, ByteArray> multiply(
 		final ArrayImg<ByteType, ByteArray> image, final byte value)
@@ -120,19 +120,21 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyDouble.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.MultiplyDouble.class,
 		net.imagej.ops.math.ConstantToArrayImage.MultiplyDouble.class })
 	public ArrayImg<DoubleType, DoubleArray> multiply(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Multiply.NAME, image,
-				value);
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Multiply.NAME,
+				image, value);
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyFloat.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.MultiplyFloat.class,
 		net.imagej.ops.math.ConstantToArrayImage.MultiplyFloat.class })
 	public ArrayImg<FloatType, FloatArray> multiply(
 		final ArrayImg<FloatType, FloatArray> image, final float value)
@@ -156,7 +158,8 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyLong.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.MultiplyLong.class,
 		net.imagej.ops.math.ConstantToArrayImage.MultiplyLong.class })
 	public ArrayImg<LongType, LongArray> multiply(
 		final ArrayImg<LongType, LongArray> image, final long value)
@@ -222,12 +225,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Add.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> add(
-		final IterableRealInterval<T> image, final T value)
+	public <T extends NumericType<T>> IterableInterval<T> add(
+		final IterableInterval<T> in, final T value)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToIIOutputII.Add.class, image, value);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Add.class, in, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Add.class)
+	public <T extends NumericType<T>> IterableInterval<T> add(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Add.class, out, in, value);
 		return result;
 	}
 
@@ -280,8 +294,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<ByteType, ByteArray> result =
 			(PlanarImg<ByteType, ByteArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.AddByte.class, image,
-				value);
+				net.imagej.ops.math.ConstantToPlanarImage.AddByte.class, image, value);
 		return result;
 	}
 
@@ -304,8 +317,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<FloatType, FloatArray> result =
 			(PlanarImg<FloatType, FloatArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.AddFloat.class, image,
-				value);
+				net.imagej.ops.math.ConstantToPlanarImage.AddFloat.class, image, value);
 		return result;
 	}
 
@@ -316,8 +328,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<IntType, IntArray> result =
 			(PlanarImg<IntType, IntArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.AddInt.class, image,
-				value);
+				net.imagej.ops.math.ConstantToPlanarImage.AddInt.class, image, value);
 		return result;
 	}
 
@@ -328,8 +339,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<LongType, LongArray> result =
 			(PlanarImg<LongType, LongArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.AddLong.class, image,
-				value);
+				net.imagej.ops.math.ConstantToPlanarImage.AddLong.class, image, value);
 		return result;
 	}
 
@@ -341,8 +351,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
 			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToIIOutputRAI.Add.class, out, in,
-				value);
+				net.imagej.ops.math.ConstantToIIOutputRAI.Add.class, out, in, value);
 		return result;
 	}
 
@@ -794,7 +803,8 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideDouble.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.DivideDouble.class,
 		net.imagej.ops.math.ConstantToArrayImage.DivideDouble.class })
 	public ArrayImg<DoubleType, DoubleArray> divide(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
@@ -896,12 +906,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Divide.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> divide(
-		final IterableRealInterval<T> image, final T value)
+	public <T extends NumericType<T>> IterableInterval<T> divide(
+		final IterableInterval<T> in, final T value)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToIIOutputII.Divide.class, image, value);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Divide.class, in, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Divide.class)
+	public <T extends NumericType<T>> IterableInterval<T> divide(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Divide.class, out, in, value);
 		return result;
 	}
 
@@ -1006,8 +1027,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
 			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToIIOutputRAI.Divide.class, out, in,
-				value);
+				net.imagej.ops.math.ConstantToIIOutputRAI.Divide.class, out, in, value);
 		return result;
 	}
 
@@ -1347,8 +1367,7 @@ public class MathNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<IntType, IntArray> result =
-			(ArrayImg<IntType, IntArray>) ops().run(Ops.Math.Add.NAME, image,
-				value);
+			(ArrayImg<IntType, IntArray>) ops().run(Ops.Math.Add.NAME, image, value);
 		return result;
 	}
 
@@ -1418,12 +1437,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Multiply.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> multiply(
-		final IterableRealInterval<T> image, final T value)
+	public <T extends NumericType<T>> IterableInterval<T> multiply(
+		final IterableInterval<T> in, final T value)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToIIOutputII.Multiply.class, image, value);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Multiply.class, in, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Multiply.class)
+	public <T extends NumericType<T>> IterableInterval<T> multiply(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Multiply.class, out, in, value);
 		return result;
 	}
 
@@ -2023,7 +2053,8 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Step.class, args);
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractByte.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.SubtractByte.class,
 		net.imagej.ops.math.ConstantToArrayImage.SubtractByte.class })
 	public ArrayImg<ByteType, ByteArray> subtract(
 		final ArrayImg<ByteType, ByteArray> image, final byte value)
@@ -2035,19 +2066,21 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractDouble.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.SubtractDouble.class,
 		net.imagej.ops.math.ConstantToArrayImage.SubtractDouble.class })
 	public ArrayImg<DoubleType, DoubleArray> subtract(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Subtract.NAME, image,
-				value);
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Subtract.NAME,
+				image, value);
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractFloat.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.SubtractFloat.class,
 		net.imagej.ops.math.ConstantToArrayImage.SubtractFloat.class })
 	public ArrayImg<FloatType, FloatArray> subtract(
 		final ArrayImg<FloatType, FloatArray> image, final float value)
@@ -2071,7 +2104,8 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractLong.class,
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.SubtractLong.class,
 		net.imagej.ops.math.ConstantToArrayImage.SubtractLong.class })
 	public ArrayImg<LongType, LongArray> subtract(
 		final ArrayImg<LongType, LongArray> image, final long value)
@@ -2137,12 +2171,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Subtract.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> subtract(
-		final IterableRealInterval<T> image, final T value)
+	public <T extends NumericType<T>> IterableInterval<T> subtract(
+		final IterableInterval<T> in, final T value)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToIIOutputII.Subtract.class, image, value);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Subtract.class, in, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Subtract.class)
+	public <T extends NumericType<T>> IterableInterval<T> subtract(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToIIOutputII.Subtract.class, out, in, value);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -333,7 +333,7 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Add.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputRAI.Add.class)
 	public <T extends NumericType<T>> RandomAccessibleInterval<T> add(
 		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
 		final T value)
@@ -341,7 +341,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
 			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Add.class, out, in,
+				net.imagej.ops.math.ConstantToIIOutputRAI.Add.class, out, in,
 				value);
 		return result;
 	}
@@ -998,7 +998,7 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Divide.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputRAI.Divide.class)
 	public <T extends NumericType<T>> RandomAccessibleInterval<T> divide(
 		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
 		final T value)
@@ -1006,7 +1006,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
 			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Divide.class, out, in,
+				net.imagej.ops.math.ConstantToIIOutputRAI.Divide.class, out, in,
 				value);
 		return result;
 	}
@@ -1530,7 +1530,7 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Multiply.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputRAI.Multiply.class)
 	public <T extends NumericType<T>> RandomAccessibleInterval<T> multiply(
 		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
 		final T value)
@@ -1538,7 +1538,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
 			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Multiply.class, out, in,
+				net.imagej.ops.math.ConstantToIIOutputRAI.Multiply.class, out, in,
 				value);
 		return result;
 	}
@@ -2249,7 +2249,7 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Subtract.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputRAI.Subtract.class)
 	public <T extends NumericType<T>> RandomAccessibleInterval<T> subtract(
 		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
 		final T value)
@@ -2257,7 +2257,7 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
 			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Subtract.class, out, in,
+				net.imagej.ops.math.ConstantToIIOutputRAI.Subtract.class, out, in,
 				value);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -185,23 +185,23 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Add.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Add.class)
 	public <T extends NumericType<T>> Img<T> add(final Img<T> out,
 		final Img<T> in, final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Add.class, out, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Add.class, out, in, ii);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Add.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Add.class)
 	public <T extends NumericType<T>> Img<T> add(final Img<T> in,
 		final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Add.class, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Add.class, in, ii);
 		return result;
 	}
 
@@ -866,23 +866,23 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Divide.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Divide.class)
 	public <T extends NumericType<T>> Img<T> divide(final Img<T> out,
 		final Img<T> in, final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Divide.class, out, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Divide.class, out, in, ii);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Divide.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Divide.class)
 	public <T extends NumericType<T>> Img<T> divide(final Img<T> in,
 		final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Divide.class, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Divide.class, in, ii);
 		return result;
 	}
 
@@ -1397,23 +1397,23 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Multiply.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Multiply.class)
 	public <T extends NumericType<T>> Img<T> multiply(final Img<T> out,
 		final Img<T> in, final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Multiply.class, out, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Multiply.class, out, in, ii);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Multiply.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Multiply.class)
 	public <T extends NumericType<T>> Img<T> multiply(final Img<T> in,
 		final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Multiply.class, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Multiply.class, in, ii);
 		return result;
 	}
 
@@ -2131,23 +2131,23 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Subtract.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Subtract.class)
 	public <T extends NumericType<T>> Img<T> subtract(final Img<T> out,
 		final Img<T> in, final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Subtract.class, out, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Subtract.class, out, in, ii);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Subtract.class)
+	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Subtract.class)
 	public <T extends NumericType<T>> Img<T> subtract(final Img<T> in,
 		final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IterableIntervalToImg.Subtract.class, in, ii);
+			net.imagej.ops.math.IIToIIOutputII.Subtract.class, in, ii);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -36,7 +36,6 @@ import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
@@ -186,22 +185,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Add.class)
-	public <T extends NumericType<T>> Img<T> add(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> add(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Add.class, out, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Add.class, out, in1, in2);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Add.class)
-	public <T extends NumericType<T>> Img<T> add(final Img<T> in,
-		final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> add(
+		final IterableInterval<T> in1, final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Add.class, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Add.class, in1, in2);
 		return result;
 	}
 
@@ -867,22 +867,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Divide.class)
-	public <T extends NumericType<T>> Img<T> divide(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> divide(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Divide.class, out, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Divide.class, out, in1, in2);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Divide.class)
-	public <T extends NumericType<T>> Img<T> divide(final Img<T> in,
-		final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> divide(
+		final IterableInterval<T> in1, final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Divide.class, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Divide.class, in1, in2);
 		return result;
 	}
 
@@ -1398,22 +1399,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Multiply.class)
-	public <T extends NumericType<T>> Img<T> multiply(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> multiply(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Multiply.class, out, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Multiply.class, out, in1, in2);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Multiply.class)
-	public <T extends NumericType<T>> Img<T> multiply(final Img<T> in,
-		final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> multiply(
+		final IterableInterval<T> in1, final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Multiply.class, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Multiply.class, in1, in2);
 		return result;
 	}
 
@@ -2132,22 +2134,23 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Subtract.class)
-	public <T extends NumericType<T>> Img<T> subtract(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> subtract(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Subtract.class, out, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Subtract.class, out, in1, in2);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.IIToIIOutputII.Subtract.class)
-	public <T extends NumericType<T>> Img<T> subtract(final Img<T> in,
-		final IterableInterval<T> ii)
+	public <T extends NumericType<T>> IterableInterval<T> subtract(
+		final IterableInterval<T> in1, final IterableInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.math.IIToIIOutputII.Subtract.class, in, ii);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToIIOutputII.Subtract.class, in1, in2);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -213,13 +213,13 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Add.class)
+		op = net.imagej.ops.math.IIToRAIOutputII.Add.class)
 	public <T extends NumericType<T>> IterableInterval<T> add(
 		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Add.class,
+			net.imagej.ops.math.IIToRAIOutputII.Add.class,
 			a, b);
 		return result;
 	}
@@ -895,13 +895,13 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Divide.class)
+		op = net.imagej.ops.math.IIToRAIOutputII.Divide.class)
 	public <T extends NumericType<T>> IterableInterval<T> divide(
 		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Divide.class,
+			net.imagej.ops.math.IIToRAIOutputII.Divide.class,
 			a, b);
 		return result;
 	}
@@ -1427,13 +1427,13 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Multiply.class)
+		op = net.imagej.ops.math.IIToRAIOutputII.Multiply.class)
 	public <T extends NumericType<T>> IterableInterval<T> multiply(
 		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Multiply.class,
+			net.imagej.ops.math.IIToRAIOutputII.Multiply.class,
 			a, b);
 		return result;
 	}
@@ -2162,13 +2162,13 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Subtract.class)
+		op = net.imagej.ops.math.IIToRAIOutputII.Subtract.class)
 	public <T extends NumericType<T>> IterableInterval<T> subtract(
 		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Subtract.class,
+			net.imagej.ops.math.IIToRAIOutputII.Subtract.class,
 			a, b);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -196,6 +196,27 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.math.RealMath.Add.class)
+	public <I extends RealType<I>, O extends RealType<O>> O add(final O out,
+		final I in, final double constant)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Add.class, out,
+			in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Add.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		add(final O out, final I1 in1, final I2 in2)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Add.class,
+			out, in1, in2);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Math.Add.class)
 	public Object add(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Math.Add.class, args);
@@ -223,16 +244,6 @@ public class MathNamespace extends AbstractNamespace {
 			(RandomAccessibleInterval<T>) ops().run(
 				net.imagej.ops.math.ConstantToImageFunctional.Add.class, out, in,
 				value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Add.class)
-	public <I extends RealType<I>, O extends RealType<O>> O add(final O out,
-		final I in, final double constant)
-	{
-		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Add.class, out,
-			in, constant);
 		return result;
 	}
 
@@ -273,6 +284,17 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
 			net.imagej.ops.math.RealMath.AndConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.And.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		and(final O out, final I1 in1, final I2 in2)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.And.class,
+			out, in1, in2);
 		return result;
 	}
 
@@ -754,6 +776,17 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Divide.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		divide(final O out, final I1 in1, final I2 in2, final double dbzVal)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealBinaryMath.Divide.class, out, in1, in2, dbzVal);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Math.Divide.class)
 	public Object divide(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Math.Divide.class, args);
@@ -1183,6 +1216,17 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Multiply.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		multiply(final O out, final I1 in1, final I2 in2)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealBinaryMath.Multiply.class, out, in1, in2);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Math.Multiply.class)
 	public Object multiply(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Math.Multiply.class, args);
@@ -1310,6 +1354,17 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
 			net.imagej.ops.math.RealMath.OrConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Or.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		or(final O out, final I1 in1, final I2 in2)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Or.class,
+			out, in1, in2);
 		return result;
 	}
 
@@ -1777,6 +1832,17 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Subtract.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		subtract(final O out, final I1 in1, final I2 in2)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealBinaryMath.Subtract.class, out, in1, in2);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.Ops.Math.Subtract.class)
 	public Object subtract(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Math.Subtract.class, args);
@@ -1925,6 +1991,17 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
 			net.imagej.ops.math.RealMath.XorConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Xor.class)
+	public <
+		I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O
+		xor(final O out, final I1 in1, final I2 in2)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Xor.class,
+			out, in1, in2);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -41,11 +41,17 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.planar.PlanarImg;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.scijava.plugin.Plugin;
 
@@ -102,26 +108,62 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Abs.class, args);
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddByte.class,
-		net.imagej.ops.math.ConstantToArrayImage.AddByte.class })
-	public ArrayImg<ByteType, ByteArray> add(
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyByte.class,
+		net.imagej.ops.math.ConstantToArrayImage.MultiplyByte.class })
+	public ArrayImg<ByteType, ByteArray> multiply(
 		final ArrayImg<ByteType, ByteArray> image, final byte value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<ByteType, ByteArray> result =
-			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Add.NAME, image,
+			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Multiply.NAME, image,
 				value);
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddDouble.class,
-		net.imagej.ops.math.ConstantToArrayImage.AddDouble.class })
-	public ArrayImg<DoubleType, DoubleArray> add(
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyDouble.class,
+		net.imagej.ops.math.ConstantToArrayImage.MultiplyDouble.class })
+	public ArrayImg<DoubleType, DoubleArray> multiply(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Add.NAME, image,
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Multiply.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyFloat.class,
+		net.imagej.ops.math.ConstantToArrayImage.MultiplyFloat.class })
+	public ArrayImg<FloatType, FloatArray> multiply(
+		final ArrayImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<FloatType, FloatArray> result =
+			(ArrayImg<FloatType, FloatArray>) ops().run(Ops.Math.Multiply.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyInt.class,
+		net.imagej.ops.math.ConstantToArrayImage.MultiplyInt.class })
+	public ArrayImg<IntType, IntArray> multiply(
+		final ArrayImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<IntType, IntArray> result =
+			(ArrayImg<IntType, IntArray>) ops().run(Ops.Math.Multiply.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.MultiplyLong.class,
+		net.imagej.ops.math.ConstantToArrayImage.MultiplyLong.class })
+	public ArrayImg<LongType, LongArray> multiply(
+		final ArrayImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<LongType, LongArray> result =
+			(ArrayImg<LongType, LongArray>) ops().run(Ops.Math.Multiply.NAME, image,
 				value);
 		return result;
 	}
@@ -231,6 +273,18 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Add.class, args);
 	}
 
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.AddByte.class)
+	public PlanarImg<ByteType, ByteArray> add(
+		final PlanarImg<ByteType, ByteArray> image, final byte value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<ByteType, ByteArray> result =
+			(PlanarImg<ByteType, ByteArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.AddByte.class, image,
+				value);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class)
 	public PlanarImg<DoubleType, DoubleArray> add(
 		final PlanarImg<DoubleType, DoubleArray> image, final double value)
@@ -239,6 +293,42 @@ public class MathNamespace extends AbstractNamespace {
 		final PlanarImg<DoubleType, DoubleArray> result =
 			(PlanarImg<DoubleType, DoubleArray>) ops().run(
 				net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.AddFloat.class)
+	public PlanarImg<FloatType, FloatArray> add(
+		final PlanarImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<FloatType, FloatArray> result =
+			(PlanarImg<FloatType, FloatArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.AddFloat.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.AddInt.class)
+	public PlanarImg<IntType, IntArray> add(
+		final PlanarImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<IntType, IntArray> result =
+			(PlanarImg<IntType, IntArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.AddInt.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.AddLong.class)
+	public PlanarImg<LongType, LongArray> add(
+		final PlanarImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<LongType, LongArray> result =
+			(PlanarImg<LongType, LongArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.AddLong.class, image,
 				value);
 		return result;
 	}
@@ -704,8 +794,7 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.DivideDouble.class,
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideDouble.class,
 		net.imagej.ops.math.ConstantToArrayImage.DivideDouble.class })
 	public ArrayImg<DoubleType, DoubleArray> divide(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
@@ -713,6 +802,42 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
 			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Divide.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideFloat.class,
+		net.imagej.ops.math.ConstantToArrayImage.DivideFloat.class })
+	public ArrayImg<FloatType, FloatArray> divide(
+		final ArrayImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<FloatType, FloatArray> result =
+			(ArrayImg<FloatType, FloatArray>) ops().run(Ops.Math.Divide.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideInt.class,
+		net.imagej.ops.math.ConstantToArrayImage.DivideInt.class })
+	public ArrayImg<IntType, IntArray> divide(
+		final ArrayImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<IntType, IntArray> result =
+			(ArrayImg<IntType, IntArray>) ops().run(Ops.Math.Divide.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideLong.class,
+		net.imagej.ops.math.ConstantToArrayImage.DivideLong.class })
+	public ArrayImg<LongType, LongArray> divide(
+		final ArrayImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<LongType, LongArray> result =
+			(ArrayImg<LongType, LongArray>) ops().run(Ops.Math.Divide.NAME, image,
 				value);
 		return result;
 	}
@@ -813,6 +938,18 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Divide.class, args);
 	}
 
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.DivideByte.class)
+	public PlanarImg<ByteType, ByteArray> divide(
+		final PlanarImg<ByteType, ByteArray> image, final byte value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<ByteType, ByteArray> result =
+			(PlanarImg<ByteType, ByteArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.DivideByte.class, image,
+				value);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class)
 	public PlanarImg<DoubleType, DoubleArray> divide(
 		final PlanarImg<DoubleType, DoubleArray> image, final double value)
@@ -821,6 +958,42 @@ public class MathNamespace extends AbstractNamespace {
 		final PlanarImg<DoubleType, DoubleArray> result =
 			(PlanarImg<DoubleType, DoubleArray>) ops().run(
 				net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.DivideFloat.class)
+	public PlanarImg<FloatType, FloatArray> divide(
+		final PlanarImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<FloatType, FloatArray> result =
+			(PlanarImg<FloatType, FloatArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.DivideFloat.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.DivideInt.class)
+	public PlanarImg<IntType, IntArray> divide(
+		final PlanarImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<IntType, IntArray> result =
+			(PlanarImg<IntType, IntArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.DivideInt.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.DivideLong.class)
+	public PlanarImg<LongType, LongArray> divide(
+		final PlanarImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<LongType, LongArray> result =
+			(PlanarImg<LongType, LongArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.DivideLong.class, image,
 				value);
 		return result;
 	}
@@ -1131,29 +1304,63 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Min.class, args);
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.MultiplyByte.class,
-		net.imagej.ops.math.ConstantToArrayImage.MultiplyByte.class })
-	public ArrayImg<ByteType, ByteArray> multiply(
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddByte.class,
+		net.imagej.ops.math.ConstantToArrayImage.AddByte.class })
+	public ArrayImg<ByteType, ByteArray> add(
 		final ArrayImg<ByteType, ByteArray> image, final byte value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<ByteType, ByteArray> result =
-			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Multiply.NAME, image,
+			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Add.NAME, image,
 				value);
 		return result;
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.MultiplyDouble.class,
-		net.imagej.ops.math.ConstantToArrayImage.MultiplyDouble.class })
-	public ArrayImg<DoubleType, DoubleArray> multiply(
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddDouble.class,
+		net.imagej.ops.math.ConstantToArrayImage.AddDouble.class })
+	public ArrayImg<DoubleType, DoubleArray> add(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Multiply.NAME,
-				image, value);
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Add.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddFloat.class,
+		net.imagej.ops.math.ConstantToArrayImage.AddFloat.class })
+	public ArrayImg<FloatType, FloatArray> add(
+		final ArrayImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<FloatType, FloatArray> result =
+			(ArrayImg<FloatType, FloatArray>) ops().run(Ops.Math.Add.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddInt.class,
+		net.imagej.ops.math.ConstantToArrayImage.AddInt.class })
+	public ArrayImg<IntType, IntArray> add(
+		final ArrayImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<IntType, IntArray> result =
+			(ArrayImg<IntType, IntArray>) ops().run(Ops.Math.Add.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddLong.class,
+		net.imagej.ops.math.ConstantToArrayImage.AddLong.class })
+	public ArrayImg<LongType, LongArray> add(
+		final ArrayImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<LongType, LongArray> result =
+			(ArrayImg<LongType, LongArray>) ops().run(Ops.Math.Add.NAME, image,
+				value);
 		return result;
 	}
 
@@ -1263,6 +1470,18 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Multiply.class, args);
 	}
 
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyByte.class)
+	public PlanarImg<ByteType, ByteArray> multiply(
+		final PlanarImg<ByteType, ByteArray> image, final byte value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<ByteType, ByteArray> result =
+			(PlanarImg<ByteType, ByteArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.MultiplyByte.class, image,
+				value);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class)
 	public PlanarImg<DoubleType, DoubleArray> multiply(
 		final PlanarImg<DoubleType, DoubleArray> image, final double value)
@@ -1271,6 +1490,42 @@ public class MathNamespace extends AbstractNamespace {
 		final PlanarImg<DoubleType, DoubleArray> result =
 			(PlanarImg<DoubleType, DoubleArray>) ops().run(
 				net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyFloat.class)
+	public PlanarImg<FloatType, FloatArray> multiply(
+		final PlanarImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<FloatType, FloatArray> result =
+			(PlanarImg<FloatType, FloatArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.MultiplyFloat.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyInt.class)
+	public PlanarImg<IntType, IntArray> multiply(
+		final PlanarImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<IntType, IntArray> result =
+			(PlanarImg<IntType, IntArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.MultiplyInt.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyLong.class)
+	public PlanarImg<LongType, LongArray> multiply(
+		final PlanarImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<LongType, LongArray> result =
+			(PlanarImg<LongType, LongArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.MultiplyLong.class, image,
 				value);
 		return result;
 	}
@@ -1768,8 +2023,7 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Step.class, args);
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.SubtractByte.class,
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractByte.class,
 		net.imagej.ops.math.ConstantToArrayImage.SubtractByte.class })
 	public ArrayImg<ByteType, ByteArray> subtract(
 		final ArrayImg<ByteType, ByteArray> image, final byte value)
@@ -1781,16 +2035,51 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.SubtractDouble.class,
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractDouble.class,
 		net.imagej.ops.math.ConstantToArrayImage.SubtractDouble.class })
 	public ArrayImg<DoubleType, DoubleArray> subtract(
 		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Subtract.NAME,
-				image, value);
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Subtract.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractFloat.class,
+		net.imagej.ops.math.ConstantToArrayImage.SubtractFloat.class })
+	public ArrayImg<FloatType, FloatArray> subtract(
+		final ArrayImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<FloatType, FloatArray> result =
+			(ArrayImg<FloatType, FloatArray>) ops().run(Ops.Math.Subtract.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractInt.class,
+		net.imagej.ops.math.ConstantToArrayImage.SubtractInt.class })
+	public ArrayImg<IntType, IntArray> subtract(
+		final ArrayImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<IntType, IntArray> result =
+			(ArrayImg<IntType, IntArray>) ops().run(Ops.Math.Subtract.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.SubtractLong.class,
+		net.imagej.ops.math.ConstantToArrayImage.SubtractLong.class })
+	public ArrayImg<LongType, LongArray> subtract(
+		final ArrayImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<LongType, LongArray> result =
+			(ArrayImg<LongType, LongArray>) ops().run(Ops.Math.Subtract.NAME, image,
+				value);
 		return result;
 	}
 
@@ -1900,6 +2189,18 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Subtract.class, args);
 	}
 
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.SubtractByte.class)
+	public PlanarImg<ByteType, ByteArray> subtract(
+		final PlanarImg<ByteType, ByteArray> image, final byte value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<ByteType, ByteArray> result =
+			(PlanarImg<ByteType, ByteArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.SubtractByte.class, image,
+				value);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class)
 	public PlanarImg<DoubleType, DoubleArray> subtract(
 		final PlanarImg<DoubleType, DoubleArray> image, final double value)
@@ -1908,6 +2209,42 @@ public class MathNamespace extends AbstractNamespace {
 		final PlanarImg<DoubleType, DoubleArray> result =
 			(PlanarImg<DoubleType, DoubleArray>) ops().run(
 				net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.SubtractFloat.class)
+	public PlanarImg<FloatType, FloatArray> subtract(
+		final PlanarImg<FloatType, FloatArray> image, final float value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<FloatType, FloatArray> result =
+			(PlanarImg<FloatType, FloatArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.SubtractFloat.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.SubtractInt.class)
+	public PlanarImg<IntType, IntArray> subtract(
+		final PlanarImg<IntType, IntArray> image, final int value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<IntType, IntArray> result =
+			(PlanarImg<IntType, IntArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.SubtractInt.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.SubtractLong.class)
+	public PlanarImg<LongType, LongArray> subtract(
+		final PlanarImg<LongType, LongArray> image, final long value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<LongType, LongArray> result =
+			(PlanarImg<LongType, LongArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.SubtractLong.class, image,
 				value);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -59,37 +59,31 @@ public class MathNamespace extends AbstractNamespace {
 
 	// -- Math namespace ops --
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Abs.class)
-	public Object abs(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Abs.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerAbs.class)
-	public int abs(final int a) {
-		final int result =
-			(Integer) ops()
-				.run(net.imagej.ops.math.PrimitiveMath.IntegerAbs.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongAbs.class)
-	public long abs(final long a) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongAbs.class, a);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleAbs.class)
+	public double abs(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleAbs.class, a);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatAbs.class)
 	public float abs(final float a) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatAbs.class, a);
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatAbs.class, a);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleAbs.class)
-	public double abs(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleAbs.class, a);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerAbs.class)
+	public int abs(final int a) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerAbs.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongAbs.class)
+	public long abs(final long a) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongAbs.class, a);
 		return result;
 	}
 
@@ -98,35 +92,32 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Abs.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Abs.class, out,
+			in);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Add.class)
-	public Object add(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Add.class, args);
+	@OpMethod(op = net.imagej.ops.Ops.Math.Abs.class)
+	public Object abs(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Abs.class, args);
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.AddByte.class,
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddByte.class,
 		net.imagej.ops.math.ConstantToArrayImage.AddByte.class })
 	public ArrayImg<ByteType, ByteArray> add(
 		final ArrayImg<ByteType, ByteArray> image, final byte value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<ByteType, ByteArray> result =
-			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Add.NAME, image, value);
+			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Add.NAME, image,
+				value);
 		return result;
 	}
 
-	@OpMethod(
-		ops = {
-			net.imagej.ops.math.ConstantToArrayImageP.AddDouble.class,
-			net.imagej.ops.math.ConstantToArrayImage.AddDouble.class })
-	public
-		ArrayImg<DoubleType, DoubleArray> add(
-			final ArrayImg<DoubleType, DoubleArray> image, final double value)
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddDouble.class,
+		net.imagej.ops.math.ConstantToArrayImage.AddDouble.class })
+	public ArrayImg<DoubleType, DoubleArray> add(
+		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
@@ -135,31 +126,955 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.SubtractByte.class,
-		net.imagej.ops.math.ConstantToArrayImage.SubtractByte.class })
-	public ArrayImg<ByteType, ByteArray> subtract(
-		final ArrayImg<ByteType, ByteArray> image, final byte value)
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleAdd.class)
+	public double add(final double a, final double b) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleAdd.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatAdd.class)
+	public float add(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatAdd.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Add.class)
+	public <T extends NumericType<T>> Img<T> add(final Img<T> out,
+		final Img<T> in, final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
-		final ArrayImg<ByteType, ByteArray> result =
-			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Subtract.NAME, image, value);
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Add.class, out, in, ii);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Add.class)
+	public <T extends NumericType<T>> Img<T> add(final Img<T> in,
+		final IterableInterval<T> ii)
+	{
+		@SuppressWarnings("unchecked")
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Add.class, in, ii);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerAdd.class)
+	public int add(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerAdd.class, a, b);
 		return result;
 	}
 
 	@OpMethod(
-		ops = {
-			net.imagej.ops.math.ConstantToArrayImageP.SubtractDouble.class,
-			net.imagej.ops.math.ConstantToArrayImage.SubtractDouble.class })
-	public
-		ArrayImg<DoubleType, DoubleArray> subtract(
-			final ArrayImg<DoubleType, DoubleArray> image, final double value)
+		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Add.class)
+	public <T extends NumericType<T>> IterableInterval<T> add(
+		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Add.class,
+			a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Add.class)
+	public <T extends NumericType<T>> IterableRealInterval<T> add(
+		final IterableRealInterval<T> image, final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToImageInPlace.Add.class, image, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongAdd.class)
+	public long add(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongAdd.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Add.class)
+	public Object add(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Add.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class)
+	public PlanarImg<DoubleType, DoubleArray> add(
+		final PlanarImg<DoubleType, DoubleArray> image, final double value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<DoubleType, DoubleArray> result =
+			(PlanarImg<DoubleType, DoubleArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Add.class)
+	public <T extends NumericType<T>> RandomAccessibleInterval<T> add(
+		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(
+				net.imagej.ops.math.ConstantToImageFunctional.Add.class, out, in,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Add.class)
+	public <I extends RealType<I>, O extends RealType<O>> RealType<O> add(
+		final RealType<O> out, final RealType<I> in, final double constant)
+	{
+		@SuppressWarnings("unchecked")
+		final RealType<O> result = (RealType<O>) ops().run(
+			net.imagej.ops.math.RealMath.Add.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
+	public <T extends NumericType<T>> T add(final T in, final T b) {
+		@SuppressWarnings("unchecked")
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Add.class, in, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
+	public <T extends NumericType<T>> T add(final T out, final T in, final T b) {
+		@SuppressWarnings("unchecked")
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out, in, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerAnd.class)
+	public int and(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerAnd.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongAnd.class)
+	public long and(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongAnd.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.AndConstant.class)
+	public <I extends RealType<I>, O extends RealType<O>> O and(final O out,
+		final I in, final long constant)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.AndConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.And.class)
+	public Object and(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.And.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArccos.class)
+	public double arccos(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleArccos.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arccos.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arccos(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccos.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arccos.class)
+	public Object arccos(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arccos.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arccosh.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arccosh(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccosh.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arccosh.class)
+	public Object arccosh(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arccosh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arccot.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arccot(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccot.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arccot.class)
+	public Object arccot(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arccot.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arccoth.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arccoth(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccoth.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arccoth.class)
+	public Object arccoth(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arccoth.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arccsc.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arccsc(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccsc.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arccsc.class)
+	public Object arccsc(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arccsc.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arccsch.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arccsch(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccsch.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arccsch.class)
+	public Object arccsch(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arccsch.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsec.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arcsec(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsec.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsec.class)
+	public Object arcsec(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arcsec.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsech.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arcsech(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsech.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsech.class)
+	public Object arcsech(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arcsech.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArcsin.class)
+	public double arcsin(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleArcsin.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsin.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arcsin(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsin.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsin.class)
+	public Object arcsin(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arcsin.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsinh.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arcsinh(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsinh.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsinh.class)
+	public Object arcsinh(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arcsinh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArctan.class)
+	public double arctan(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleArctan.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arctan.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arctan(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arctan.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arctan.class)
+	public Object arctan(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arctan.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Arctanh.class)
+	public <I extends RealType<I>, O extends RealType<O>> O arctanh(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arctanh.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Arctanh.class)
+	public Object arctanh(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Arctanh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCeil.class)
+	public double ceil(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleCeil.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Ceil.class)
+	public <I extends RealType<I>, O extends RealType<O>> O ceil(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Ceil.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Ceil.class)
+	public Object ceil(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Ceil.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerComplement.class)
+	public int complement(final int a) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerComplement.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongComplement.class)
+	public long complement(final long a) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongComplement.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Complement.class)
+	public Object complement(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Complement.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCos.class)
+	public double cos(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleCos.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Cos.class)
+	public <I extends RealType<I>, O extends RealType<O>> O cos(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Cos.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Cos.class)
+	public Object cos(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Cos.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCosh.class)
+	public double cosh(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleCosh.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Cosh.class)
+	public <I extends RealType<I>, O extends RealType<O>> O cosh(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Cosh.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Cosh.class)
+	public Object cosh(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Cosh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Cot.class)
+	public <I extends RealType<I>, O extends RealType<O>> O cot(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Cot.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Cot.class)
+	public Object cot(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Cot.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Coth.class)
+	public <I extends RealType<I>, O extends RealType<O>> O coth(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Coth.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Coth.class)
+	public Object coth(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Coth.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Csc.class)
+	public <I extends RealType<I>, O extends RealType<O>> O csc(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Csc.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Csc.class)
+	public Object csc(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Csc.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Csch.class)
+	public <I extends RealType<I>, O extends RealType<O>> O csch(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Csch.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Csch.class)
+	public Object csch(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Csch.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCubeRoot.class)
+	public double cubeRoot(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleCubeRoot.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.CubeRoot.class)
+	public <I extends RealType<I>, O extends RealType<O>> O cubeRoot(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.CubeRoot.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.CubeRoot.class)
+	public Object cubeRoot(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.CubeRoot.class, args);
+	}
+
+	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideByte.class,
+		net.imagej.ops.math.ConstantToArrayImage.DivideByte.class })
+	public ArrayImg<ByteType, ByteArray> divide(
+		final ArrayImg<ByteType, ByteArray> image, final byte value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<ByteType, ByteArray> result =
+			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Divide.NAME, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.DivideDouble.class,
+		net.imagej.ops.math.ConstantToArrayImage.DivideDouble.class })
+	public ArrayImg<DoubleType, DoubleArray> divide(
+		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Subtract.NAME, image,
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Divide.NAME, image,
 				value);
 		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleDivide.class)
+	public double divide(final double a, final double b) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleDivide.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatDivide.class)
+	public float divide(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatDivide.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Divide.class)
+	public <T extends NumericType<T>> Img<T> divide(final Img<T> out,
+		final Img<T> in, final IterableInterval<T> ii)
+	{
+		@SuppressWarnings("unchecked")
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Divide.class, out, in, ii);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Divide.class)
+	public <T extends NumericType<T>> Img<T> divide(final Img<T> in,
+		final IterableInterval<T> ii)
+	{
+		@SuppressWarnings("unchecked")
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Divide.class, in, ii);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerDivide.class)
+	public int divide(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerDivide.class, a, b);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Divide.class)
+	public <T extends NumericType<T>> IterableInterval<T> divide(
+		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Divide.class,
+			a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Divide.class)
+	public <T extends NumericType<T>> IterableRealInterval<T> divide(
+		final IterableRealInterval<T> image, final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToImageInPlace.Divide.class, image, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongDivide.class)
+	public long divide(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongDivide.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Divide.class)
+	public <I extends RealType<I>, O extends RealType<O>> O divide(final O out,
+		final I in, final double constant, final double dbzVal)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Divide.class,
+			out, in, constant, dbzVal);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Divide.class)
+	public Object divide(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Divide.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class)
+	public PlanarImg<DoubleType, DoubleArray> divide(
+		final PlanarImg<DoubleType, DoubleArray> image, final double value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<DoubleType, DoubleArray> result =
+			(PlanarImg<DoubleType, DoubleArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Divide.class)
+	public <T extends NumericType<T>> RandomAccessibleInterval<T> divide(
+		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(
+				net.imagej.ops.math.ConstantToImageFunctional.Divide.class, out, in,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Divide.class)
+	public <T extends NumericType<T>> T divide(final T in, final T b) {
+		@SuppressWarnings("unchecked")
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Divide.class, in, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Divide.class)
+	public <T extends NumericType<T>> T divide(final T out, final T in,
+		final T b)
+	{
+		@SuppressWarnings("unchecked")
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Divide.class, out, in, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleExp.class)
+	public double exp(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleExp.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Exp.class)
+	public <I extends RealType<I>, O extends RealType<O>> O exp(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Exp.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Exp.class)
+	public Object exp(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Exp.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.ExpMinusOne.class)
+	public <I extends RealType<I>, O extends RealType<O>> O expMinusOne(
+		final O out, final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.ExpMinusOne.class, out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.ExpMinusOne.class)
+	public Object expMinusOne(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.ExpMinusOne.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleFloor.class)
+	public double floor(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleFloor.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Floor.class)
+	public <I extends RealType<I>, O extends RealType<O>> O floor(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Floor.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Floor.class)
+	public Object floor(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Floor.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.GammaConstant.class)
+	public <I extends RealType<I>, O extends RealType<O>> O gamma(final O out,
+		final I in, final double constant)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.GammaConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Gamma.class)
+	public Object gamma(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Gamma.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Invert.class)
+	public <I extends RealType<I>, O extends RealType<O>> O invert(final O out,
+		final I in, final double specifiedMin, final double specifiedMax)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Invert.class,
+			out, in, specifiedMin, specifiedMax);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Invert.class)
+	public Object invert(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Invert.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerLeftShift.class)
+	public int leftShift(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerLeftShift.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongLeftShift.class)
+	public long leftShift(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongLeftShift.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.LeftShift.class)
+	public Object leftShift(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.LeftShift.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLog.class)
+	public double log(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleLog.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Log.class)
+	public <I extends RealType<I>, O extends RealType<O>> O log(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Log.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Log.class)
+	public Object log(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Log.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLog10.class)
+	public double log10(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleLog10.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Log10.class)
+	public <I extends RealType<I>, O extends RealType<O>> O log10(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Log10.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Log10.class)
+	public Object log10(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Log10.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Log2.class)
+	public <I extends RealType<I>, O extends RealType<O>> O log2(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Log2.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Log2.class)
+	public Object log2(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Log2.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLogOnePlusX.class)
+	public double logOnePlusX(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleLogOnePlusX.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.LogOnePlusX.class)
+	public <I extends RealType<I>, O extends RealType<O>> O logOnePlusX(
+		final O out, final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.LogOnePlusX.class, out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.LogOnePlusX.class)
+	public Object logOnePlusX(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.LogOnePlusX.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMax.class)
+	public double max(final double a, final double b) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleMax.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatMax.class)
+	public float max(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatMax.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerMax.class)
+	public int max(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerMax.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongMax.class)
+	public long max(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongMax.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.MaxConstant.class)
+	public <I extends RealType<I>, O extends RealType<O>> O max(final O out,
+		final I in, final double constant)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.MaxConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Max.class)
+	public Object max(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Max.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMin.class)
+	public double min(final double a, final double b) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleMin.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatMin.class)
+	public float min(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatMin.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerMin.class)
+	public int min(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerMin.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongMin.class)
+	public long min(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongMin.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.MinConstant.class)
+	public <I extends RealType<I>, O extends RealType<O>> O min(final O out,
+		final I in, final double constant)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.MinConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Min.class)
+	public Object min(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Min.class, args);
 	}
 
 	@OpMethod(ops = {
@@ -170,326 +1085,35 @@ public class MathNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<ByteType, ByteArray> result =
-			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Multiply.NAME, image, value);
-		return result;
-	}
-
-	@OpMethod(
-		ops = {
-			net.imagej.ops.math.ConstantToArrayImageP.MultiplyDouble.class,
-			net.imagej.ops.math.ConstantToArrayImage.MultiplyDouble.class })
-	public
-		ArrayImg<DoubleType, DoubleArray> multiply(
-			final ArrayImg<DoubleType, DoubleArray> image, final double value)
-	{
-		@SuppressWarnings("unchecked")
-		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Multiply.NAME, image,
+			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Multiply.NAME, image,
 				value);
 		return result;
 	}
 
 	@OpMethod(ops = {
-		net.imagej.ops.math.ConstantToArrayImageP.DivideByte.class,
-		net.imagej.ops.math.ConstantToArrayImage.DivideByte.class })
-	public ArrayImg<ByteType, ByteArray> divide(
-		final ArrayImg<ByteType, ByteArray> image, final byte value)
-	{
-		@SuppressWarnings("unchecked")
-		final ArrayImg<ByteType, ByteArray> result =
-			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Divide.NAME, image, value);
-		return result;
-	}
-
-	@OpMethod(
-		ops = {
-			net.imagej.ops.math.ConstantToArrayImageP.DivideDouble.class,
-			net.imagej.ops.math.ConstantToArrayImage.DivideDouble.class })
-	public
-		ArrayImg<DoubleType, DoubleArray> divide(
-			final ArrayImg<DoubleType, DoubleArray> image, final double value)
+		net.imagej.ops.math.ConstantToArrayImageP.MultiplyDouble.class,
+		net.imagej.ops.math.ConstantToArrayImage.MultiplyDouble.class })
+	public ArrayImg<DoubleType, DoubleArray> multiply(
+		final ArrayImg<DoubleType, DoubleArray> image, final double value)
 	{
 		@SuppressWarnings("unchecked")
 		final ArrayImg<DoubleType, DoubleArray> result =
-			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Divide.NAME, image,
-				value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerAdd.class)
-	public int add(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(net.imagej.ops.math.PrimitiveMath.IntegerAdd.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongAdd.class)
-	public long add(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongAdd.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatAdd.class)
-	public float add(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatAdd.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleAdd.class)
-	public double add(final double a, final double b) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleAdd.class, a,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Add.class)
-	public <I extends RealType<I>, O extends RealType<O>> RealType<O> add(
-		final RealType<O> out, final RealType<I> in, final double constant)
-	{
-		@SuppressWarnings("unchecked")
-		final RealType<O> result =
-			(RealType<O>) ops().run(net.imagej.ops.math.RealMath.Add.class, out, in,
-				constant);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
-	public <T extends NumericType<T>> T add(final T in, final T b) {
-		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Add.class, in, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
-	public <T extends NumericType<T>> T add(final T out, final T in, final T b) {
-		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out,
-				in, b);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Add.class)
-	public
-		<T extends NumericType<T>> IterableInterval<T> add(
-			final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops()
-				.run(
-					net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Add.class,
-					a, b);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class)
-	public PlanarImg<DoubleType, DoubleArray> add(
-		final PlanarImg<DoubleType, DoubleArray> image, final double value)
-	{
-		@SuppressWarnings("unchecked")
-		final PlanarImg<DoubleType, DoubleArray> result =
-			(PlanarImg<DoubleType, DoubleArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class,
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Multiply.NAME,
 				image, value);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Add.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> add(
-		final IterableRealInterval<T> image, final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result =
-			(IterableRealInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageInPlace.Add.class, image,
-				value);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMultiply.class)
+	public double multiply(final double a, final double b) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleMultiply.class, a, b);
 		return result;
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToImageFunctional.Add.class)
-	public <T extends NumericType<T>> RandomAccessibleInterval<T> add(
-		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
-		final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Add.class, out,
-				in, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Add.class)
-	public <T extends NumericType<T>> Img<T> add(final Img<T> in,
-		final IterableInterval<T> ii)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Add.class, in, ii);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Add.class)
-	public <T extends NumericType<T>> Img<T> add(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Add.class, out, in,
-				ii);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Subtract.class)
-	public
-		<T extends NumericType<T>> IterableInterval<T> subtract(
-			final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops()
-				.run(
-					net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Subtract.class,
-					a, b);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class)
-	public PlanarImg<DoubleType, DoubleArray> subtract(
-		final PlanarImg<DoubleType, DoubleArray> image, final double value)
-	{
-		@SuppressWarnings("unchecked")
-		final PlanarImg<DoubleType, DoubleArray> result =
-			(PlanarImg<DoubleType, DoubleArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class,
-				image, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Subtract.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> subtract(
-		final IterableRealInterval<T> image, final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result =
-			(IterableRealInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageInPlace.Subtract.class, image,
-				value);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToImageFunctional.Subtract.class)
-	public <T extends NumericType<T>> RandomAccessibleInterval<T> subtract(
-		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
-		final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Subtract.class, out,
-				in, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Subtract.class)
-	public <T extends NumericType<T>> Img<T> subtract(final Img<T> in,
-		final IterableInterval<T> ii)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Subtract.class, in, ii);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Subtract.class)
-	public <T extends NumericType<T>> Img<T> subtract(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Subtract.class, out, in,
-				ii);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Multiply.class)
-	public
-		<T extends NumericType<T>> IterableInterval<T> multiply(
-			final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops()
-				.run(
-					net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Multiply.class,
-					a, b);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class)
-	public PlanarImg<DoubleType, DoubleArray> multiply(
-		final PlanarImg<DoubleType, DoubleArray> image, final double value)
-	{
-		@SuppressWarnings("unchecked")
-		final PlanarImg<DoubleType, DoubleArray> result =
-			(PlanarImg<DoubleType, DoubleArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class,
-				image, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Multiply.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> multiply(
-		final IterableRealInterval<T> image, final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result =
-			(IterableRealInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageInPlace.Multiply.class, image,
-				value);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToImageFunctional.Multiply.class)
-	public <T extends NumericType<T>> RandomAccessibleInterval<T> multiply(
-		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
-		final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Multiply.class, out,
-				in, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Multiply.class)
-	public <T extends NumericType<T>> Img<T> multiply(final Img<T> in,
-		final IterableInterval<T> ii)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Multiply.class, in, ii);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatMultiply.class)
+	public float multiply(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatMultiply.class, a, b);
 		return result;
 	}
 
@@ -498,885 +1122,54 @@ public class MathNamespace extends AbstractNamespace {
 		final Img<T> in, final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Multiply.class, out, in,
-				ii);
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Multiply.class, out, in, ii);
 		return result;
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Divide.class)
-	public
-		<T extends NumericType<T>> IterableInterval<T> divide(
-			final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops()
-				.run(
-					net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Divide.class,
-					a, b);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class)
-	public PlanarImg<DoubleType, DoubleArray> divide(
-		final PlanarImg<DoubleType, DoubleArray> image, final double value)
-	{
-		@SuppressWarnings("unchecked")
-		final PlanarImg<DoubleType, DoubleArray> result =
-			(PlanarImg<DoubleType, DoubleArray>) ops().run(
-				net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class,
-				image, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Divide.class)
-	public <T extends NumericType<T>> IterableRealInterval<T> divide(
-		final IterableRealInterval<T> image, final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableRealInterval<T> result =
-			(IterableRealInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageInPlace.Divide.class, image,
-				value);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.math.ConstantToImageFunctional.Divide.class)
-	public <T extends NumericType<T>> RandomAccessibleInterval<T> divide(
-		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
-		final T value)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.math.ConstantToImageFunctional.Divide.class, out,
-				in, value);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Divide.class)
-	public <T extends NumericType<T>> Img<T> divide(final Img<T> in,
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Multiply.class)
+	public <T extends NumericType<T>> Img<T> multiply(final Img<T> in,
 		final IterableInterval<T> ii)
 	{
 		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Divide.class, in, ii);
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Multiply.class, in, ii);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Divide.class)
-	public <T extends NumericType<T>> Img<T> divide(final Img<T> out,
-		final Img<T> in, final IterableInterval<T> ii)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.math.IterableIntervalToImg.Divide.class, out, in,
-				ii);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.And.class)
-	public Object and(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.And.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerAnd.class)
-	public int and(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(net.imagej.ops.math.PrimitiveMath.IntegerAnd.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongAnd.class)
-	public long and(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongAnd.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.AndConstant.class)
-	public <I extends RealType<I>, O extends RealType<O>> O and(final O out,
-		final I in, final long constant)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.AndConstant.class, out, in,
-				constant);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccos.class)
-	public Object arccos(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccos.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArccos.class)
-	public double arccos(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleArccos.class,
-				a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arccos.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arccos(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arccos.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccosh.class)
-	public Object arccosh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccosh.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arccosh.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arccosh(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arccosh.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccot.class)
-	public Object arccot(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccot.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arccot.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arccot(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arccot.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccoth.class)
-	public Object arccoth(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccoth.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arccoth.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arccoth(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arccoth.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccsc.class)
-	public Object arccsc(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccsc.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arccsc.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arccsc(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arccsc.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccsch.class)
-	public Object arccsch(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccsch.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arccsch.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arccsch(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arccsch.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsec.class)
-	public Object arcsec(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsec.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsec.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arcsec(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arcsec.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsech.class)
-	public Object arcsech(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsech.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsech.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arcsech(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arcsech.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsin.class)
-	public Object arcsin(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsin.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArcsin.class)
-	public double arcsin(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleArcsin.class,
-				a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsin.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arcsin(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arcsin.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsinh.class)
-	public Object arcsinh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsinh.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsinh.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arcsinh(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arcsinh.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arctan.class)
-	public Object arctan(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arctan.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArctan.class)
-	public double arctan(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleArctan.class,
-				a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arctan.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arctan(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arctan.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arctanh.class)
-	public Object arctanh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arctanh.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Arctanh.class)
-	public <I extends RealType<I>, O extends RealType<O>> O arctanh(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Arctanh.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Ceil.class)
-	public Object ceil(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Ceil.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCeil.class)
-	public double ceil(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleCeil.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Ceil.class)
-	public <I extends RealType<I>, O extends RealType<O>> O ceil(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Ceil.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Complement.class)
-	public Object complement(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Complement.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerComplement.class)
-	public int complement(final int a) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerComplement.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongComplement.class)
-	public long complement(final long a) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongComplement.class,
-				a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Cos.class)
-	public Object cos(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Cos.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCos.class)
-	public double cos(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleCos.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Cos.class)
-	public <I extends RealType<I>, O extends RealType<O>> O cos(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Cos.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Cosh.class)
-	public Object cosh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Cosh.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCosh.class)
-	public double cosh(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleCosh.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Cosh.class)
-	public <I extends RealType<I>, O extends RealType<O>> O cosh(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Cosh.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Cot.class)
-	public Object cot(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Cot.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Cot.class)
-	public <I extends RealType<I>, O extends RealType<O>> O cot(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Cot.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Coth.class)
-	public Object coth(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Coth.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Coth.class)
-	public <I extends RealType<I>, O extends RealType<O>> O coth(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Coth.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Csc.class)
-	public Object csc(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Csc.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Csc.class)
-	public <I extends RealType<I>, O extends RealType<O>> O csc(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Csc.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Csch.class)
-	public Object csch(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Csch.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Csch.class)
-	public <I extends RealType<I>, O extends RealType<O>> O csch(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Csch.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.CubeRoot.class)
-	public Object cubeRoot(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.CubeRoot.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCubeRoot.class)
-	public double cubeRoot(final double a) {
-		final double result =
-			(Double) ops().run(
-				net.imagej.ops.math.PrimitiveMath.DoubleCubeRoot.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.CubeRoot.class)
-	public <I extends RealType<I>, O extends RealType<O>> O cubeRoot(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.CubeRoot.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Divide.class)
-	public Object divide(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Divide.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerDivide.class)
-	public int divide(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerDivide.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongDivide.class)
-	public long divide(final long a, final long b) {
-		final long result =
-			(Long) ops()
-				.run(net.imagej.ops.math.PrimitiveMath.LongDivide.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatDivide.class)
-	public float divide(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatDivide.class, a,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleDivide.class)
-	public double divide(final double a, final double b) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleDivide.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Divide.class)
-	public <I extends RealType<I>, O extends RealType<O>> O divide(final O out,
-		final I in, final double constant, final double dbzVal)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Divide.class, out, in,
-				constant, dbzVal);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Divide.class)
-	public <T extends NumericType<T>> T divide(final T in, final T b) {
-		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Divide.class, in,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Divide.class)
-	public <T extends NumericType<T>> T
-		divide(final T out, final T in, final T b)
-	{
-		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Divide.class,
-				out, in, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Exp.class)
-	public Object exp(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Exp.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleExp.class)
-	public double exp(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleExp.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Exp.class)
-	public <I extends RealType<I>, O extends RealType<O>> O exp(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Exp.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.ExpMinusOne.class)
-	public Object expMinusOne(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.ExpMinusOne.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.ExpMinusOne.class)
-	public <I extends RealType<I>, O extends RealType<O>> O expMinusOne(
-		final O out, final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.ExpMinusOne.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Floor.class)
-	public Object floor(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Floor.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleFloor.class)
-	public double floor(final double a) {
-		final double result =
-			(Double) ops()
-				.run(net.imagej.ops.math.PrimitiveMath.DoubleFloor.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Floor.class)
-	public <I extends RealType<I>, O extends RealType<O>> O floor(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Floor.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Gamma.class)
-	public Object gamma(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Gamma.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.GammaConstant.class)
-	public <I extends RealType<I>, O extends RealType<O>> O gamma(final O out,
-		final I in, final double constant)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.GammaConstant.class, out, in,
-				constant);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Invert.class)
-	public Object invert(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Invert.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Invert.class)
-	public <I extends RealType<I>, O extends RealType<O>> O invert(final O out,
-		final I in, final double specifiedMin, final double specifiedMax)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Invert.class, out, in,
-				specifiedMin, specifiedMax);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.LeftShift.class)
-	public Object leftShift(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.LeftShift.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerLeftShift.class)
-	public int leftShift(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerLeftShift.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongLeftShift.class)
-	public long leftShift(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongLeftShift.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Log.class)
-	public Object log(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Log.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLog.class)
-	public double log(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleLog.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Log.class)
-	public <I extends RealType<I>, O extends RealType<O>> O log(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Log.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Log2.class)
-	public Object log2(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Log2.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Log2.class)
-	public <I extends RealType<I>, O extends RealType<O>> O log2(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Log2.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Log10.class)
-	public Object log10(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Log10.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLog10.class)
-	public double log10(final double a) {
-		final double result =
-			(Double) ops()
-				.run(net.imagej.ops.math.PrimitiveMath.DoubleLog10.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.Log10.class)
-	public <I extends RealType<I>, O extends RealType<O>> O log10(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Log10.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.LogOnePlusX.class)
-	public Object logOnePlusX(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.LogOnePlusX.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLogOnePlusX.class)
-	public double logOnePlusX(final double a) {
-		final double result =
-			(Double) ops().run(
-				net.imagej.ops.math.PrimitiveMath.DoubleLogOnePlusX.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.LogOnePlusX.class)
-	public <I extends RealType<I>, O extends RealType<O>> O logOnePlusX(
-		final O out, final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.LogOnePlusX.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Max.class)
-	public Object max(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Max.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerMax.class)
-	public int max(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(net.imagej.ops.math.PrimitiveMath.IntegerMax.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongMax.class)
-	public long max(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongMax.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatMax.class)
-	public float max(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatMax.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMax.class)
-	public double max(final double a, final double b) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleMax.class, a,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.MaxConstant.class)
-	public <I extends RealType<I>, O extends RealType<O>> O max(final O out,
-		final I in, final double constant)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.MaxConstant.class, out, in,
-				constant);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Min.class)
-	public Object min(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Min.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerMin.class)
-	public int min(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(net.imagej.ops.math.PrimitiveMath.IntegerMin.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongMin.class)
-	public long min(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongMin.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatMin.class)
-	public float min(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatMin.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMin.class)
-	public double min(final double a, final double b) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleMin.class, a,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.MinConstant.class)
-	public <I extends RealType<I>, O extends RealType<O>> O min(final O out,
-		final I in, final double constant)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.MinConstant.class, out, in,
-				constant);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Multiply.class)
-	public Object multiply(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Multiply.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerMultiply.class)
 	public int multiply(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerMultiply.class, a, b);
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerMultiply.class, a, b);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Multiply.class)
+	public <T extends NumericType<T>> IterableInterval<T> multiply(
+		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Multiply.class,
+			a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Multiply.class)
+	public <T extends NumericType<T>> IterableRealInterval<T> multiply(
+		final IterableRealInterval<T> image, final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToImageInPlace.Multiply.class, image, value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongMultiply.class)
 	public long multiply(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongMultiply.class, a,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatMultiply.class)
-	public float multiply(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatMultiply.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMultiply.class)
-	public double multiply(final double a, final double b) {
-		final double result =
-			(Double) ops().run(
-				net.imagej.ops.math.PrimitiveMath.DoubleMultiply.class, a, b);
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongMultiply.class, a, b);
 		return result;
 	}
 
@@ -1385,18 +1178,46 @@ public class MathNamespace extends AbstractNamespace {
 		final I in, final double constant)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Multiply.class, out, in,
-				constant);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Multiply.class,
+			out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Multiply.class)
+	public Object multiply(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Multiply.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class)
+	public PlanarImg<DoubleType, DoubleArray> multiply(
+		final PlanarImg<DoubleType, DoubleArray> image, final double value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<DoubleType, DoubleArray> result =
+			(PlanarImg<DoubleType, DoubleArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Multiply.class)
+	public <T extends NumericType<T>> RandomAccessibleInterval<T> multiply(
+		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(
+				net.imagej.ops.math.ConstantToImageFunctional.Multiply.class, out, in,
+				value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class)
 	public <T extends NumericType<T>> T multiply(final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class,
-				in, b);
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, in, b);
 		return result;
 	}
 
@@ -1405,9 +1226,18 @@ public class MathNamespace extends AbstractNamespace {
 		final T b)
 	{
 		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class,
-				out, in, b);
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, out, in, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.NearestInt.class)
+	public <I extends RealType<I>, O extends RealType<O>> O nearestInt(
+		final O out, final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.NearestInt.class, out, in);
 		return result;
 	}
 
@@ -1416,48 +1246,31 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.NearestInt.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.NearestInt.class)
-	public <I extends RealType<I>, O extends RealType<O>> O nearestInt(
-		final O out, final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.NearestInt.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Negate.class)
-	public Object negate(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Negate.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerNegate.class)
-	public int negate(final int a) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerNegate.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongNegate.class)
-	public long negate(final long a) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongNegate.class, a);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleNegate.class)
+	public double negate(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleNegate.class, a);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatNegate.class)
 	public float negate(final float a) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatNegate.class, a);
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatNegate.class, a);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleNegate.class)
-	public double negate(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleNegate.class,
-				a);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerNegate.class)
+	public int negate(final int a) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerNegate.class, a);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongNegate.class)
+	public long negate(final long a) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongNegate.class, a);
 		return result;
 	}
 
@@ -1466,28 +1279,27 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Negate.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Negate.class,
+			out, in);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Or.class)
-	public Object or(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Or.class, args);
+	@OpMethod(op = net.imagej.ops.Ops.Math.Negate.class)
+	public Object negate(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Negate.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerOr.class)
 	public int or(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(net.imagej.ops.math.PrimitiveMath.IntegerOr.class, a,
-				b);
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerOr.class, a, b);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongOr.class)
 	public long or(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongOr.class, a, b);
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongOr.class, a, b);
 		return result;
 	}
 
@@ -1496,22 +1308,20 @@ public class MathNamespace extends AbstractNamespace {
 		final I in, final long constant)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.OrConstant.class, out, in,
-				constant);
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.OrConstant.class, out, in, constant);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Power.class)
-	public Object power(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Power.class, args);
+	@OpMethod(op = net.imagej.ops.Ops.Math.Or.class)
+	public Object or(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Or.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoublePower.class)
 	public double power(final double a, final double b) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoublePower.class,
-				a, b);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoublePower.class, a, b);
 		return result;
 	}
 
@@ -1520,9 +1330,33 @@ public class MathNamespace extends AbstractNamespace {
 		final I in, final double constant)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.PowerConstant.class, out, in,
-				constant);
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.PowerConstant.class, out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Power.class)
+	public Object power(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Power.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.RandomGaussian.class)
+	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(
+		final O out, final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.RandomGaussian.class, out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.RandomGaussian.class)
+	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(
+		final O out, final I in, final long seed)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.RandomGaussian.class, out, in, seed);
 		return result;
 	}
 
@@ -1531,24 +1365,23 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.RandomGaussian.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.RandomGaussian.class)
-	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(
+	@OpMethod(op = net.imagej.ops.math.RealMath.RandomUniform.class)
+	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(
 		final O out, final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.RandomGaussian.class, out, in);
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.RandomUniform.class, out, in);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.RandomGaussian.class)
-	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(
+	@OpMethod(op = net.imagej.ops.math.RealMath.RandomUniform.class)
+	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(
 		final O out, final I in, final long seed)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.RandomGaussian.class, out, in,
-				seed);
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.RandomUniform.class, out, in, seed);
 		return result;
 	}
 
@@ -1557,24 +1390,13 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.RandomUniform.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.RandomUniform.class)
-	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(
-		final O out, final I in)
+	@OpMethod(op = net.imagej.ops.math.RealMath.Reciprocal.class)
+	public <I extends RealType<I>, O extends RealType<O>> O reciprocal(
+		final O out, final I in, final double dbzVal)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.RandomUniform.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.RealMath.RandomUniform.class)
-	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(
-		final O out, final I in, final long seed)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.RandomUniform.class, out, in,
-				seed);
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.Reciprocal.class, out, in, dbzVal);
 		return result;
 	}
 
@@ -1583,14 +1405,31 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Reciprocal.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Reciprocal.class)
-	public <I extends RealType<I>, O extends RealType<O>> O reciprocal(
-		final O out, final I in, final double dbzVal)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Reciprocal.class, out, in,
-				dbzVal);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleRemainder.class)
+	public double remainder(final double a, final double b) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleRemainder.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatRemainder.class)
+	public float remainder(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatRemainder.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerRemainder.class)
+	public int remainder(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerRemainder.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongRemainder.class)
+	public long remainder(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongRemainder.class, a, b);
 		return result;
 	}
 
@@ -1599,35 +1438,17 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Remainder.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerRemainder.class)
-	public int remainder(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerRemainder.class, a, b);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerRightShift.class)
+	public int rightShift(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerRightShift.class, a, b);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongRemainder.class)
-	public long remainder(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongRemainder.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatRemainder.class)
-	public float remainder(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatRemainder.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleRemainder.class)
-	public double remainder(final double a, final double b) {
-		final double result =
-			(Double) ops().run(
-				net.imagej.ops.math.PrimitiveMath.DoubleRemainder.class, a, b);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongRightShift.class)
+	public long rightShift(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongRightShift.class, a, b);
 		return result;
 	}
 
@@ -1636,39 +1457,17 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.RightShift.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerRightShift.class)
-	public int rightShift(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerRightShift.class, a, b);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleRound.class)
+	public double round(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleRound.class, a);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongRightShift.class)
-	public long rightShift(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongRightShift.class,
-				a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Round.class)
-	public Object round(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Round.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatRound.class)
 	public float round(final float a) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatRound.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleRound.class)
-	public double round(final double a) {
-		final double result =
-			(Double) ops()
-				.run(net.imagej.ops.math.PrimitiveMath.DoubleRound.class, a);
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatRound.class, a);
 		return result;
 	}
 
@@ -1677,8 +1476,23 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Round.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Round.class,
+			out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Round.class)
+	public Object round(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Round.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Sec.class)
+	public <I extends RealType<I>, O extends RealType<O>> O sec(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sec.class, out,
+			in);
 		return result;
 	}
 
@@ -1687,13 +1501,13 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Sec.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Sec.class)
-	public <I extends RealType<I>, O extends RealType<O>> O sec(final O out,
+	@OpMethod(op = net.imagej.ops.math.RealMath.Sech.class)
+	public <I extends RealType<I>, O extends RealType<O>> O sech(final O out,
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sec.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sech.class, out,
+			in);
 		return result;
 	}
 
@@ -1702,33 +1516,17 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Sech.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Sech.class)
-	public <I extends RealType<I>, O extends RealType<O>> O sech(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sech.class, out, in);
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSignum.class)
+	public double signum(final double a) {
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleSignum.class, a);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Signum.class)
-	public Object signum(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Signum.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatSignum.class)
 	public float signum(final float a) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatSignum.class, a);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSignum.class)
-	public double signum(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleSignum.class,
-				a);
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatSignum.class, a);
 		return result;
 	}
 
@@ -1737,20 +1535,20 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Signum.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Signum.class,
+			out, in);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sin.class)
-	public Object sin(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sin.class, args);
+	@OpMethod(op = net.imagej.ops.Ops.Math.Signum.class)
+	public Object signum(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Signum.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSin.class)
 	public double sin(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleSin.class, a);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleSin.class, a);
 		return result;
 	}
 
@@ -1759,8 +1557,23 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sin.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sin.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Sin.class)
+	public Object sin(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Sin.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Sinc.class)
+	public <I extends RealType<I>, O extends RealType<O>> O sinc(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sinc.class, out,
+			in);
 		return result;
 	}
 
@@ -1769,13 +1582,13 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Sinc.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Sinc.class)
-	public <I extends RealType<I>, O extends RealType<O>> O sinc(final O out,
+	@OpMethod(op = net.imagej.ops.math.RealMath.SincPi.class)
+	public <I extends RealType<I>, O extends RealType<O>> O sincPi(final O out,
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sinc.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.SincPi.class,
+			out, in);
 		return result;
 	}
 
@@ -1784,25 +1597,10 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.SincPi.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.SincPi.class)
-	public <I extends RealType<I>, O extends RealType<O>> O sincPi(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.SincPi.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sinh.class)
-	public Object sinh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sinh.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSinh.class)
 	public double sinh(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleSinh.class, a);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleSinh.class, a);
 		return result;
 	}
 
@@ -1811,8 +1609,23 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sinh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sinh.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Sinh.class)
+	public Object sinh(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Sinh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Sqr.class)
+	public <I extends RealType<I>, O extends RealType<O>> O sqr(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sqr.class, out,
+			in);
 		return result;
 	}
 
@@ -1821,25 +1634,10 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Sqr.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Sqr.class)
-	public <I extends RealType<I>, O extends RealType<O>> O sqr(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sqr.class, out, in);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sqrt.class)
-	public Object sqrt(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sqrt.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSqrt.class)
 	public double sqrt(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleSqrt.class, a);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleSqrt.class, a);
 		return result;
 	}
 
@@ -1848,8 +1646,23 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Sqrt.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sqrt.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Sqrt.class)
+	public Object sqrt(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Sqrt.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Step.class)
+	public <I extends RealType<I>, O extends RealType<O>> O step(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Step.class, out,
+			in);
 		return result;
 	}
 
@@ -1858,50 +1671,99 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Step.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Step.class)
-	public <I extends RealType<I>, O extends RealType<O>> O step(final O out,
-		final I in)
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.SubtractByte.class,
+		net.imagej.ops.math.ConstantToArrayImage.SubtractByte.class })
+	public ArrayImg<ByteType, ByteArray> subtract(
+		final ArrayImg<ByteType, ByteArray> image, final byte value)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Step.class, out, in);
+		final ArrayImg<ByteType, ByteArray> result =
+			(ArrayImg<ByteType, ByteArray>) ops().run(Ops.Math.Subtract.NAME, image,
+				value);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Subtract.class)
-	public Object subtract(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Subtract.class, args);
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerSubtract.class)
-	public int subtract(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(
-				net.imagej.ops.math.PrimitiveMath.IntegerSubtract.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongSubtract.class)
-	public long subtract(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongSubtract.class, a,
-				b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatSubtract.class)
-	public float subtract(final float a, final float b) {
-		final float result =
-			(Float) ops().run(net.imagej.ops.math.PrimitiveMath.FloatSubtract.class,
-				a, b);
+	@OpMethod(ops = {
+		net.imagej.ops.math.ConstantToArrayImageP.SubtractDouble.class,
+		net.imagej.ops.math.ConstantToArrayImage.SubtractDouble.class })
+	public ArrayImg<DoubleType, DoubleArray> subtract(
+		final ArrayImg<DoubleType, DoubleArray> image, final double value)
+	{
+		@SuppressWarnings("unchecked")
+		final ArrayImg<DoubleType, DoubleArray> result =
+			(ArrayImg<DoubleType, DoubleArray>) ops().run(Ops.Math.Subtract.NAME,
+				image, value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSubtract.class)
 	public double subtract(final double a, final double b) {
-		final double result =
-			(Double) ops().run(
-				net.imagej.ops.math.PrimitiveMath.DoubleSubtract.class, a, b);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleSubtract.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.FloatSubtract.class)
+	public float subtract(final float a, final float b) {
+		final float result = (Float) ops().run(
+			net.imagej.ops.math.PrimitiveMath.FloatSubtract.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Subtract.class)
+	public <T extends NumericType<T>> Img<T> subtract(final Img<T> out,
+		final Img<T> in, final IterableInterval<T> ii)
+	{
+		@SuppressWarnings("unchecked")
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Subtract.class, out, in, ii);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IterableIntervalToImg.Subtract.class)
+	public <T extends NumericType<T>> Img<T> subtract(final Img<T> in,
+		final IterableInterval<T> ii)
+	{
+		@SuppressWarnings("unchecked")
+		final Img<T> result = (Img<T>) ops().run(
+			net.imagej.ops.math.IterableIntervalToImg.Subtract.class, in, ii);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerSubtract.class)
+	public int subtract(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerSubtract.class, a, b);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Subtract.class)
+	public <T extends NumericType<T>> IterableInterval<T> subtract(
+		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.RandomAccessibleIntervalToIterableInterval.Subtract.class,
+			a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Subtract.class)
+	public <T extends NumericType<T>> IterableRealInterval<T> subtract(
+		final IterableRealInterval<T> image, final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
+			net.imagej.ops.math.ConstantToImageInPlace.Subtract.class, image, value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongSubtract.class)
+	public long subtract(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongSubtract.class, a, b);
 		return result;
 	}
 
@@ -1910,18 +1772,46 @@ public class MathNamespace extends AbstractNamespace {
 		final I in, final double constant)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Subtract.class, out, in,
-				constant);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Subtract.class,
+			out, in, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Subtract.class)
+	public Object subtract(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Subtract.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class)
+	public PlanarImg<DoubleType, DoubleArray> subtract(
+		final PlanarImg<DoubleType, DoubleArray> image, final double value)
+	{
+		@SuppressWarnings("unchecked")
+		final PlanarImg<DoubleType, DoubleArray> result =
+			(PlanarImg<DoubleType, DoubleArray>) ops().run(
+				net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class, image,
+				value);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.ConstantToImageFunctional.Subtract.class)
+	public <T extends NumericType<T>> RandomAccessibleInterval<T> subtract(
+		final RandomAccessibleInterval<T> out, final IterableInterval<T> in,
+		final T value)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(
+				net.imagej.ops.math.ConstantToImageFunctional.Subtract.class, out, in,
+				value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class)
 	public <T extends NumericType<T>> T subtract(final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class,
-				in, b);
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, in, b);
 		return result;
 	}
 
@@ -1930,21 +1820,15 @@ public class MathNamespace extends AbstractNamespace {
 		final T b)
 	{
 		@SuppressWarnings("unchecked")
-		final T result =
-			(T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class,
-				out, in, b);
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, out, in, b);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Tan.class)
-	public Object tan(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Tan.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleTan.class)
 	public double tan(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleTan.class, a);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleTan.class, a);
 		return result;
 	}
 
@@ -1953,20 +1837,20 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Tan.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Tan.class, out,
+			in);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Tanh.class)
-	public Object tanh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Tanh.class, args);
+	@OpMethod(op = net.imagej.ops.Ops.Math.Tan.class)
+	public Object tan(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Tan.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleTanh.class)
 	public double tanh(final double a) {
-		final double result =
-			(Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleTanh.class, a);
+		final double result = (Double) ops().run(
+			net.imagej.ops.math.PrimitiveMath.DoubleTanh.class, a);
 		return result;
 	}
 
@@ -1975,8 +1859,23 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Tanh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Tanh.class, out,
+			in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Tanh.class)
+	public Object tanh(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Tanh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.RealMath.Ulp.class)
+	public <I extends RealType<I>, O extends RealType<O>> O ulp(final O out,
+		final I in)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Ulp.class, out,
+			in);
 		return result;
 	}
 
@@ -1985,13 +1884,18 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Ulp.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Ulp.class)
-	public <I extends RealType<I>, O extends RealType<O>> O ulp(final O out,
-		final I in)
-	{
-		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Ulp.class, out, in);
+	@OpMethod(
+		op = net.imagej.ops.math.PrimitiveMath.IntegerUnsignedRightShift.class)
+	public int unsignedRightShift(final int a, final int b) {
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerUnsignedRightShift.class, a, b);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongUnsignedRightShift.class)
+	public long unsignedRightShift(final long a, final long b) {
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongUnsignedRightShift.class, a, b);
 		return result;
 	}
 
@@ -2000,42 +1904,17 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.UnsignedRightShift.class, args);
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.PrimitiveMath.IntegerUnsignedRightShift.class)
-	public int unsignedRightShift(final int a, final int b) {
-		final int result =
-			(Integer) ops()
-				.run(net.imagej.ops.math.PrimitiveMath.IntegerUnsignedRightShift.class,
-					a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongUnsignedRightShift.class)
-	public
-		long unsignedRightShift(final long a, final long b) {
-		final long result =
-			(Long) ops().run(
-				net.imagej.ops.math.PrimitiveMath.LongUnsignedRightShift.class, a, b);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Xor.class)
-	public Object xor(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Xor.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerXor.class)
 	public int xor(final int a, final int b) {
-		final int result =
-			(Integer) ops().run(net.imagej.ops.math.PrimitiveMath.IntegerXor.class,
-				a, b);
+		final int result = (Integer) ops().run(
+			net.imagej.ops.math.PrimitiveMath.IntegerXor.class, a, b);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.LongXor.class)
 	public long xor(final long a, final long b) {
-		final long result =
-			(Long) ops().run(net.imagej.ops.math.PrimitiveMath.LongXor.class, a, b);
+		final long result = (Long) ops().run(
+			net.imagej.ops.math.PrimitiveMath.LongXor.class, a, b);
 		return result;
 	}
 
@@ -2044,15 +1923,14 @@ public class MathNamespace extends AbstractNamespace {
 		final I in, final long constant)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.XorConstant.class, out, in,
-				constant);
+		final O result = (O) ops().run(
+			net.imagej.ops.math.RealMath.XorConstant.class, out, in, constant);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Zero.class)
-	public Object zero(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Zero.class, args);
+	@OpMethod(op = net.imagej.ops.Ops.Math.Xor.class)
+	public Object xor(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Xor.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.RealMath.Zero.class)
@@ -2060,9 +1938,14 @@ public class MathNamespace extends AbstractNamespace {
 		final I in)
 	{
 		@SuppressWarnings("unchecked")
-		final O result =
-			(O) ops().run(net.imagej.ops.math.RealMath.Zero.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Zero.class, out,
+			in);
 		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Zero.class)
+	public Object zero(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Zero.class, args);
 	}
 
 	// -- Named methods --

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -2073,13 +2073,11 @@ public class MathNamespace extends AbstractNamespace {
 		return ops().run(net.imagej.ops.Ops.Math.Xor.class, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.math.RealMath.Zero.class)
-	public <I extends RealType<I>, O extends RealType<O>> O zero(final O out,
-		final I in)
-	{
+	@OpMethod(op = net.imagej.ops.math.NumericTypeNullaryMath.Zero.class)
+	public <T extends NumericType<T>> T zero(final T out) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Zero.class, out,
-			in);
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeNullaryMath.Zero.class, out);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -212,15 +212,24 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.IIToRAIOutputII.Add.class)
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Add.class)
 	public <T extends NumericType<T>> IterableInterval<T> add(
-		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+		final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.IIToRAIOutputII.Add.class,
-			a, b);
+			net.imagej.ops.math.IIToRAIOutputII.Add.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Add.class)
+	public <T extends NumericType<T>> IterableInterval<T> add(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final RandomAccessibleInterval<T> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToRAIOutputII.Add.class, out, in1, in2);
 		return result;
 	}
 
@@ -894,15 +903,24 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.IIToRAIOutputII.Divide.class)
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Divide.class)
 	public <T extends NumericType<T>> IterableInterval<T> divide(
-		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+		final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.IIToRAIOutputII.Divide.class,
-			a, b);
+			net.imagej.ops.math.IIToRAIOutputII.Divide.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Divide.class)
+	public <T extends NumericType<T>> IterableInterval<T> divide(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final RandomAccessibleInterval<T> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToRAIOutputII.Divide.class, out, in1, in2);
 		return result;
 	}
 
@@ -1426,15 +1444,24 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.IIToRAIOutputII.Multiply.class)
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Multiply.class)
 	public <T extends NumericType<T>> IterableInterval<T> multiply(
-		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+		final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.IIToRAIOutputII.Multiply.class,
-			a, b);
+			net.imagej.ops.math.IIToRAIOutputII.Multiply.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Multiply.class)
+	public <T extends NumericType<T>> IterableInterval<T> multiply(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final RandomAccessibleInterval<T> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToRAIOutputII.Multiply.class, out, in1, in2);
 		return result;
 	}
 
@@ -2161,15 +2188,24 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(
-		op = net.imagej.ops.math.IIToRAIOutputII.Subtract.class)
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Subtract.class)
 	public <T extends NumericType<T>> IterableInterval<T> subtract(
-		final IterableInterval<T> a, final RandomAccessibleInterval<T> b)
+		final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-			net.imagej.ops.math.IIToRAIOutputII.Subtract.class,
-			a, b);
+			net.imagej.ops.math.IIToRAIOutputII.Subtract.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.math.IIToRAIOutputII.Subtract.class)
+	public <T extends NumericType<T>> IterableInterval<T> subtract(
+		final IterableInterval<T> out, final IterableInterval<T> in1,
+		final RandomAccessibleInterval<T> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.math.IIToRAIOutputII.Subtract.class, out, in1, in2);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -221,13 +221,13 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Add.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Add.class)
 	public <T extends NumericType<T>> IterableRealInterval<T> add(
 		final IterableRealInterval<T> image, final T value)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToImageInPlace.Add.class, image, value);
+			net.imagej.ops.math.ConstantToIIOutputII.Add.class, image, value);
 		return result;
 	}
 
@@ -895,13 +895,13 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Divide.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Divide.class)
 	public <T extends NumericType<T>> IterableRealInterval<T> divide(
 		final IterableRealInterval<T> image, final T value)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToImageInPlace.Divide.class, image, value);
+			net.imagej.ops.math.ConstantToIIOutputII.Divide.class, image, value);
 		return result;
 	}
 
@@ -1417,13 +1417,13 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Multiply.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Multiply.class)
 	public <T extends NumericType<T>> IterableRealInterval<T> multiply(
 		final IterableRealInterval<T> image, final T value)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToImageInPlace.Multiply.class, image, value);
+			net.imagej.ops.math.ConstantToIIOutputII.Multiply.class, image, value);
 		return result;
 	}
 
@@ -2136,13 +2136,13 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.math.ConstantToImageInPlace.Subtract.class)
+	@OpMethod(op = net.imagej.ops.math.ConstantToIIOutputII.Subtract.class)
 	public <T extends NumericType<T>> IterableRealInterval<T> subtract(
 		final IterableRealInterval<T> image, final T value)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableRealInterval<T> result = (IterableRealInterval<T>) ops().run(
-			net.imagej.ops.math.ConstantToImageInPlace.Subtract.class, image, value);
+			net.imagej.ops.math.ConstantToIIOutputII.Subtract.class, image, value);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/NumericTypeNullaryMath.java
+++ b/src/main/java/net/imagej/ops/math/NumericTypeNullaryMath.java
@@ -1,0 +1,90 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractNullaryComputerOp;
+import net.imagej.ops.special.InplaceOp;
+import net.imglib2.type.numeric.NumericType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Nullary Ops of the {@code math} namespace which operate on
+ * {@link NumericType}s.
+ * 
+ * @author Leon Yang
+ */
+public class NumericTypeNullaryMath {
+
+	private NumericTypeNullaryMath() {
+		// NB: Prevent instantiation of utility class.
+	}
+
+	/**
+	 * Sets the output to zero.
+	 */
+	@Plugin(type = Ops.Math.Zero.class)
+	public static class Zero<T extends NumericType<T>> extends
+		AbstractNullaryComputerOp<T> implements InplaceOp<T>, Ops.Math.Zero
+	{
+
+		@Override
+		public void compute0(final T output) {
+			output.setZero();
+		}
+
+		@Override
+		public void run() {
+			InplaceOp.super.run();
+		}
+
+		@Override
+		public void mutate(T arg) {
+			compute0(arg);
+		}
+
+		@Override
+		public T arg() {
+			return out();
+		}
+
+		@Override
+		public void setArg(T arg) {
+			setOutput(arg);
+		}
+
+		@Override
+		public Zero<T> getIndependentInstance() {
+			return this;
+		}
+	}
+}

--- a/src/main/java/net/imagej/ops/math/RealBinaryMath.java
+++ b/src/main/java/net/imagej/ops/math/RealBinaryMath.java
@@ -1,0 +1,167 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractBinaryComputerOp;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Binary Ops of the {@code math} namespace which operate on {@link RealType}s.
+ *
+ * @author Leon Yang
+ */
+public class RealBinaryMath {
+
+	private RealBinaryMath() {
+		// NB: Prevent instantiation of utility class.
+	}
+
+	/**
+	 * Sets the real component of an output real number to the addition of the
+	 * real components of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.Add.class)
+	public static class Add<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.Add
+	{
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			output.setReal(input1.getRealDouble() + input2.getRealDouble());
+		}
+	}
+
+	/**
+	 * Sets the real component of an output real number to the logical AND of the
+	 * real component of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.And.class)
+	public static class And<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.And
+	{
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			output.setReal((long) input1.getRealDouble() & (long) input2
+				.getRealDouble());
+		}
+	}
+
+	/**
+	 * Sets the real component of an output real number to the division of the
+	 * real component of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.Divide.class)
+	public static class Divide<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.Divide
+	{
+
+		@Parameter
+		private double dbzVal;
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			if (input2.getRealDouble() == 0) {
+				output.setReal(dbzVal);
+			}
+			else {
+				output.setReal(input1.getRealDouble() / input2.getRealDouble());
+			}
+		}
+	}
+
+	/**
+	 * Sets the real component of an output real number to the multiplication of
+	 * the real component of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.Multiply.class)
+	public static class Multiply<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.Multiply
+	{
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			output.setReal(input1.getRealDouble() * input2.getRealDouble());
+		}
+	}
+
+	/**
+	 * Sets the real component of an output real number to the logical OR of the
+	 * real component of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.Or.class)
+	public static class Or<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.Or
+	{
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			output.setReal((long) input1.getRealDouble() | (long) input2
+				.getRealDouble());
+		}
+	}
+
+	/**
+	 * Sets the real component of an output real number to the subtraction between
+	 * the real component of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.Subtract.class)
+	public static class Subtract<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.Subtract
+	{
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			output.setReal(input1.getRealDouble() - input2.getRealDouble());
+		}
+	}
+
+	/**
+	 * Sets the real component of an output real number to the logical XOR of the
+	 * real component of two input real numbers.
+	 */
+	@Plugin(type = Ops.Math.Xor.class)
+	public static class Xor<I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>>
+		extends AbstractBinaryComputerOp<I1, I2, O> implements Ops.Math.Xor
+	{
+
+		@Override
+		public void compute2(final I1 input1, final I2 input2, final O output) {
+			output.setReal((long) input1.getRealDouble() ^ (long) input2
+				.getRealDouble());
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/math/RealMath.java
+++ b/src/main/java/net/imagej/ops/math/RealMath.java
@@ -334,8 +334,8 @@ public final class RealMath {
 	 * component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Ceil.class)
-	public static class Ceil<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Ceil
+	public static class Ceil<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Ceil
 	{
 
 		@Override
@@ -364,8 +364,8 @@ public final class RealMath {
 	 * of the real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Cosh.class)
-	public static class Cosh<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Cosh
+	public static class Cosh<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Cosh
 	{
 
 		@Override
@@ -394,8 +394,8 @@ public final class RealMath {
 	 * cotangent of the real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Coth.class)
-	public static class Coth<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Coth
+	public static class Coth<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Coth
 	{
 
 		@Override
@@ -424,8 +424,8 @@ public final class RealMath {
 	 * of the real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Csch.class)
-	public static class Csch<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Csch
+	public static class Csch<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Csch
 	{
 
 		@Override
@@ -596,8 +596,8 @@ public final class RealMath {
 	 * real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Log2.class)
-	public static class Log2<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Log2
+	public static class Log2<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Log2
 	{
 
 		@Override
@@ -865,8 +865,8 @@ public final class RealMath {
 	 * of the real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Sech.class)
-	public static class Sech<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Sech
+	public static class Sech<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Sech
 	{
 
 		@Override
@@ -913,8 +913,8 @@ public final class RealMath {
 	 * sin(x) / x.
 	 */
 	@Plugin(type = Ops.Math.Sinc.class)
-	public static class Sinc<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Sinc
+	public static class Sinc<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Sinc
 	{
 
 		@Override
@@ -952,8 +952,8 @@ public final class RealMath {
 	 * the real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Sinh.class)
-	public static class Sinh<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Sinh
+	public static class Sinh<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Sinh
 	{
 
 		@Override
@@ -983,8 +983,8 @@ public final class RealMath {
 	 * real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Sqrt.class)
-	public static class Sqrt<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Sqrt
+	public static class Sqrt<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Sqrt
 	{
 
 		@Override
@@ -1000,8 +1000,8 @@ public final class RealMath {
 	 * with h(0) = 1 rather than 0.5.
 	 */
 	@Plugin(type = Ops.Math.Step.class)
-	public static class Step<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Step
+	public static class Step<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Step
 	{
 
 		@Override
@@ -1049,8 +1049,8 @@ public final class RealMath {
 	 * of the real component of an input real number.
 	 */
 	@Plugin(type = Ops.Math.Tanh.class)
-	public static class Tanh<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Tanh
+	public static class Tanh<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Tanh
 	{
 
 		@Override
@@ -1098,8 +1098,8 @@ public final class RealMath {
 	 * Sets the real component of an output real number to zero.
 	 */
 	@Plugin(type = Ops.Math.Zero.class)
-	public static class Zero<I extends RealType<I>, O extends RealType<O>>
-		extends AbstractUnaryComputerOp<I, O> implements Ops.Math.Zero
+	public static class Zero<I extends RealType<I>, O extends RealType<O>> extends
+		AbstractUnaryComputerOp<I, O> implements Ops.Math.Zero
 	{
 
 		@Override

--- a/src/main/java/net/imagej/ops/math/RealMath.java
+++ b/src/main/java/net/imagej/ops/math/RealMath.java
@@ -1094,18 +1094,4 @@ public final class RealMath {
 		}
 	}
 
-	/**
-	 * Sets the real component of an output real number to zero.
-	 */
-	@Plugin(type = Ops.Math.Zero.class)
-	public static class Zero<I extends RealType<I>, O extends RealType<O>> extends
-		AbstractUnaryComputerOp<I, O> implements Ops.Math.Zero
-	{
-
-		@Override
-		public void compute1(final I input, final O output) {
-			output.setZero();
-		}
-	}
-
 }

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.list
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.list
@@ -1,11 +1,14 @@
-# Generated binary arithmetic ops with ArrayImages of ByteType or DoubleType.
+# Generated binary arithmetic ops with ArrayImages.
 
 [ConstantToArrayImage.java]
 
 types = ```
 [
-	[name: "Byte",   primitive: "byte"], 
-	[name: "Double", primitive: "double"]
+	[name: "Byte",     primitive: "byte"], 
+	[name: "Int",      primitive: "int"], 
+	[name: "Long",     primitive: "long"], 
+	[name: "Float",    primitive: "float"], 
+	[name: "Double",   primitive: "double"]
 ]
 ```
 

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.vm
@@ -30,9 +30,9 @@
 
 package net.imagej.ops.math;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractInplaceOp;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
@@ -45,7 +45,7 @@ import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 
-import org.scijava.ItemIO;
+import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -63,21 +63,22 @@ public final class ConstantToArrayImage {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($type in $types)
+#set ($imgType = "ArrayImg<${type.name}Type, ${type.name}Array>")
 #foreach ($op in $ops)
 #set ($iface = "Ops.Math.$op.name")
 
-	@Plugin(type = ${iface}.class)
-	public static class ${op.name}${type.name} extends AbstractOp implements Contingent, $iface {
-
-		@Parameter(type = ItemIO.BOTH)
-		private ArrayImg<${type.name}Type, ${type.name}Array> image;
+	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
+	public static class ${op.name}${type.name} extends
+		AbstractInplaceOp<$imgType> implements Contingent,
+		$iface
+	{
 
 		@Parameter
 		private ${type.primitive} value;
 
 		@Override
-		public void run() {
-			final ${type.primitive}[] data = image.update(null).getCurrentStorageArray();
+		public void mutate(final $imgType arg) {
+			final ${type.primitive}[] data = arg.update(null).getCurrentStorageArray();
 			for (int i = 0; i < data.length; i++) {
 				data[i] ${op.operator}= value;
 			}
@@ -88,7 +89,7 @@ public final class ConstantToArrayImage {
 			// NB: Until https://github.com/imagej/imagej-ops/issues/95 is addressed.
 			// The warning is expected, because the image parameter is assigned via
 			// reflection and hence might not match the declared generic types.
-			return image.firstElement() instanceof ${type.name}Type;
+			return arg().firstElement() instanceof ${type.name}Type;
 		}
 	}
 #end

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.vm
@@ -35,9 +35,15 @@ import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
-import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImage.vm
@@ -31,6 +31,7 @@
 package net.imagej.ops.math;
 
 import net.imagej.ops.AbstractOp;
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
@@ -39,7 +40,6 @@ import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.type.numeric.real.DoubleType;
 
 import org.scijava.ItemIO;
-import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -60,8 +60,8 @@ public final class ConstantToArrayImage {
 #foreach ($op in $ops)
 #set ($iface = "Ops.Math.$op.name")
 
-	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY#if ($type.name == "Double") + 1#elseif ($type.name == "Byte")#end)
-	public static class ${op.name}${type.name} extends AbstractOp implements $iface {
+	@Plugin(type = ${iface}.class)
+	public static class ${op.name}${type.name} extends AbstractOp implements Contingent, $iface {
 
 		@Parameter(type = ItemIO.BOTH)
 		private ArrayImg<${type.name}Type, ${type.name}Array> image;
@@ -75,6 +75,14 @@ public final class ConstantToArrayImage {
 			for (int i = 0; i < data.length; i++) {
 				data[i] ${op.operator}= value;
 			}
+		}
+
+		@Override
+		public boolean conforms() {
+			// NB: Until https://github.com/imagej/imagej-ops/issues/95 is addressed.
+			// The warning is expected, because the image parameter is assigned via
+			// reflection and hence might not match the declared generic types.
+			return image.firstElement() instanceof ${type.name}Type;
 		}
 	}
 #end

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.list
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.list
@@ -1,12 +1,14 @@
-# Generated multi-threaded version of binary arithmetic ops with generic images
-# of ByteType or DoubleType.
+# Generated multi-threaded version of binary arithmetic ops with ArrayImages.
 
 [ConstantToArrayImageP.java]
 
 types = ```
 [
-	[name: "Byte",   primitive: "byte"], 
-	[name: "Double", primitive: "double"]
+	[name: "Byte",     primitive: "byte"], 
+	[name: "Int",      primitive: "int"], 
+	[name: "Long",     primitive: "long"], 
+	[name: "Float",    primitive: "float"], 
+	[name: "Double",   primitive: "double"]
 ]
 ```
 

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
@@ -30,9 +30,9 @@
 
 package net.imagej.ops.math;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractInplaceOp;
 import net.imagej.ops.thread.chunker.Chunk;
 import net.imagej.ops.thread.chunker.ChunkerOp;
 import net.imglib2.img.array.ArrayImg;
@@ -47,7 +47,6 @@ import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 
-import org.scijava.ItemIO;
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -68,6 +67,7 @@ public final class ConstantToArrayImageP {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($type in $types)
+#set ($imgType = "ArrayImg<${type.name}Type, ${type.name}Array>")
 #foreach ($op in $ops)
 #set ($iface = "Ops.Math.$op.name")
 
@@ -77,18 +77,18 @@ public final class ConstantToArrayImageP {
 	 * 
 	 * @author Christian Dietz (University of Konstanz)
 	 */
-	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY#if ($type.name == "Double") + 11#else + 10#end)
-	public static class ${op.name}${type.name} extends AbstractOp implements Contingent, $iface {
-
-		@Parameter(type = ItemIO.BOTH)
-		private ArrayImg<${type.name}Type, ${type.name}Array> image;
+	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY + 1)
+	public static class ${op.name}${type.name} extends
+		AbstractInplaceOp<$imgType> implements Contingent,
+		$iface
+	{
 
 		@Parameter
 		private ${type.primitive} value;
 
 		@Override
-		public void run() {
-			final ${type.primitive}[] data = image.update(null).getCurrentStorageArray();
+		public void mutate(final $imgType arg) {
+			final ${type.primitive}[] data = arg.update(null).getCurrentStorageArray();
 			ops().run(ChunkerOp.class, new Chunk() {
 
 				@Override
@@ -113,7 +113,7 @@ public final class ConstantToArrayImageP {
 			// NB: Until https://github.com/imagej/imagej-ops/issues/95 is addressed.
 			// The warning is expected, because the image parameter is assigned via
 			// reflection and hence might not match the declared generic types.
-			return image.firstElement() instanceof ${type.name}Type;
+			return arg().firstElement() instanceof ${type.name}Type;
 		}
 	}
 #end

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
@@ -32,15 +32,20 @@ package net.imagej.ops.math;
 
 import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
-import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.thread.chunker.Chunk;
 import net.imagej.ops.thread.chunker.ChunkerOp;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
-import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.scijava.ItemIO;
 import org.scijava.Priority;

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
@@ -31,6 +31,7 @@
 package net.imagej.ops.math;
 
 import net.imagej.ops.AbstractOp;
+import net.imagej.ops.Contingent;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.thread.chunker.Chunk;
@@ -72,7 +73,7 @@ public final class ConstantToArrayImageP {
 	 * @author Christian Dietz (University of Konstanz)
 	 */
 	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY#if ($type.name == "Double") + 11#else + 10#end)
-	public static class ${op.name}${type.name} extends AbstractOp implements $iface {
+	public static class ${op.name}${type.name} extends AbstractOp implements Contingent, $iface {
 
 		@Parameter(type = ItemIO.BOTH)
 		private ArrayImg<${type.name}Type, ${type.name}Array> image;
@@ -100,6 +101,14 @@ public final class ConstantToArrayImageP {
 					}
 				}
 			}, data.length);
+		}
+
+		@Override
+		public boolean conforms() {
+			// NB: Until https://github.com/imagej/imagej-ops/issues/95 is addressed.
+			// The warning is expected, because the image parameter is assigned via
+			// reflection and hence might not match the declared generic types.
+			return image.firstElement() instanceof ${type.name}Type;
 		}
 	}
 #end

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.list
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.list
@@ -1,4 +1,4 @@
-# Generated in-place binary arithmetic ops with generic images.
+# Generated functional binary arithmetic ops with II as both input and output.
 
 [ConstantToIIOutputII.java]
 

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.list
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.list
@@ -1,6 +1,6 @@
 # Generated in-place binary arithmetic ops with generic images.
 
-[ConstantToImageInPlace.java]
+[ConstantToIIOutputII.java]
 
 ops = ```
 [

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.vm
@@ -30,18 +30,23 @@
 
 package net.imagej.ops.math;
 
-import net.imagej.ops.AbstractOp;
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
-import net.imglib2.IterableRealInterval;
+import net.imagej.ops.special.AbstractUnaryHybridOp;
+import net.imagej.ops.special.InplaceOp;
+import net.imagej.ops.special.Output;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.NumericType;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Wrapper class for in-place binary math operations between constant values 
- * and images in format of (@link IterableRealInterval}.
+ * Wrapper class for functional binary math operations between constant values 
+ * and {@link IterableInterval}s, and write the result
+ * to {@link IterableInterval}s.
  *
  * @author Leon Yang
  */
@@ -54,21 +59,73 @@ public final class ConstantToIIOutputII {
 #set ($iface = "Ops.Math.$op.name")
 
 	@Plugin(type = ${iface}.class)
-	public static class ${op.name}<T extends NumericType<T>> extends AbstractOp implements
-		$iface
+	public static class ${op.name}<T extends NumericType<T>> extends
+		AbstractUnaryHybridOp<IterableInterval<T>, IterableInterval<T>>
+		implements InplaceOp<IterableInterval<T>>, Contingent, $iface
 	{
-
-		@Parameter(type = ItemIO.BOTH)
-		private IterableRealInterval<T> image;
 
 		@Parameter
 		private T value;
 
+		private Op outputCreator;
+
 		@Override
-		public void run() {
-			for (final T t : image) {
+		public void initialize() {
+			outputCreator = ops().op(Ops.Create.Img.class, in(), in().firstElement()
+				.createVariable());
+		}
+
+		@Override
+		public void compute1(final IterableInterval<T> input,
+			final IterableInterval<T> output)
+		{
+			final Cursor<T> inCursor = input.cursor();
+			final Cursor<T> outCursor = output.cursor();
+			while (inCursor.hasNext()) {
+				outCursor.next().set(inCursor.next());
+				outCursor.get().${op.function}(value);
+			}
+		}
+
+		@Override
+		public IterableInterval<T> createOutput(
+			final IterableInterval<T> input)
+		{
+			// NB: Temporary approach until DefaultCreateImg and friends are properly
+			// typed as the needed SpecialOp subtypes.
+			outputCreator.run();
+			@SuppressWarnings("unchecked")
+			final IterableInterval<T> created =
+				((Output<IterableInterval<T>>) outputCreator).out();
+			return created;
+		}
+
+		@Override
+		public boolean conforms() {
+			if (out() == null) return true;
+			return in().iterationOrder().equals(out().iterationOrder());
+		}
+
+		@Override
+		public void mutate(final IterableInterval<T> arg) {
+			for (final T t : arg) {
 				t.${op.function}(value);
 			}
+		}
+
+		@Override
+		public IterableInterval<T> arg() {
+			return out();
+		}
+
+		@Override
+		public void setArg(final IterableInterval<T> arg) {
+			setOutput(arg);
+		}
+
+		@Override
+		public ${op.name}<T> getIndependentInstance() {
+			return this;
 		}
 
 	}

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.vm
@@ -45,9 +45,9 @@ import org.scijava.plugin.Plugin;
  *
  * @author Leon Yang
  */
-public final class ConstantToImageInPlace {
+public final class ConstantToIIOutputII {
 	
-	private ConstantToImageInPlace() {
+	private ConstantToIIOutputII() {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($op in $ops)

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputRAI.list
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputRAI.list
@@ -1,6 +1,6 @@
-# Generated functional binary arithmetic ops with ArrayImages.
+# Generated functional binary arithmetic ops with II as input and RAI as output.
 
-[ConstantToImageFunctional.java]
+[ConstantToIIOutputRAI.java]
 
 ops = ```
 [

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputRAI.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputRAI.vm
@@ -44,13 +44,14 @@ import org.scijava.plugin.Plugin;
 
 /**
  * Wrapper class for functional binary math operations between constant values 
- * and images in format of {@link IterableInterval}s.
+ * and {@link IterableInterval}s, and write the result
+ * to {@link RandomAccessibleInterval}s.
  *
  * @author Leon Yang
  */
-public final class ConstantToImageFunctional {
+public final class ConstantToIIOutputRAI {
 	
-	private ConstantToImageFunctional() {
+	private ConstantToIIOutputRAI() {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($op in $ops)

--- a/src/main/templates/net/imagej/ops/math/ConstantToPlanarImage.list
+++ b/src/main/templates/net/imagej/ops/math/ConstantToPlanarImage.list
@@ -1,10 +1,14 @@
-# Generated binary arithmetic ops with PlanarImages of ByteType or DoubleType. 
+# Generated binary arithmetic ops with PlanarImages. 
 
 [ConstantToPlanarImage.java]
 
 types = ```
 [
-	[name: "Double", primitive: "double"], 
+	[name: "Byte",     primitive: "byte"], 
+	[name: "Int",      primitive: "int"], 
+	[name: "Long",     primitive: "long"], 
+	[name: "Float",    primitive: "float"], 
+	[name: "Double",   primitive: "double"]
 ]
 ```
 

--- a/src/main/templates/net/imagej/ops/math/ConstantToPlanarImage.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToPlanarImage.vm
@@ -30,9 +30,9 @@
 
 package net.imagej.ops.math;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractInplaceOp;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
@@ -45,7 +45,6 @@ import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -64,26 +63,27 @@ public final class ConstantToPlanarImage {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($type in $types)
+#set ($imgType = "PlanarImg<${type.name}Type, ${type.name}Array>")
 #foreach ($op in $ops)
 #set ($iface = "Ops.Math.$op.name")
 	
 	@Plugin(type = ${iface}.class)
-	public static class ${op.name}${type.name} extends AbstractOp implements $iface, Contingent {
-
-		@Parameter(type = ItemIO.BOTH)
-		private PlanarImg<${type.name}Type, ${type.name}Array> image;
+	public static class ${op.name}${type.name} extends
+		AbstractInplaceOp<$imgType> implements $iface,
+		Contingent
+	{
 
 		@Parameter
 		private ${type.primitive} value;
 
 		@Override
-		public void run() {
+		public void mutate(final $imgType arg) {
 			long planeCount = 1;
-			for (int d = 2; d < image.numDimensions(); d++) {
-				planeCount *= image.dimension(d);
+			for (int d = 2; d < arg.numDimensions(); d++) {
+				planeCount *= arg.dimension(d);
 			}
 			for (int p = 0; p < planeCount; p++) {
-				final ${type.primitive}[] plane = image.getPlane(p).getCurrentStorageArray();
+				final ${type.primitive}[] plane = arg.getPlane(p).getCurrentStorageArray();
 				for (int i = 0; i < plane.length; i++) {
 					plane[i] ${op.operator}= value;
 				}
@@ -95,7 +95,7 @@ public final class ConstantToPlanarImage {
 			// NB: Until https://github.com/imagej/imagej-ops/issues/95 is addressed.
 			// The warning is expected, because the image parameter is assigned via
 			// reflection and hence might not match the declared generic types.
-			return image.firstElement() instanceof ${type.name}Type;
+			return arg().firstElement() instanceof ${type.name}Type;
 		}
 
 	}

--- a/src/main/templates/net/imagej/ops/math/ConstantToPlanarImage.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToPlanarImage.vm
@@ -33,9 +33,17 @@ package net.imagej.ops.math;
 import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;

--- a/src/main/templates/net/imagej/ops/math/IIToIIOutputII.list
+++ b/src/main/templates/net/imagej/ops/math/IIToIIOutputII.list
@@ -1,6 +1,7 @@
-# Generated binary arithmetic ops with IterableIntervals and generic images.
+# Generated binary arithmetic ops with IterableIntervals and output to
+# IterableIntervals.
 
-[IterableIntervalToImg.java]
+[IIToIIOutputII.java]
 
 ops = ```
 [

--- a/src/main/templates/net/imagej/ops/math/IIToIIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/IIToIIOutputII.vm
@@ -45,14 +45,14 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Wrapper class for binary math operations between {@link IterableInterval} and 
- * {@link Img}s.
+ * Wrapper class for binary math operations between {@link IterableInterval}s
+ * and write result to {@link IterableInterval}s. 
  *
  * @author Leon Yang
  */
-public final class IterableIntervalToImg {
+public final class IIToIIOutputII {
 	
-	private IterableIntervalToImg() {
+	private IIToIIOutputII() {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($op in $ops)

--- a/src/main/templates/net/imagej/ops/math/IIToIIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/IIToIIOutputII.vm
@@ -31,17 +31,17 @@
 package net.imagej.ops.math;
 
 import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.AbstractUnaryHybridOp;
+import net.imagej.ops.special.AbstractBinaryHybridOp;
+import net.imagej.ops.special.InplaceOp;
+import net.imagej.ops.special.Output;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
-import net.imglib2.RandomAccess;
-import net.imglib2.img.Img;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Intervals;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -58,47 +58,92 @@ public final class IIToIIOutputII {
 #foreach ($op in $ops)
 #set ($iface = "Ops.Math.$op.name")
 	
-		@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
-		public static class ${op.name}<T extends NumericType<T>> extends
-			AbstractUnaryHybridOp<Img<T>, Img<T>> implements $iface, Contingent
+	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
+	public static class ${op.name}<T extends NumericType<T>> extends
+		AbstractBinaryHybridOp<IterableInterval<T>, IterableInterval<T>, IterableInterval<T>>
+		implements $iface, Contingent, InplaceOp<IterableInterval<T>>
+	{
+
+		private Op outputCreator;
+
+		@Override
+		public void initialize() {
+			outputCreator = ops().op(Ops.Create.Img.class, in1(), in1().firstElement()
+				.createVariable());
+		}
+
+		// TODO: extend common abstract base class which implements Contingent
+		// for dimensionality checking.
+
+		@Override
+		public boolean conforms() {
+			if (!Intervals.equalDimensions(in1(), in2())) return false;
+			if (!in1().iterationOrder().equals(in2().iterationOrder())) return false;
+			if (out() == null) return true;
+			return Intervals.equalDimensions(in1(), out()) && in1().iterationOrder()
+				.equals(out().iterationOrder());
+		}
+
+		@Override
+		public IterableInterval<T> createOutput(final IterableInterval<T> input1,
+			final IterableInterval<T> input2)
 		{
+			// NB: Temporary approach until DefaultCreateImg and friends are properly
+			// typed as the needed SpecialOp subtypes.
+			outputCreator.run();
+			@SuppressWarnings("unchecked")
+			final IterableInterval<T> created =
+				((Output<IterableInterval<T>>) outputCreator).out();
+			return created;
+		}
 
-			// TODO: extend common abstract base class which implements Contingent
-			// for dimensionality checking.
-			// TODO: code generate this and all add ops to generalize them to other
-			// operators.
-
-			@Parameter
-			private IterableInterval<T> ii;
-
-			@Override
-			public boolean conforms() {
-				if (!Intervals.equalDimensions(in(), ii)) return false;
-				if (out() == null) return true;
-				return Intervals.equalDimensions(ii, out());
+		@Override
+		public void compute2(final IterableInterval<T> input1,
+			final IterableInterval<T> input2, final IterableInterval<T> output)
+		{
+			final Cursor<T> in1Cursor = input1.cursor();
+			final Cursor<T> in2Cursor = input2.cursor();
+			final Cursor<T> outCursor = output.cursor();
+			while (in1Cursor.hasNext()) {
+				outCursor.next().set(in1Cursor.next());
+				outCursor.get().${op.function}(in2Cursor.next());
 			}
+		}
 
-			@Override
-			public Img<T> createOutput(final Img<T> input) {
-				return input.factory().create(input, input.firstElement());
-			}
-
-			@Override
-			public void compute1(final Img<T> input, final Img<T> output) {
-				final Cursor<T> cursor = ii.localizingCursor();
-				final RandomAccess<T> iRA = input.randomAccess();
-				final RandomAccess<T> oRA = output.randomAccess();
-				final T tmp = output.firstElement().copy();
-				while (cursor.hasNext()) {
-					cursor.fwd();
-					iRA.setPosition(cursor);
-					oRA.setPosition(cursor);
-					tmp.set(iRA.get());
-					tmp.${op.function}(cursor.get());
-					oRA.get().set(tmp);
+		@Override
+		public void mutate(final IterableInterval<T> arg) {
+			if (arg == in1()) {
+				final Cursor<T> in1Cursor = in1().cursor();
+				final Cursor<T> in2Cursor = in2().cursor();
+				while (in1Cursor.hasNext()) {
+					in1Cursor.next().${op.function}(in2Cursor.next());
+				}
+			} else {
+				final T tmp = in1().firstElement().createVariable();
+				final Cursor<T> in1Cursor = in1().cursor();
+				final Cursor<T> in2Cursor = in2().cursor();
+				while (in1Cursor.hasNext()) {
+					tmp.set(in1Cursor.next());
+					tmp.${op.function}(in2Cursor.next());
+					in2Cursor.get().set(tmp);
 				}
 			}
-
 		}
+
+		@Override
+		public IterableInterval<T> arg() {
+			return out();
+		}
+
+		@Override
+		public void setArg(final IterableInterval<T> arg) {
+			setOutput(arg);
+		}
+
+		@Override
+		public ${op.name}<T> getIndependentInstance() {
+			return this;
+		}
+	}
 #end
 }

--- a/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.list
+++ b/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.list
@@ -1,7 +1,7 @@
-# Generated binary arithmetic ops with RandomAccessibleIntervals and
-# IterableIntervals. 
+# Generated binary arithmetic ops with IterableIntervals and
+# RandomAccessibleIntervals, and output to IterableIntervals.
 
-[RandomAccessibleIntervalToIterableInterval.java]
+[IIToRAIOutputII.java]
 
 ops = ```
 [

--- a/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.vm
@@ -30,17 +30,19 @@
 
 package net.imagej.ops.math;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractBinaryHybridOp;
+import net.imagej.ops.special.InplaceOp;
+import net.imagej.ops.special.Output;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.NumericType;
+import net.imglib2.util.Intervals;
 
-import org.scijava.ItemIO;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -59,40 +61,82 @@ public final class IIToRAIOutputII {
 #set ($iface = "Ops.Math.$op.name")
 
 	@Plugin(type = ${iface}.class)
-	public static class ${op.name}<T extends NumericType<T>> extends AbstractOp
-		implements $iface, Contingent
+	public static class ${op.name}<T extends NumericType<T>> extends
+		AbstractBinaryHybridOp<IterableInterval<T>, RandomAccessibleInterval<T>, IterableInterval<T>>
+		implements $iface, Contingent, InplaceOp<IterableInterval<T>>
 	{
 
-		@Parameter(type = ItemIO.BOTH)
-		private IterableInterval<T> a;
-
-		@Parameter
-		private RandomAccessibleInterval<T> b;
+		private Op outputCreator;
 
 		@Override
-		public void run() {
-			final long[] pos = new long[a.numDimensions()];
-			final Cursor<T> cursor = a.cursor();
-			final RandomAccess<T> access = b.randomAccess();
-			while (cursor.hasNext()) {
-				cursor.fwd();
-				cursor.localize(pos);
-				access.setPosition(pos);
-				cursor.get().${op.function}(access.get());
+		public void initialize() {
+			outputCreator = ops().op(Ops.Create.Img.class, in1(), in1().firstElement()
+				.createVariable());
+		}
+
+		// TODO: extend common abstract base class which implements Contingent
+		// for dimensionality checking.
+
+		@Override
+		public boolean conforms() {
+			if (!Intervals.equalDimensions(in1(), in2())) return false;
+			if (out() == null) return true;
+			return Intervals.equalDimensions(in1(), out()) && in1().iterationOrder()
+				.equals(out().iterationOrder());
+		}
+
+		@Override
+		public IterableInterval<T> createOutput(final IterableInterval<T> input1,
+			final RandomAccessibleInterval<T> input2)
+		{
+			// NB: Temporary approach until DefaultCreateImg and friends are properly
+			// typed as the needed SpecialOp subtypes.
+			outputCreator.run();
+			@SuppressWarnings("unchecked")
+			final IterableInterval<T> created =
+				((Output<IterableInterval<T>>) outputCreator).out();
+			return created;
+		}
+
+		@Override
+		public void compute2(final IterableInterval<T> input1,
+			final RandomAccessibleInterval<T> input2,
+			final IterableInterval<T> output)
+		{
+			final Cursor<T> in1Cursor = input1.localizingCursor();
+			final RandomAccess<T> in2Access = input2.randomAccess();
+			final Cursor<T> outCursor = output.cursor();
+			while (in1Cursor.hasNext()) {
+				outCursor.next().set(in1Cursor.next());
+				in2Access.setPosition(in1Cursor);
+				outCursor.get().${op.function}(in2Access.get());
 			}
 		}
 
 		@Override
-		public boolean conforms() {
-			int n = a.numDimensions();
-			if (n != b.numDimensions()) return false;
-			long[] dimsA = new long[n], dimsB = new long[n];
-			a.dimensions(dimsA);
-			b.dimensions(dimsB);
-			for (int i = 0; i < n; i++) {
-				if (dimsA[i] != dimsB[i]) return false;
+		public void mutate(final IterableInterval<T> arg) {
+			final Cursor<T> argCursor = arg.localizingCursor();
+			final RandomAccess<T> in2Access = in2().randomAccess();
+			while (argCursor.hasNext()) {
+				argCursor.fwd();
+				in2Access.setPosition(argCursor);
+				argCursor.get().${op.function}(in2Access.get());
 			}
-			return true;
+		}
+
+		@Override
+		public IterableInterval<T> arg() {
+			return out();
+		}
+
+		@Override
+		public void setArg(final IterableInterval<T> arg) {
+			setOutput(arg);
+		}
+
+		@Override
+		public ${op.name}<T> getIndependentInstance() {
+			return this;
 		}
 
 	}

--- a/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.vm
@@ -44,14 +44,15 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Wrapper class for binary math operations between {@link RandomAccessibleInterval}
- * and {@link IterableInterval}s.
+ * Wrapper class for binary math operations between {@link IterableInterval}s
+ * and {@link RandomAccessibleInterval}s, and writes the result to
+ * {@link IterableInterval}s.
  *
  * @author Leon Yang
  */
-public final class RandomAccessibleIntervalToIterableInterval {
+public final class IIToRAIOutputII {
 	
-	private RandomAccessibleIntervalToIterableInterval() {
+	private IIToRAIOutputII() {
 		// NB: Prevent instantiation of utility class.
 	}
 #foreach ($op in $ops)

--- a/src/main/templates/net/imagej/ops/math/NumericTypeBinaryMath.vm
+++ b/src/main/templates/net/imagej/ops/math/NumericTypeBinaryMath.vm
@@ -31,10 +31,11 @@
 package net.imagej.ops.math;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.AbstractUnaryHybridOp;
+import net.imagej.ops.special.AbstractBinaryHybridOp;
+import net.imagej.ops.special.InplaceOp;
 import net.imglib2.type.numeric.NumericType;
 
-import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -51,29 +52,42 @@ public final class NumericTypeBinaryMath {
 #set ($iface = "Ops.Math.$op.name")
 
 	/** Op that $op.verbs two NumericType values. */
-	@Plugin(type = ${iface}.class)
+	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
 	public static class $op.name<T extends NumericType<T>>
-		extends AbstractUnaryHybridOp<T, T> implements $iface
+		extends AbstractBinaryHybridOp<T, T, T> implements InplaceOp<T>, $iface
 	{
 
-		@Parameter
-		private T b;
-
 		@Override
-		public T createOutput(T input) {
-			return input.createVariable();
+		public void compute2(final T input1, final T input2, final T output) {
+			output.set(input1);
+			output.${op.function}(input2);
 		}
 
 		@Override
-		public void compute1(final T input, final T output) {
-			if(output== b)
-			{
-				output.$!{op.function}(input);
-			}
-			else{
-				output.set(input);
-				output.$!{op.function}(b);
-			}
+		public T createOutput(T input1, T input2) {
+			return in1().createVariable();
+		}
+
+		@Override
+		public void mutate(T arg) {
+			final T result = arg.createVariable();
+			compute2(in1(), in2(), result);
+			arg.set(result);
+		}
+
+		@Override
+		public T arg() {
+			return out() == null ? in1() : out();
+		}
+
+		@Override
+		public void setArg(T arg) {
+			setOutput(arg);
+		}
+
+		@Override
+		public ${op.name}<T> getIndependentInstance() {
+			return this;
 		}
 	}
 #end

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -38,7 +38,7 @@ import net.imagej.ops.map.MapIterableIntervalToIterableIntervalParallel;
 import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
 import net.imagej.ops.math.ConstantToArrayImage;
 import net.imagej.ops.math.ConstantToArrayImageP;
-import net.imagej.ops.math.ConstantToImageFunctional;
+import net.imagej.ops.math.ConstantToIIOutputRAI;
 import net.imagej.ops.math.ConstantToImageInPlace;
 import net.imagej.ops.math.NumericTypeBinaryMath;
 import net.imglib2.img.array.ArrayImg;
@@ -93,7 +93,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void fTtestAddConstantToImage() {
-		ops.run(ConstantToImageFunctional.Add.class, out, in,
+		ops.run(ConstantToIIOutputRAI.Add.class, out, in,
 			new ByteType((byte) 10));
 	}
 

--- a/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
+++ b/src/test/java/net/imagej/ops/benchmark/AddOpBenchmarkTest.java
@@ -39,7 +39,7 @@ import net.imagej.ops.map.MapIterableIntervalToRAIParallel;
 import net.imagej.ops.math.ConstantToArrayImage;
 import net.imagej.ops.math.ConstantToArrayImageP;
 import net.imagej.ops.math.ConstantToIIOutputRAI;
-import net.imagej.ops.math.ConstantToImageInPlace;
+import net.imagej.ops.math.ConstantToIIOutputII;
 import net.imagej.ops.math.NumericTypeBinaryMath;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
@@ -105,7 +105,7 @@ public class AddOpBenchmarkTest extends AbstractOpBenchmark {
 
 	@Test
 	public void inTestAddConstantToImageInPlace() {
-		ops.run(ConstantToImageInPlace.Add.class, in, new ByteType(
+		ops.run(ConstantToIIOutputII.Add.class, in, new ByteType(
 			(byte) 10));
 	}
 

--- a/src/test/java/net/imagej/ops/math/RealMathTest.java
+++ b/src/test/java/net/imagej/ops/math/RealMathTest.java
@@ -33,7 +33,10 @@ package net.imagej.ops.math;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,10 +45,470 @@ import org.junit.rules.ExpectedException;
 /**
  * Tests {@link RealMath}.
  *
+ * @author Leon Yang
  * @author Alison Walter
  * @author Curtis Rueden
  */
 public class RealMathTest extends AbstractOpTest {
+
+	// NB: long number LARGE_NUM is rounded to double 9007199254740992.0.
+	final static private long LARGE_NUM = 9007199254740993L;
+
+	@Test
+	public void testAbs() {
+		final LongType in = new LongType(-LARGE_NUM);
+		final LongType out = ops.math().abs(in.createVariable(), in);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testAdd() {
+		final LongType in1 = new LongType(LARGE_NUM - 1);
+		final ByteType in2 = new ByteType((byte) 1);
+		final LongType out = ops.math().add(in1.createVariable(), in1, 1.0);
+		assertEquals(out.get(), LARGE_NUM - 1, 0.0);
+		ops.math().add(out, in1, in2);
+		assertEquals(out.get(), LARGE_NUM - 1, 0.0);
+	}
+
+	@Test
+	public void testAnd() {
+		final LongType in1 = new LongType(LARGE_NUM);
+		final ByteType in2 = new ByteType((byte) 1);
+		final LongType out = ops.math().and(in1.createVariable(), in1, 1L);
+		assertEquals(out.get(), 0L);
+		ops.math().and(out, in1, in2);
+		assertEquals(out.get(), 0L);
+	}
+
+	@Test
+	public void testArccos() {
+		final FloatType in = new FloatType(0.5f);
+		final DoubleType out = new DoubleType();
+		ops.math().arccos(out, in);
+		assertEquals(out.get(), Math.acos(0.5), 0.0);
+	}
+
+	@Test
+	public void testArccosh() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arccosh(out, in);
+		final double delta = Math.sqrt(1234567890.0 * 1234567890.0 - 1);
+		assertEquals(out.get(), Math.log(1234567890 + delta), 0.0);
+	}
+
+	@Test
+	public void testArccot() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arccot(out, in);
+		assertEquals(out.get(), Math.atan(1.0 / 1234567890), 0.0);
+	}
+
+	@Test
+	public void testArccoth() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arccoth(out, in);
+		final double result = 0.5 * Math.log(1234567891.0 / 1234567889.0);
+		assertEquals(out.get(), result, 0.0);
+	}
+
+	@Test
+	public void testArccsch() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arccsch(out, in);
+		final double delta = Math.sqrt(1 + 1 / (1234567890.0 * 1234567890.0));
+		assertEquals(out.get(), Math.log(1 / 1234567890.0 + delta), 0.0);
+	}
+
+	@Test
+	public void testArcsech() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arcsech(out, in);
+		final double numer = 1 + Math.sqrt(1 - 1234567890.0 * 1234567890.0);
+		assertEquals(out.get(), Math.log(numer / 1234567890.0), 0.0);
+	}
+
+	@Test
+	public void testArcsin() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arcsin(out, in);
+		assertEquals(out.get(), Math.asin(1234567890), 0.0);
+	}
+
+	@Test
+	public void testArcsinh() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arcsinh(out, in);
+		final double delta = Math.sqrt(1234567890.0 * 1234567890.0 + 1);
+		assertEquals(out.get(), Math.log(1234567890 + delta), 0.0);
+	}
+
+	@Test
+	public void testArctan() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arctan(out, in);
+		assertEquals(out.get(), Math.atan(1234567890), 0.0);
+	}
+
+	@Test
+	public void testArctanh() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().arctanh(out, in);
+		assertEquals(out.get(), 0.5 * Math.log(1234567891.0 / -1234567889.0), 0.0);
+	}
+
+	@Test
+	public void testCeil() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = ops.math().ceil(in.createVariable(), in);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testCos() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().cos(out, in);
+		assertEquals(out.get(), Math.cos(1234567890), 0.0);
+	}
+
+	@Test
+	public void testCosh() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().cosh(out, in);
+		assertEquals(out.get(), Math.cosh(1234567890), 0.0);
+	}
+
+	@Test
+	public void testCot() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().cot(out, in);
+		assertEquals(out.get(), 1 / Math.tan(1234567890), 0.0);
+	}
+
+	@Test
+	public void testCoth() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().coth(out, in);
+		assertEquals(out.get(), 1 / Math.tanh(1234567890), 0.0);
+	}
+
+	@Test
+	public void testCsc() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().csc(out, in);
+		assertEquals(out.get(), 1 / Math.sin(1234567890), 0.0);
+	}
+
+	@Test
+	public void testCsch() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().csch(out, in);
+		assertEquals(out.get(), 1 / Math.sinh(1234567890), 0.0);
+		ops.math().add(3, 43.0);
+	}
+
+	@Test
+	public void testCubeRoot() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().cubeRoot(out, in);
+		assertEquals(out.get(), Math.cbrt(1234567890), 0.0);
+	}
+
+	@Test
+	public void testDivide() {
+		final LongType in1 = new LongType(LARGE_NUM * 2);
+		final ByteType in2 = new ByteType((byte) 2);
+		final LongType out = ops.math().divide(in1.createVariable(), in1, 2.0, 0);
+		assertEquals(out.get(), LARGE_NUM - 1);
+		ops.math().divide(out, in1, in2, 0);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testExp() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().exp(out, in);
+		assertEquals(out.get(), Math.exp(1234567890), 0.0);
+	}
+
+	@Test
+	public void testExpMinusOne() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().expMinusOne(out, in);
+		assertEquals(out.get(), Math.exp(1234567890) - 1, 0.0);
+	}
+
+	@Test
+	public void testFloor() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = ops.math().floor(in.createVariable(), in);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testInvert() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = ops.math().invert(in.createVariable(), in,
+			9007199254740992.0, 9007199254740994.0);
+		assertEquals(out.get(), LARGE_NUM + 1);
+	}
+
+	@Test
+	public void testLog() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().log(out, in);
+		assertEquals(out.get(), Math.log(1234567890), 0.0);
+	}
+
+	@Test
+	public void testLog10() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().log10(out, in);
+		assertEquals(out.get(), Math.log10(1234567890), 0.0);
+	}
+
+	@Test
+	public void testLog2() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().log2(out, in);
+		assertEquals(out.get(), Math.log(1234567890) / Math.log(2), 0.0);
+	}
+
+	@Test
+	public void testLogOnePlusX() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().logOnePlusX(out, in);
+		assertEquals(out.get(), Math.log1p(1234567890), 0.0);
+	}
+
+	@Test
+	public void testMax() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = ops.math().max(in.createVariable(), in, LARGE_NUM +
+			1.0);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testMin() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = ops.math().min(in.createVariable(), in, LARGE_NUM -
+			1.0);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testMultiply() {
+		final LongType in1 = new LongType(LARGE_NUM);
+		final ByteType in2 = new ByteType((byte) 2);
+		final LongType out = ops.math().multiply(in1.createVariable(), in1, 2.0);
+		assertEquals(out.get(), (LARGE_NUM - 1) * 2);
+		ops.math().multiply(out, in1, in2);
+		assertEquals(out.get(), (LARGE_NUM - 1) * 2);
+	}
+
+	@Test
+	public void testNearestInt() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = ops.math().nearestInt(in.createVariable(), in);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	@Test
+	public void testNegate() {
+		final LongType in = new LongType(-LARGE_NUM);
+		final LongType out = ops.math().negate(in.createVariable(), in);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
+
+	// NB: This tests always fails until this issue
+	// https://github.com/imglib/imglib2/issues/110 has been addressed.
+//	@Test
+//	public void testOr() {
+//		final LongType in1 = new LongType(LARGE_NUM);
+//		final ByteType in2 = new ByteType((byte) 0);
+//		final LongType out = ops.math().or(in1.createVariable(), in1, 0L);
+//		assertEquals(out.get(), LARGE_NUM - 1);
+//		ops.math().or(out, in1, in2);
+//		assertEquals(out.get(), LARGE_NUM - 1);
+//	}
+
+	@Test
+	public void testPower() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().power(out, in, 1.5);
+		assertEquals(out.get(), Math.pow(1234567890, 1.5), 0.0);
+	}
+
+	@Test
+	public void testReciprocal() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().reciprocal(out, in, 0.0);
+		assertEquals(out.get(), 1.0 / 1234567890, 0.0);
+	}
+
+	// NB: This tests always fails until this issue
+	// https://github.com/imglib/imglib2/issues/110 has been addressed.
+//	@Test
+//	public void testRound() {
+//		final LongType in = new LongType(LARGE_NUM);
+//		final LongType out = ops.math().round(in.createVariable(), in);
+//		assertEquals(out.get(), LARGE_NUM - 1);
+//	}
+
+	@Test
+	public void testSec() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sec(out, in);
+		assertEquals(out.get(), 1 / Math.cos(1234567890), 0.0);
+	}
+
+	@Test
+	public void testSech() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sech(out, in);
+		assertEquals(out.get(), 1 / Math.cosh(1234567890), 0.0);
+	}
+
+	@Test
+	public void testSignum() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().signum(out, in);
+		assertEquals(out.get(), 1.0, 0.0);
+	}
+
+	@Test
+	public void testSin() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sin(out, in);
+		assertEquals(out.get(), Math.sin(1234567890), 0.0);
+	}
+
+	@Test
+	public void testSinc() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sinc(out, in);
+		assertEquals(out.get(), Math.sin(1234567890) / 1234567890, 0.0);
+	}
+
+	@Test
+	public void testSincPi() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sincPi(out, in);
+		final double PI = Math.PI;
+		assertEquals(out.get(), Math.sin(PI * 1234567890) / (PI * 1234567890), 0.0);
+	}
+
+	@Test
+	public void testSinh() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sinh(out, in);
+		assertEquals(out.get(), Math.sinh(1234567890), 0.0);
+	}
+
+	@Test
+	public void testSqr() {
+		final LongType in = new LongType(94906267L);
+		final LongType out = ops.math().sqr(in.createVariable(), in);
+		// NB: for any odd number greater than LARGE_NUM - 1, its double
+		// representation is not exact.
+		assertEquals(out.get(), 94906267L * 94906267L - 1);
+	}
+
+	@Test
+	public void testSqrt() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().sqrt(out, in);
+		assertEquals(out.get(), Math.sqrt(1234567890), 0.0);
+	}
+
+	@Test
+	public void testStep() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().step(out, in);
+		assertEquals(out.get(), 1.0, 0.0);
+	}
+
+	@Test
+	public void testSubtract() {
+		final LongType in1 = new LongType(LARGE_NUM + 1);
+		final ByteType in2 = new ByteType((byte) 1);
+		final LongType out = ops.math().subtract(in1.createVariable(), in1, 1.0);
+		assertEquals(out.get(), LARGE_NUM - 1, 0.0);
+		ops.math().subtract(out, in1, in2);
+		assertEquals(out.get(), LARGE_NUM - 1, 0.0);
+	}
+
+	@Test
+	public void testTan() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().tan(out, in);
+		assertEquals(out.get(), Math.tan(1234567890), 0.0);
+	}
+
+	@Test
+	public void testTanh() {
+		final LongType in = new LongType(1234567890);
+		final DoubleType out = new DoubleType();
+		ops.math().tanh(out, in);
+		assertEquals(out.get(), Math.tanh(1234567890), 0.0);
+	}
+
+	@Test
+	public void testUlp() {
+		final LongType in = new LongType(LARGE_NUM);
+		final DoubleType out = new DoubleType();
+		ops.math().ulp(out, in);
+		assertEquals(out.get(), 2.0, 0.0);
+	}
+
+	// NB: This tests always fails until this issue
+	// https://github.com/imglib/imglib2/issues/110 has been addressed.
+//	@Test
+//	public void testXor() {
+//		final LongType in1 = new LongType(LARGE_NUM);
+//		final ByteType in2 = new ByteType((byte) 1);
+//		final LongType out = ops.math().xor(in1.createVariable(), in1, 1L);
+//		assertEquals(out.get(), 1L);
+//		ops.math().xor(out, in1, in2);
+//		assertEquals(out.get(), 1L);
+//	}
+
+	// -- complex tests --
 
 	@Test
 	public void testArccsc() {
@@ -122,8 +585,8 @@ public class RealMathTest extends AbstractOpTest {
 		final long seed)
 	{
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out =
-			ops.math().randomGaussian(in.createVariable(), in, seed);
+		final DoubleType out = ops.math().randomGaussian(in.createVariable(), in,
+			seed);
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -134,8 +597,8 @@ public class RealMathTest extends AbstractOpTest {
 		final DoubleType out = new DoubleType();
 		final long seed = 0xcafebabe12345678L;
 		@SuppressWarnings("unchecked")
-		final RealMath.RandomGaussian<DoubleType, DoubleType> op =
-			ops.op(RealMath.RandomGaussian.class, in.createVariable(), in, seed);
+		final RealMath.RandomGaussian<DoubleType, DoubleType> op = ops.op(
+			RealMath.RandomGaussian.class, in.createVariable(), in, seed);
 		op.compute1(in, out);
 		assertEquals(o, out.get(), 0);
 		in.set(i2);
@@ -153,8 +616,8 @@ public class RealMathTest extends AbstractOpTest {
 		final long seed)
 	{
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out =
-			ops.math().randomUniform(in.createVariable(), in, seed);
+		final DoubleType out = ops.math().randomUniform(in.createVariable(), in,
+			seed);
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -165,8 +628,8 @@ public class RealMathTest extends AbstractOpTest {
 		final DoubleType out = new DoubleType();
 		final long seed = 0xcafebabe12345678L;
 		@SuppressWarnings("unchecked")
-		final RealMath.RandomUniform<DoubleType, DoubleType> op =
-			ops.op(RealMath.RandomUniform.class, in.createVariable(), in, seed);
+		final RealMath.RandomUniform<DoubleType, DoubleType> op = ops.op(
+			RealMath.RandomUniform.class, in.createVariable(), in, seed);
 		op.compute1(in, out);
 		assertEquals(o, out.get(), 0);
 		in.set(i2);

--- a/src/test/templates/net/imagej/ops/math/ConstantToArrayImageTest.list
+++ b/src/test/templates/net/imagej/ops/math/ConstantToArrayImageTest.list
@@ -1,0 +1,22 @@
+# Unit tests for binary arithmetic ops with ArrayImages and their parallelized version.
+
+[ConstantToArrayImageTest.java]
+
+types = ```
+[
+	[name: "Byte",     primitive: "byte"], 
+	[name: "Int",      primitive: "int"], 
+	[name: "Long",     primitive: "long"], 
+	[name: "Float",    primitive: "float"], 
+	[name: "Double",   primitive: "double"]
+]
+```
+
+ops = ```
+[
+	[name: "Add",      operator: "+"],
+	[name: "Subtract", operator: "-"], 
+	[name: "Multiply", operator: "*"], 
+	[name: "Divide",   operator: "/"]
+]
+```

--- a/src/test/templates/net/imagej/ops/math/ConstantToArrayImageTest.vm
+++ b/src/test/templates/net/imagej/ops/math/ConstantToArrayImageTest.vm
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Test;
+
+public class ConstantToArrayImageTest extends AbstractOpTest {
+
+#foreach ($type in $types)
+#set ($imglibType = $type.name + "Type")
+#set ($isByte = $type.name == "Byte")
+#set ($isFloat = $type.name == "Float" || $type.name == "Double")
+	private ${type.primitive}[] get${type.name}Array() {
+		return new ${type.primitive}[] { 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+	}
+
+#foreach ($op in $ops)
+#set ($className = $op.name + $type.name)
+	@Test
+	public void test${className}() {
+		final Img<$imglibType> in = ArrayImgs.${type.primitive}s(get${type.name}Array(), 3, 3);
+		final Img<$imglibType> copy = in.copy();
+		final ${type.primitive} constant = 3;
+		ops.run(ConstantToArrayImage.${className}.class, in, constant);
+		final Cursor<$imglibType> inCursor = in.cursor();
+		final Cursor<$imglibType> copyCursor = copy.cursor();
+		while (inCursor.hasNext()) {
+			assertEquals(inCursor.next().get(), #if ($isByte)(byte) #{end}(copyCursor.next().get() $op.operator constant)#if ($isFloat), 0.0#{end});
+		}
+		ops.run(ConstantToArrayImageP.${className}.class, copy, constant);
+		inCursor.reset();
+		copyCursor.reset();
+		while (inCursor.hasNext()) {
+			assertEquals(inCursor.next().get(), copyCursor.next().get()#if ($isFloat), 0.0#{end});
+		}
+	}
+
+#end
+#end
+}

--- a/src/test/templates/net/imagej/ops/math/ConstantToIIOutputIITest.list
+++ b/src/test/templates/net/imagej/ops/math/ConstantToIIOutputIITest.list
@@ -1,0 +1,12 @@
+# Unit tests for functional binary arithmetic ops with II as both input and output.
+
+[ConstantToIIOutputIITest.java]
+
+ops = ```
+[
+	[name: "Add",      function: "add"],
+	[name: "Subtract", function: "sub"], 
+	[name: "Multiply", function: "mul"], 
+	[name: "Divide",   function: "div"]
+]
+```

--- a/src/test/templates/net/imagej/ops/math/ConstantToIIOutputIITest.vm
+++ b/src/test/templates/net/imagej/ops/math/ConstantToIIOutputIITest.vm
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConstantToIIOutputIITest extends AbstractOpTest {
+
+	final private FloatType constant = new FloatType(3.0f);
+	private Img<FloatType> in;
+	private Img<FloatType> copy;
+	private Img<FloatType> out;
+
+	@Before
+	public void initImg() {
+		in = generateFloatArrayTestImg(true, 3, 3);
+		copy = in.copy();
+		out = generateFloatArrayTestImg(false, 3, 3);
+	}
+
+#foreach ($op in $ops)
+	@Test
+	public void test${op.name}() {
+		@SuppressWarnings("unchecked")
+		final ConstantToIIOutputII.${op.name}<FloatType> op = ops.op(
+			ConstantToIIOutputII.${op.name}.class, out, in, constant);
+		op.run();
+		final IterableInterval<FloatType> created = op.compute1(in);
+		op.mutate(in);
+		final Cursor<FloatType> inCursor = in.cursor();
+		final Cursor<FloatType> copyCursor = copy.cursor();
+		final Cursor<FloatType> outCursor = out.cursor();
+		final Cursor<FloatType> crtCursor = created.cursor();
+		while (inCursor.hasNext()) {
+			copyCursor.next().${op.function}(constant);
+			final float expected = copyCursor.get().get();
+			assertEquals(inCursor.next().get(), expected, 0.0);
+			assertEquals(outCursor.next().get(), expected, 0.0);
+			assertEquals(crtCursor.next().get(), expected, 0.0);
+		}
+	}
+
+#end
+}

--- a/src/test/templates/net/imagej/ops/math/ConstantToIIOutputRAITest.list
+++ b/src/test/templates/net/imagej/ops/math/ConstantToIIOutputRAITest.list
@@ -1,0 +1,12 @@
+# Unit tests for functional binary arithmetic ops with II as input and RAI as output.
+
+[ConstantToIIOutputRAITest.java]
+
+ops = ```
+[
+	[name: "Add",      function: "add"],
+	[name: "Subtract", function: "sub"], 
+	[name: "Multiply", function: "mul"], 
+	[name: "Divide",   function: "div"]
+]
+```

--- a/src/test/templates/net/imagej/ops/math/ConstantToIIOutputRAITest.vm
+++ b/src/test/templates/net/imagej/ops/math/ConstantToIIOutputRAITest.vm
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConstantToIIOutputRAITest extends AbstractOpTest {
+
+	final private FloatType constant = new FloatType(3.0f);
+	private Img<FloatType> in;
+	private Img<FloatType> out;
+
+	@Before
+	public void initImg() {
+		in = generateFloatArrayTestImg(true, 3, 3);
+		out = generateFloatArrayTestImg(false, 3, 3);
+	}
+
+#foreach ($op in $ops)
+	@Test
+	public void test${op.name}() {
+		ops.run(ConstantToIIOutputRAI.${op.name}.class, out, in, constant);
+		final Cursor<FloatType> inCursor = in.cursor();
+		final Cursor<FloatType> outCursor = out.cursor();
+		while (inCursor.hasNext()) {
+			inCursor.next().${op.function}(constant);
+			assertEquals(outCursor.next().get(), inCursor.get().get(), 0.0);
+		}
+	}
+
+#end
+}

--- a/src/test/templates/net/imagej/ops/math/ConstantToPlanarImageTest.list
+++ b/src/test/templates/net/imagej/ops/math/ConstantToPlanarImageTest.list
@@ -1,0 +1,22 @@
+# Unit tests for binary arithmetic ops with PlanarImages. 
+
+[ConstantToPlanarImageTest.java]
+
+types = ```
+[
+	[name: "Byte",     primitive: "byte"], 
+	[name: "Int",      primitive: "int"], 
+	[name: "Long",     primitive: "long"], 
+	[name: "Float",    primitive: "float"], 
+	[name: "Double",   primitive: "double"]
+]
+```
+
+ops = ```
+[
+	[name: "Add",      operator: "+"],
+	[name: "Subtract", operator: "-"], 
+	[name: "Multiply", operator: "*"], 
+	[name: "Divide",   operator: "/"],
+]
+```

--- a/src/test/templates/net/imagej/ops/math/ConstantToPlanarImageTest.vm
+++ b/src/test/templates/net/imagej/ops/math/ConstantToPlanarImageTest.vm
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Test;
+
+public class ConstantToPlanarImageTest extends AbstractOpTest {
+
+#foreach ($type in $types)
+#set ($imglibType = $type.name + "Type")
+#set ($isByte = $type.name == "Byte")
+#set ($isFloat = $type.name == "Float" || $type.name == "Double")
+	private Img<$imglibType> get${type.name}PlanarImg() {
+		final Img<$imglibType> img = PlanarImgs.${type.primitive}s(3, 3);
+		$type.primitive i = 11;
+		for ($imglibType px : img) 
+			px.set(i++);
+		return img;
+	}
+
+#foreach ($op in $ops)
+#set ($className = $op.name + $type.name)
+	@Test
+	public void test${className}() {
+		final Img<$imglibType> in = get${type.name}PlanarImg();
+		final Img<$imglibType> copy = in.copy();
+		final $type.primitive constant = 3;
+		ops.run(ConstantToPlanarImage.${className}.class, in, constant);
+		final Cursor<$imglibType> inCursor = in.cursor();
+		final Cursor<$imglibType> copyCursor = copy.cursor();
+		while (inCursor.hasNext()) {
+			assertEquals(inCursor.next().get(), #if ($isByte)(byte) #{end}(copyCursor.next().get() $op.operator constant)#if ($isFloat), 0.0#{end});
+		}
+	}
+
+#end
+#end
+}

--- a/src/test/templates/net/imagej/ops/math/IIToIIOutputIITest.list
+++ b/src/test/templates/net/imagej/ops/math/IIToIIOutputIITest.list
@@ -1,0 +1,12 @@
+# Unit tests for binary arithmetic ops with IIs and RAIs and output to IIs.
+
+[IIToRAIOutputIITest.java]
+
+ops = ```
+[
+	[name: "Add",      function: "add"],
+	[name: "Subtract", function: "sub"], 
+	[name: "Multiply", function: "mul"], 
+	[name: "Divide",   function: "div"]
+]
+```

--- a/src/test/templates/net/imagej/ops/math/IIToIIOutputIITest.vm
+++ b/src/test/templates/net/imagej/ops/math/IIToIIOutputIITest.vm
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class IIToRAIOutputIITest extends AbstractOpTest {
+
+	private Img<FloatType> in1;
+	private Img<FloatType> in2;
+	private Img<FloatType> copy1;
+	private Img<FloatType> out;
+
+	@Before
+	public void initImg() {
+		in1 = generateFloatArrayTestImg(true, 3, 3);
+		in2 = ArrayImgs.floats(new float[] { 11, 12, 13, 14, 15, 16, 17, 18, 19 },
+			3, 3);
+		copy1 = in1.copy();
+		out = ArrayImgs.floats(3, 3);
+	}
+	
+#foreach ($op in $ops)
+	@Test
+	public void test${op.name}() {
+		@SuppressWarnings("unchecked")
+		final IIToRAIOutputII.${op.name}<FloatType> op = ops.op(IIToRAIOutputII.${op.name}.class,
+			out, in1, in2);
+		op.run();
+		final IterableInterval<FloatType> created = op.compute2(in1, in2);
+		op.mutate(in1);
+		final Cursor<FloatType> in1Cursor = in1.cursor();
+		final Cursor<FloatType> copy1Cursor = copy1.cursor();
+		final Cursor<FloatType> in2Cursor = in2.cursor();
+		final Cursor<FloatType> outCursor = out.cursor();
+		final Cursor<FloatType> crtCursor = created.cursor();
+		while (copy1Cursor.hasNext()) {
+			copy1Cursor.next().${op.function}(in2Cursor.next());
+			final float expected = copy1Cursor.get().get();
+			assertEquals(in1Cursor.next().get(), expected, 0.0);
+			assertEquals(outCursor.next().get(), expected, 0.0);
+			assertEquals(crtCursor.next().get(), expected, 0.0);
+		}
+	}
+
+#end
+}

--- a/src/test/templates/net/imagej/ops/math/IIToRAIOutputIITest.list
+++ b/src/test/templates/net/imagej/ops/math/IIToRAIOutputIITest.list
@@ -1,0 +1,13 @@
+# Unit tests for binary arithmetic ops with IterableIntervals and output to
+# IterableIntervals.
+
+[IIToIIOutputIITest.java]
+
+ops = ```
+[
+	[name: "Add",      function: "add"],
+	[name: "Subtract", function: "sub"], 
+	[name: "Multiply", function: "mul"], 
+	[name: "Divide",   function: "div"]
+]
+```

--- a/src/test/templates/net/imagej/ops/math/IIToRAIOutputIITest.vm
+++ b/src/test/templates/net/imagej/ops/math/IIToRAIOutputIITest.vm
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.math;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class IIToIIOutputIITest extends AbstractOpTest {
+
+	private Img<FloatType> in1;
+	private Img<FloatType> in2;
+	private Img<FloatType> copy1;
+	private Img<FloatType> copy2;
+	private Img<FloatType> out;
+
+	@Before
+	public void initImg() {
+		in1 = generateFloatArrayTestImg(true, 3, 3);
+		in2 = ArrayImgs.floats(new float[] { 11, 12, 13, 14, 15, 16, 17, 18, 19 },
+			3, 3);
+		copy1 = in1.copy();
+		copy2 = in2.copy();
+		out = ArrayImgs.floats(3, 3);
+	}
+	
+#foreach ($op in $ops)
+	@Test
+	public void test${op.name}() {
+		@SuppressWarnings("unchecked")
+		final IIToIIOutputII.${op.name}<FloatType> op = ops.op(IIToIIOutputII.${op.name}.class,
+			out, in1, in2);
+		op.run();
+		final IterableInterval<FloatType> created = op.compute2(in1, in2);
+		op.mutate(in1);
+		op.setInput1(copy1);
+		op.mutate(in2);
+		final Cursor<FloatType> in1Cursor = in1.cursor();
+		final Cursor<FloatType> copy1Cursor = copy1.cursor();
+		final Cursor<FloatType> in2Cursor = in2.cursor();
+		final Cursor<FloatType> copy2Cursor = copy2.cursor();
+		final Cursor<FloatType> outCursor = out.cursor();
+		final Cursor<FloatType> crtCursor = created.cursor();
+		while (copy1Cursor.hasNext()) {
+			copy1Cursor.next().${op.function}(copy2Cursor.next());
+			final float expected = copy1Cursor.get().get();
+			assertEquals(in1Cursor.next().get(), expected, 0.0);
+			assertEquals(in2Cursor.next().get(), expected, 0.0);
+			assertEquals(outCursor.next().get(), expected, 0.0);
+			assertEquals(crtCursor.next().get(), expected, 0.0);
+		}
+	}
+
+#end
+}

--- a/src/test/templates/net/imagej/ops/math/NumericTypeBinaryMathTest.vm
+++ b/src/test/templates/net/imagej/ops/math/NumericTypeBinaryMathTest.vm
@@ -61,6 +61,7 @@ public class NumericTypeBinaryMathTest extends AbstractOpTest {
 #foreach ($test in $tests)
 #set ($className = "NumericTypeBinaryMath.$test.op")
 #foreach ($type in $types)
+#set ($methodName = $test.op.substring(0, 1).toLowerCase() + $test.op.substring(1))
 
 	/** Tests {@link $className} with {@link $type} arguments. */
 	@Test
@@ -72,7 +73,7 @@ public class NumericTypeBinaryMathTest extends AbstractOpTest {
 		final $type expected = new ${type}();
 		expected.set(a);
 		expected.${test.function}(b);
-		final Object result = ops.run(${className}.class, a, b);
+		final Object result = ops.math().$methodName(a, b);
 		final $type actual = ($type) result;
 ## NB: Compare values, until all types implement equals properly.
 ##		assertEquals(expected, actual);

--- a/src/test/templates/net/imagej/ops/math/PrimitiveMathTest.vm
+++ b/src/test/templates/net/imagej/ops/math/PrimitiveMathTest.vm
@@ -46,11 +46,12 @@ public class PrimitiveMathTest extends AbstractOpTest {
 #if ($types.containsKey($test.code))
 #set ($type = $types.get($test.code))
 #set ($className = "$type.name$test.op")
+#set ($methodName = $test.op.substring(0, 1).toLowerCase() + $test.op.substring(1))
 
 	/** Tests {@link PrimitiveMath.$className}. */
 	@Test
 	public void test$className() {
-		final Object result = ops.run(PrimitiveMath.${className}.class, $test.args);
+		final Object result = ops.math().$methodName($test.args);
 		assertTrue(result instanceof $type.name);
 		final $type.primitive value = ($type.name) result;
 #if ($type.delta)


### PR DESCRIPTION
This branch refactor the current math package quite a lot. To sum up:
1. create RealBinaryMath
2. make the RealMathTest complete
3. integrate BinaryOp and InplaceOp into NumericTypeBinaryMath
4. refactor the image-related math operations (they are auto-generated)
    - add more types to the ConstantToXXXImage
    - rename ops with improper names (e.g. named on Img)
    - extends the functionality of some ops (make them BinaryOp and/or InplaceOp as proper)
5. cleanup, auto-format, small bug, etc.

This branch is not ready to merge since the II/RAI/Img related ops do not have unit tests yet. Since I have made quite a few commits, it would be great if someone can review before I move on.