### PR TITLE
Make op implementations extend proper abstract SpecialOp

### DIFF
--- a/src/main/java/net/imagej/ops/create/img/DefaultCreateImg.java
+++ b/src/main/java/net/imagej/ops/create/img/DefaultCreateImg.java
@@ -30,9 +30,8 @@
 
 package net.imagej.ops.create.img;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Dimensions;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
@@ -42,7 +41,6 @@ import net.imglib2.img.ImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Util;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -54,15 +52,9 @@ import org.scijava.plugin.Plugin;
  * @param <T>
  */
 @Plugin(type = Ops.Create.Img.class)
-public class DefaultCreateImg<T> extends AbstractOp implements Ops.Create.Img,
-	Output<Img<T>>
+public class DefaultCreateImg<T> extends
+	AbstractUnaryFunctionOp<Dimensions, Img<T>> implements Ops.Create.Img
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Img<T> output;
-
-	@Parameter
-	private Dimensions dims;
 
 	@Parameter(required = false)
 	private T outType;
@@ -72,15 +64,15 @@ public class DefaultCreateImg<T> extends AbstractOp implements Ops.Create.Img,
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void run() {
+	public Img<T> compute1(final Dimensions input) {
 		// FIXME: not guaranteed to be a T unless a Class<T> is given.
 		if (outType == null) {
-			if (dims instanceof IterableInterval) {
-				outType = (T) ((IterableInterval<?>) dims).firstElement();
+			if (input instanceof IterableInterval) {
+				outType = (T) ((IterableInterval<?>) input).firstElement();
 			}
-			else if (dims instanceof RandomAccessibleInterval) {
+			else if (input instanceof RandomAccessibleInterval) {
 				outType = (T) Util.getTypeFromInterval(
-					(RandomAccessibleInterval<?>) dims);
+					(RandomAccessibleInterval<?>) input);
 			}
 			else {
 				// HACK: For Java 6 compiler.
@@ -92,8 +84,8 @@ public class DefaultCreateImg<T> extends AbstractOp implements Ops.Create.Img,
 		}
 
 		if (fac == null) {
-			if (dims instanceof Img) {
-				final Img<?> inImg = ((Img<?>) dims);
+			if (input instanceof Img) {
+				final Img<?> inImg = ((Img<?>) input);
 				if (inImg.firstElement().getClass().isInstance(outType)) {
 					fac = (ImgFactory<T>) inImg.factory();
 				}
@@ -106,22 +98,17 @@ public class DefaultCreateImg<T> extends AbstractOp implements Ops.Create.Img,
 					}
 					catch (final IncompatibleTypeException e) {
 						// FIXME: outType may not be a NativeType, but imgFactory needs one.
-						fac = (ImgFactory<T>) ops().create().imgFactory(dims, outType);
+						fac = (ImgFactory<T>) ops().create().imgFactory(input, outType);
 					}
 				}
 			}
 			else {
 				// FIXME: outType may not be a NativeType, but imgFactory needs one.
-				fac = (ImgFactory<T>) ops().create().imgFactory(dims, outType);
+				fac = (ImgFactory<T>) ops().create().imgFactory(input, outType);
 			}
 		}
 
-		output = fac.create(dims, outType);
-	}
-
-	@Override
-	public Img<T> out() {
-		return output;
+		return fac.create(input, outType);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/imgFactory/DefaultCreateImgFactory.java
+++ b/src/main/java/net/imagej/ops/create/imgFactory/DefaultCreateImgFactory.java
@@ -30,9 +30,8 @@
 
 package net.imagej.ops.create.imgFactory;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractNullaryFunctionOp;
 import net.imglib2.Dimensions;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.array.ArrayImgFactory;
@@ -40,7 +39,6 @@ import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Intervals;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -53,11 +51,8 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.ImgFactory.class)
 public class DefaultCreateImgFactory<T extends NativeType<T>> extends
-	AbstractOp implements Ops.Create.ImgFactory, Output<ImgFactory<T>>
+	AbstractNullaryFunctionOp<ImgFactory<T>> implements Ops.Create.ImgFactory
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private ImgFactory<T> output;
 
 	@Parameter(required = false)
 	private Dimensions dims;
@@ -66,19 +61,13 @@ public class DefaultCreateImgFactory<T extends NativeType<T>> extends
 	private T outType;
 
 	@Override
-	public void run() {
+	public ImgFactory<T> compute0() {
 		if (outType == null) {
 			outType = ops().create().<T> nativeType();
 		}
 
-		output =
-			(dims == null || Intervals.numElements(dims) <= Integer.MAX_VALUE)
-				? new ArrayImgFactory<>() : new CellImgFactory<>();
-	}
-
-	@Override
-	public ImgFactory<T> out() {
-		return output;
+		return (dims == null || Intervals.numElements(dims) <= Integer.MAX_VALUE)
+			? new ArrayImgFactory<>() : new CellImgFactory<>();
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/CreateImgLabelingFromInterval.java
@@ -30,15 +30,13 @@
 
 package net.imagej.ops.create.imgLabeling;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Interval;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.type.numeric.IntegerType;
 
-import org.scijava.ItemIO;
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -53,14 +51,9 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.ImgLabeling.class, priority = Priority.HIGH_PRIORITY)
 public class CreateImgLabelingFromInterval<L, T extends IntegerType<T>> extends
-	AbstractOp implements Ops.Create.ImgLabeling, Output<ImgLabeling<L, T>>
+	AbstractUnaryFunctionOp<Interval, ImgLabeling<L, T>> implements
+	Ops.Create.ImgLabeling
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private ImgLabeling<L, T> output;
-
-	@Parameter
-	private Interval interval;
 
 	@Parameter(required = false)
 	private T outType;
@@ -73,18 +66,13 @@ public class CreateImgLabelingFromInterval<L, T extends IntegerType<T>> extends
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void run() {
+	public ImgLabeling<L, T> compute1(final Interval input) {
 
 		if (outType == null) {
 			outType = (T) ops().create().integerType(maxNumLabelSets);
 		}
 
-		output = new ImgLabeling<>(ops().create().img(interval, outType, fac));
-	}
-
-	@Override
-	public ImgLabeling<L, T> out() {
-		return output;
+		return new ImgLabeling<>(ops().create().img(input, outType, fac));
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/imgLabeling/DefaultCreateImgLabeling.java
+++ b/src/main/java/net/imagej/ops/create/imgLabeling/DefaultCreateImgLabeling.java
@@ -30,15 +30,13 @@
 
 package net.imagej.ops.create.imgLabeling;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Dimensions;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.type.numeric.IntegerType;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -52,14 +50,9 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.ImgLabeling.class)
 public class DefaultCreateImgLabeling<L, T extends IntegerType<T>> extends
-	AbstractOp implements Ops.Create.ImgLabeling, Output<ImgLabeling<L, T>>
+	AbstractUnaryFunctionOp<Dimensions, ImgLabeling<L, T>> implements
+	Ops.Create.ImgLabeling
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private ImgLabeling<L, T> output;
-
-	@Parameter
-	private Dimensions dims;
 
 	@Parameter(required = false)
 	private T outType;
@@ -72,18 +65,13 @@ public class DefaultCreateImgLabeling<L, T extends IntegerType<T>> extends
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void run() {
+	public ImgLabeling<L, T> compute1(final Dimensions input) {
 
 		if (outType == null) {
 			outType = (T) ops().create().integerType(maxNumLabelSets);
 		}
 
-		output = new ImgLabeling<>(ops().create().img(dims, outType, fac));
-	}
-
-	@Override
-	public ImgLabeling<L, T> out() {
-		return output;
+		return new ImgLabeling<>(ops().create().img(input, outType, fac));
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/imgPlus/DefaultCreateImgPlus.java
+++ b/src/main/java/net/imagej/ops/create/imgPlus/DefaultCreateImgPlus.java
@@ -32,13 +32,11 @@ package net.imagej.ops.create.imgPlus;
 
 import net.imagej.ImgPlus;
 import net.imagej.ImgPlusMetadata;
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.img.Img;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -49,39 +47,27 @@ import org.scijava.plugin.Plugin;
  * @param <T>
  */
 @Plugin(type = Ops.Create.ImgPlus.class)
-public class DefaultCreateImgPlus<T> extends AbstractOp implements
-	Ops.Create.ImgPlus, Output<ImgPlus<T>>, Contingent
+public class DefaultCreateImgPlus<T> extends
+	AbstractUnaryFunctionOp<Img<T>, ImgPlus<T>> implements Ops.Create.ImgPlus,
+	Contingent
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private ImgPlus<T> output;
-
-	@Parameter
-	private Img<T> img;
 
 	@Parameter(required = false)
 	private ImgPlusMetadata metadata;
 
 	@Override
-	public void run() {
+	public ImgPlus<T> compute1(final Img<T> input) {
 
 		if (metadata != null) {
-			output = new ImgPlus<>(img, metadata);
+			return new ImgPlus<>(input, metadata);
 		}
-		else {
-			output = new ImgPlus<>(img);
-		}
+		return new ImgPlus<>(input);
 
 	}
 
 	@Override
 	public boolean conforms() {
-		return metadata == null || metadata.numDimensions() == img.numDimensions();
-	}
-
-	@Override
-	public ImgPlus<T> out() {
-		return output;
+		return metadata == null || metadata.numDimensions() == in().numDimensions();
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/integerType/DefaultCreateIntegerType.java
+++ b/src/main/java/net/imagej/ops/create/integerType/DefaultCreateIntegerType.java
@@ -30,9 +30,8 @@
 
 package net.imagej.ops.create.integerType;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractNullaryFunctionOp;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -43,7 +42,6 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -54,52 +52,42 @@ import org.scijava.plugin.Plugin;
  */
 @SuppressWarnings("rawtypes")
 @Plugin(type = Ops.Create.IntegerType.class)
-public class DefaultCreateIntegerType extends AbstractOp implements
-	Ops.Create.IntegerType, Output<IntegerType>
+public class DefaultCreateIntegerType extends
+	AbstractNullaryFunctionOp<IntegerType> implements Ops.Create.IntegerType
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private IntegerType output;
 
 	@Parameter(required = false)
 	private long maxValue;
 
 	@Override
-	public void run() {
+	public IntegerType compute0() {
 		if (maxValue > 0) {
 			if (maxValue <= 2) {
-				output = new BitType();
+				return new BitType();
 			}
 			else if (maxValue <= Byte.MAX_VALUE + 1) {
-				output = new ByteType();
+				return new ByteType();
 			}
 			else if (maxValue <= (Byte.MAX_VALUE + 1) * 2) {
-				output = new UnsignedByteType();
+				return new UnsignedByteType();
 			}
 			else if (maxValue <= Short.MAX_VALUE + 1) {
-				output = new ShortType();
+				return new ShortType();
 			}
 			else if (maxValue <= (Short.MAX_VALUE + 1) * 2) {
-				output = new UnsignedShortType();
+				return new UnsignedShortType();
 			}
 			else if (maxValue <= Integer.MAX_VALUE + 1) {
-				output = new IntType();
+				return new IntType();
 			}
 			else if (maxValue <= (Integer.MAX_VALUE + 1l) * 2l) {
-				output = new UnsignedIntType();
+				return new UnsignedIntType();
 			}
-			else if (maxValue <= Long.MAX_VALUE) {
-				output = new LongType();
+			else {
+				return new LongType();
 			}
 		}
-		else {
-			output = new IntType();
-		}
-	}
-
-	@Override
-	public IntegerType out() {
-		return output;
+		return new IntType();
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/labelingMapping/DefaultCreateLabelingMapping.java
+++ b/src/main/java/net/imagej/ops/create/labelingMapping/DefaultCreateLabelingMapping.java
@@ -30,12 +30,10 @@
 
 package net.imagej.ops.create.labelingMapping;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractNullaryFunctionOp;
 import net.imglib2.roi.labeling.LabelingMapping;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -46,24 +44,17 @@ import org.scijava.plugin.Plugin;
  * @param <L> label type
  */
 @Plugin(type = Ops.Create.LabelingMapping.class)
-public class DefaultCreateLabelingMapping<L> extends AbstractOp implements
-	Ops.Create.LabelingMapping, Output<LabelingMapping<L>>
+public class DefaultCreateLabelingMapping<L> extends
+	AbstractNullaryFunctionOp<LabelingMapping<L>> implements
+	Ops.Create.LabelingMapping
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private LabelingMapping<L> output;
 
 	@Parameter(required = false)
 	private int maxNumSets;
 
 	@Override
-	public void run() {
-		output = new LabelingMapping<>(ops().create().integerType(maxNumSets));
-	}
-
-	@Override
-	public LabelingMapping<L> out() {
-		return output;
+	public LabelingMapping<L> compute0() {
+		return new LabelingMapping<>(ops().create().integerType(maxNumSets));
 	}
 
 }

--- a/src/main/java/net/imagej/ops/create/nativeType/DefaultCreateNativeType.java
+++ b/src/main/java/net/imagej/ops/create/nativeType/DefaultCreateNativeType.java
@@ -30,13 +30,11 @@
 
 package net.imagej.ops.create.nativeType;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.Output;
+import net.imagej.ops.special.AbstractNullaryFunctionOp;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.real.DoubleType;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -49,24 +47,15 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.NativeType.class)
 public class DefaultCreateNativeType<T extends NativeType<T>> extends
-	AbstractOp implements Ops.Create.NativeType, Output<T>
+	AbstractNullaryFunctionOp<T> implements Ops.Create.NativeType
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private T output;
 
 	@Parameter(required = false)
 	private Class<T> type;
 
 	@Override
-	public void run() {
-		if (type != null) output = createTypeFromClass();
-		else output = createTypeFromScratch();
-	}
-
-	@Override
-	public T out() {
-		return output;
+	public T compute0() {
+		return type != null ? createTypeFromClass() : createTypeFromScratch();
 	}
 
 	// -- Helper methods --

--- a/src/main/java/net/imagej/ops/eval/DefaultEval.java
+++ b/src/main/java/net/imagej/ops/eval/DefaultEval.java
@@ -32,18 +32,17 @@ package net.imagej.ops.eval;
 
 import java.util.Map;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
  * Evaluates an expression.
  * <p>
- * The expression is parsed using <a
- * href="https://github.com/scijava/scijava-expression-parser">SJEP</a>, then
+ * The expression is parsed using
+ * <a href="https://github.com/scijava/scijava-expression-parser">SJEP</a>, then
  * evaluated by invoking available ops.
  * </p>
  * 
@@ -51,22 +50,18 @@ import org.scijava.plugin.Plugin;
  * @see OpEvaluator
  */
 @Plugin(type = Ops.Eval.class)
-public class DefaultEval extends AbstractOp implements Ops.Eval {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Object result;
-
-	@Parameter
-	private String expression;
+public class DefaultEval extends AbstractUnaryFunctionOp<String, Object>
+	implements Ops.Eval
+{
 
 	@Parameter(required = false)
 	private Map<String, Object> vars;
 
 	@Override
-	public void run() {
+	public Object compute1(final String input) {
 		final OpEvaluator e = new OpEvaluator(ops());
 		if (vars != null) e.setAll(vars);
-		result = e.evaluate(expression);
+		return e.evaluate(input);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/image/ascii/DefaultASCII.java
+++ b/src/main/java/net/imagej/ops/image/ascii/DefaultASCII.java
@@ -30,32 +30,31 @@
 
 package net.imagej.ops.image.ascii;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Pair;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
  * Generates an ASCII version of an image.
- * <p>Only the first two dimensions of the image are considered.</p>
+ * <p>
+ * Only the first two dimensions of the image are considered.
+ * </p>
  * 
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Image.ASCII.class)
-public class DefaultASCII<T extends RealType<T>> extends AbstractOp implements
+public class DefaultASCII<T extends RealType<T>> extends
+	AbstractUnaryFunctionOp<IterableInterval<T>, String> implements
 	Ops.Image.ASCII
 {
 
 	private static final String CHARS = " .,-+o*O#";
-
-	@Parameter
-	private IterableInterval<T> image;
 
 	@Parameter(required = false)
 	private T min;
@@ -63,17 +62,14 @@ public class DefaultASCII<T extends RealType<T>> extends AbstractOp implements
 	@Parameter(required = false)
 	private T max;
 
-	@Parameter(type = ItemIO.OUTPUT)
-	private String ascii;
-
 	@Override
-	public void run() {
+	public String compute1(final IterableInterval<T> input) {
 		if (min == null || max == null) {
-			final Pair<T,T> minMax = ops().stats().minMax(image);
+			final Pair<T, T> minMax = ops().stats().minMax(input);
 			if (min == null) min = minMax.getA();
 			if (max == null) max = minMax.getB();
 		}
-		ascii = ascii(image, min, max);
+		return ascii(input, min, max);
 	}
 
 	// -- Utility methods --

--- a/src/main/java/net/imagej/ops/image/crop/CropImgPlus.java
+++ b/src/main/java/net/imagej/ops/image/crop/CropImgPlus.java
@@ -31,15 +31,14 @@
 package net.imagej.ops.image.crop;
 
 import net.imagej.ImgPlus;
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.MetadataUtil;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.ImgView;
 import net.imglib2.type.Type;
 
-import org.scijava.ItemIO;
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -49,15 +48,9 @@ import org.scijava.plugin.Plugin;
  * @author Martin Horn (University of Konstanz)
  */
 @Plugin(type = Ops.Image.Crop.class, priority = Priority.LOW_PRIORITY + 1)
-public class CropImgPlus<T extends Type<T>> extends AbstractOp implements
-	Ops.Image.Crop
+public class CropImgPlus<T extends Type<T>> extends
+	AbstractUnaryFunctionOp<ImgPlus<T>, ImgPlus<T>> implements Ops.Image.Crop
 {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private ImgPlus<T> out;
-
-	@Parameter
-	private ImgPlus<T> in;
 
 	@Parameter
 	protected Interval interval;
@@ -66,13 +59,13 @@ public class CropImgPlus<T extends Type<T>> extends AbstractOp implements
 	private boolean dropSingleDimensions = true;
 
 	@Override
-	public void run() {
-		final RandomAccessibleInterval<T> rai = in;
-		out =
-			new ImgPlus<>(ImgView.wrap(
-				ops().image().crop(rai, interval, dropSingleDimensions), in.factory()));
+	public ImgPlus<T> compute1(final ImgPlus<T> input) {
+		final RandomAccessibleInterval<T> rai = input;
+		final ImgPlus<T> out = new ImgPlus<>(ImgView.wrap(ops().image().crop(rai,
+			interval, dropSingleDimensions), input.factory()));
 
 		// TODO remove metadata-util
-		MetadataUtil.copyAndCleanImgPlusMetadata(interval, in, out);
+		MetadataUtil.copyAndCleanImgPlusMetadata(interval, input, out);
+		return out;
 	}
 }

--- a/src/main/java/net/imagej/ops/image/crop/CropRAI.java
+++ b/src/main/java/net/imagej/ops/image/crop/CropRAI.java
@@ -30,15 +30,14 @@
 
 package net.imagej.ops.image.crop;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
-import org.scijava.ItemIO;
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -48,13 +47,10 @@ import org.scijava.plugin.Plugin;
  * @author Martin Horn (University of Konstanz)
  */
 @Plugin(type = Ops.Image.Crop.class, priority = Priority.LOW_PRIORITY)
-public class CropRAI<T> extends AbstractOp implements Ops.Image.Crop {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private RandomAccessibleInterval<T> out;
-
-	@Parameter
-	private RandomAccessibleInterval<T> in;
+public class CropRAI<T> extends
+	AbstractUnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
+	implements Ops.Image.Crop
+{
 
 	@Parameter
 	protected Interval interval;
@@ -63,7 +59,9 @@ public class CropRAI<T> extends AbstractOp implements Ops.Image.Crop {
 	private boolean dropSingleDimensions = true;
 
 	@Override
-	public void run() {
+	public RandomAccessibleInterval<T> compute1(
+		final RandomAccessibleInterval<T> input)
+	{
 		boolean oneSizedDims = false;
 
 		if (dropSingleDimensions) {
@@ -75,17 +73,10 @@ public class CropRAI<T> extends AbstractOp implements Ops.Image.Crop {
 			}
 		}
 
-		if (Intervals.equals(in, interval) && !oneSizedDims) {
-			out = in;
-		}
-		else {
-			IntervalView<T> res;
-			if (Intervals.contains(in, interval)) res =
-				Views.offsetInterval(in, interval);
-			else {
-				throw new RuntimeException("Intervals don't match!");
-			}
-			out = oneSizedDims ? Views.dropSingletonDimensions(res) : res;
-		}
+		if (Intervals.equals(input, interval) && !oneSizedDims) return input;
+		if (!Intervals.contains(input, interval)) throw new RuntimeException(
+			"Intervals don't match!");
+		IntervalView<T> res = Views.offsetInterval(input, interval);
+		return oneSizedDims ? Views.dropSingletonDimensions(res) : res;
 	}
 }

--- a/src/main/java/net/imagej/ops/image/scale/ScaleImg.java
+++ b/src/main/java/net/imagej/ops/image/scale/ScaleImg.java
@@ -30,8 +30,8 @@
 
 package net.imagej.ops.image.scale;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.FlatIterationOrder;
@@ -44,7 +44,6 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -52,12 +51,9 @@ import org.scijava.plugin.Plugin;
  * @author Martin Horn (University of Konstanz)
  */
 @Plugin(type = Ops.Image.Scale.class)
-public class ScaleImg<T extends RealType<T>> extends AbstractOp implements
-	Ops.Image.Scale
+public class ScaleImg<T extends RealType<T>> extends
+	AbstractUnaryFunctionOp<Img<T>, Img<T>> implements Ops.Image.Scale
 {
-
-	@Parameter
-	private Img<T> in;
 
 	@Parameter
 	/*Scale factors for each dimension*/
@@ -66,32 +62,30 @@ public class ScaleImg<T extends RealType<T>> extends AbstractOp implements
 	@Parameter
 	private InterpolatorFactory<T, RandomAccessible<T>> interpolator;
 
-	@Parameter(type = ItemIO.OUTPUT)
-	private Img<T> out;
-
 	@Override
-	public void run() {
-		if (in.numDimensions() != scaleFactors.length) {
+	public Img<T> compute1(Img<T> input) {
+		if (input.numDimensions() != scaleFactors.length) {
 			throw new IllegalArgumentException(
-				"Less/more scale factors are provided than dimensions in the image.");
+				"Less/more scale factors are provided than dimensions input the image.");
 		}
 
-		final long[] newDims = new long[in.numDimensions()];
-		in.dimensions(newDims);
-		for (int i = 0; i < Math.min(scaleFactors.length, in.numDimensions()); i++)
+		final long[] newDims = new long[input.numDimensions()];
+		input.dimensions(newDims);
+		for (int i = 0; i < Math.min(scaleFactors.length, input
+			.numDimensions()); i++)
 		{
-			newDims[i] = Math.round(in.dimension(i) * scaleFactors[i]);
+			newDims[i] = Math.round(input.dimension(i) * scaleFactors[i]);
 		}
 
-		IntervalView<T> interval =
-			Views.interval(Views.raster(RealViews.affineReal(Views.interpolate(Views
-				.extendMirrorSingle(in), interpolator),
-				new net.imglib2.realtransform.Scale(scaleFactors))), new FinalInterval(
+		IntervalView<T> interval = Views.interval(Views.raster(RealViews.affineReal(
+			Views.interpolate(Views.extendMirrorSingle(input), interpolator),
+			new net.imglib2.realtransform.Scale(scaleFactors))), new FinalInterval(
 				newDims));
 
-		out = in.factory().create(newDims, in.firstElement().createVariable());
+		final Img<T> out = input.factory().create(newDims, input.firstElement()
+			.createVariable());
 		Cursor<T> outC = out.cursor();
-		if (in.iterationOrder().equals(new FlatIterationOrder(in))) {
+		if (input.iterationOrder().equals(new FlatIterationOrder(input))) {
 			Cursor<T> viewC = Views.flatIterable(interval).cursor();
 			while (outC.hasNext()) {
 				outC.fwd();
@@ -108,6 +102,6 @@ public class ScaleImg<T extends RealType<T>> extends AbstractOp implements
 			}
 
 		}
-
+		return out;
 	}
 }

--- a/src/main/java/net/imagej/ops/lookup/LookupByName.java
+++ b/src/main/java/net/imagej/ops/lookup/LookupByName.java
@@ -30,11 +30,10 @@
 
 package net.imagej.ops.lookup;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -44,20 +43,16 @@ import org.scijava.plugin.Plugin;
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Lookup.class)
-public class LookupByName extends AbstractOp implements Ops.Lookup {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Op op;
-
-	@Parameter
-	private String name;
+public class LookupByName extends AbstractUnaryFunctionOp<String, Op> implements
+	Ops.Lookup
+{
 
 	@Parameter
 	private Object[] args;
 
 	@Override
-	public void run() {
-		op = ops().op(name, args);
+	public Op compute1(final String input) {
+		return ops().op(input, args);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/lookup/LookupByType.java
+++ b/src/main/java/net/imagej/ops/lookup/LookupByType.java
@@ -30,11 +30,10 @@
 
 package net.imagej.ops.lookup;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -44,20 +43,16 @@ import org.scijava.plugin.Plugin;
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Lookup.class)
-public class LookupByType extends AbstractOp implements Ops.Lookup {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Op op;
-
-	@Parameter
-	private Class<? extends Op> type;
+public class LookupByType extends
+	AbstractUnaryFunctionOp<Class<? extends Op>, Op> implements Ops.Lookup
+{
 
 	@Parameter
 	private Object[] args;
 
 	@Override
-	public void run() {
-		op = ops().op(type, args);
+	public Op compute1(final Class<? extends Op> input) {
+		return ops().op(input, args);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/run/RunByName.java
+++ b/src/main/java/net/imagej/ops/run/RunByName.java
@@ -30,10 +30,9 @@
 
 package net.imagej.ops.run;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -43,20 +42,16 @@ import org.scijava.plugin.Plugin;
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Run.class)
-public class RunByName extends AbstractOp implements Ops.Run {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Object output;
-
-	@Parameter
-	private String name;
+public class RunByName extends AbstractUnaryFunctionOp<String, Object>
+	implements Ops.Run
+{
 
 	@Parameter
 	private Object[] args;
 
 	@Override
-	public void run() {
-		output = ops().run(name, args);
+	public Object compute1(final String input) {
+		return ops().run(input, args);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/run/RunByOp.java
+++ b/src/main/java/net/imagej/ops/run/RunByOp.java
@@ -30,11 +30,10 @@
 
 package net.imagej.ops.run;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -44,20 +43,16 @@ import org.scijava.plugin.Plugin;
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Run.class)
-public class RunByOp extends AbstractOp implements Ops.Run {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Object output;
-
-	@Parameter
-	private Op op;
+public class RunByOp extends AbstractUnaryFunctionOp<Op, Object> implements
+	Ops.Run
+{
 
 	@Parameter
 	private Object[] args;
 
 	@Override
-	public void run() {
-		output = ops().run(op, args);
+	public Object compute1(final Op input) {
+		return ops().run(input, args);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/run/RunByType.java
+++ b/src/main/java/net/imagej/ops/run/RunByType.java
@@ -30,11 +30,10 @@
 
 package net.imagej.ops.run;
 
-import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.AbstractUnaryFunctionOp;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
@@ -44,20 +43,16 @@ import org.scijava.plugin.Plugin;
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Run.class)
-public class RunByType extends AbstractOp implements Ops.Run {
-
-	@Parameter(type = ItemIO.OUTPUT)
-	private Object output;
-
-	@Parameter
-	private Class<? extends Op> type;
+public class RunByType extends
+	AbstractUnaryFunctionOp<Class<? extends Op>, Object> implements Ops.Run
+{
 
 	@Parameter
 	private Object[] args;
 
 	@Override
-	public void run() {
-		output = ops().run(type, args);
+	public Object compute1(final Class<? extends Op> input) {
+		return ops().run(input, args);
 	}
 
 }


### PR DESCRIPTION
Although many ops are modified, the changes are similar so I do not
split the commit. All of them include changing "extends AbstractOp" to
"extends AbstractNullary(Unary)FunctionOp", renaming variables, and
removing redundant methods/variables/imports. The logic of the classes
are not changed, and the way to retrieve these ops remains the same.
This is achieved by only making the required parameters as inputs.

See #309 