### PR TITLE
Refactor stats ops

### DIFF
--- a/src/main/java/net/imagej/ops/stats/DefaultMedian.java
+++ b/src/main/java/net/imagej/ops/stats/DefaultMedian.java
@@ -30,115 +30,41 @@
 
 package net.imagej.ops.stats;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import org.scijava.plugin.Plugin;
 
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.Computers;
+import net.imagej.ops.special.UnaryComputerOp;
 import net.imglib2.type.numeric.RealType;
-
-import org.scijava.plugin.Plugin;
 
 /**
  * {@link Op} to calculate the {@code stats.median}.
  * 
  * @author Daniel Seebacher, University of Konstanz.
  * @author Christian Dietz, University of Konstanz.
- * @param <I> input type
- * @param <O> output type
+ * @author Jan Eglinger
+ * @param <I>
+ *            input type
+ * @param <O>
+ *            output type
  */
 @Plugin(type = Ops.Stats.Median.class, label = "Statistics: Median")
-public class DefaultMedian<I extends RealType<I>, O extends RealType<O>>
-	extends AbstractStatsOp<Iterable<I>, O> implements Ops.Stats.Median
-{
+public class DefaultMedian<I extends RealType<I>, O extends RealType<O>> extends AbstractStatsOp<Iterable<I>, O>
+		implements Ops.Stats.Median {
+
+	private UnaryComputerOp<Iterable<I>, O> op;
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public void initialize() {
+		op = (UnaryComputerOp) Computers.unary(ops(), Ops.Stats.Quantile.class, out(),
+				in() == null ? Iterable.class : in(), 0.5d);
+	}
 
 	@Override
 	public void compute1(final Iterable<I> input, final O output) {
-		final ArrayList<Double> statistics = new ArrayList<>();
-
-		final Iterator<I> it = input.iterator();
-		while (it.hasNext()) {
-			statistics.add(it.next().getRealDouble());
-		}
-
-		output.setReal(select(statistics, 0, statistics.size() - 1, statistics
-			.size() / 2));
+		op.compute1(input, output);
 	}
 
-	/**
-	 * Returns the value of the kth lowest element. Do note that for nth lowest
-	 * element, k = n - 1.
-	 */
-	private double select(final ArrayList<Double> array, final int inLeft,
-		final int inRight, final int k)
-	{
-
-		int left = inLeft;
-		int right = inRight;
-
-		while (true) {
-
-			if (right <= left + 1) {
-
-				if (right == left + 1 && array.get(right) < array.get(left)) {
-					swap(array, left, right);
-				}
-
-				return array.get(k);
-
-			}
-			final int middle = (left + right) >>> 1;
-			swap(array, middle, left + 1);
-
-			if (array.get(left) > array.get(right)) {
-				swap(array, left, right);
-			}
-
-			if (array.get(left + 1) > array.get(right)) {
-				swap(array, left + 1, right);
-			}
-
-			if (array.get(left) > array.get(left + 1)) {
-				swap(array, left, left + 1);
-			}
-
-			int i = left + 1;
-			int j = right;
-			final double pivot = array.get(left + 1);
-
-			while (true) {
-				do
-					++i;
-				while (array.get(i) < pivot);
-				do
-					--j;
-				while (array.get(j) > pivot);
-
-				if (j < i) {
-					break;
-				}
-
-				swap(array, i, j);
-			}
-
-			array.set(left + 1, array.get(j));
-			array.set(j, pivot);
-
-			if (j >= k) {
-				right = j - 1;
-			}
-
-			if (j <= k) {
-				left = i;
-			}
-		}
-	}
-
-	/** Helper method for swapping array entries */
-	private void swap(final List<Double> array, final int a, final int b) {
-		final double temp = array.get(a);
-		array.set(a, array.get(b));
-		array.set(b, temp);
-	}
 }

--- a/src/main/java/net/imagej/ops/stats/DefaultPercentile.java
+++ b/src/main/java/net/imagej/ops/stats/DefaultPercentile.java
@@ -30,12 +30,10 @@
 
 package net.imagej.ops.stats;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.Computers;
+import net.imagej.ops.special.UnaryComputerOp;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Parameter;
@@ -47,103 +45,29 @@ import org.scijava.plugin.Plugin;
  * @author Daniel Seebacher, University of Konstanz.
  * @author Christian Dietz, University of Konstanz.
  * @author Jan Eglinger
- * @param <I> input type
- * @param <O> output type
+ * @param <I>
+ *            input type
+ * @param <O>
+ *            output type
  */
 @Plugin(type = Ops.Stats.Percentile.class, label = "Statistics: Percentile")
-public class DefaultPercentile<I extends RealType<I>, O extends RealType<O>>
-	extends AbstractStatsOp<Iterable<I>, O> implements Ops.Stats.Percentile
-{
+public class DefaultPercentile<I extends RealType<I>, O extends RealType<O>> extends AbstractStatsOp<Iterable<I>, O>
+		implements Ops.Stats.Percentile {
 
-	@Parameter
+	@Parameter(min = "0", max = "100")
 	private double percent;
-	
+
+	private UnaryComputerOp<Iterable<I>, O> op;
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public void initialize() {
+		op = (UnaryComputerOp) Computers.unary(ops(), Ops.Stats.Quantile.class, out(),
+				in() == null ? Iterable.class : in(), percent / 100.0);
+	}
+
 	@Override
 	public void compute1(final Iterable<I> input, final O output) {
-		final ArrayList<Double> statistics = new ArrayList<>();
-
-		final Iterator<I> it = input.iterator();
-		while (it.hasNext()) {
-			statistics.add(it.next().getRealDouble());
-		}
-
-		output.setReal(select(statistics, 0, statistics.size() - 1, (int) (statistics
-			.size() * percent / 100)));
-	}
-
-	/**
-	 * Returns the value of the kth lowest element. Do note that for nth lowest
-	 * element, k = n - 1.
-	 */
-	private double select(final ArrayList<Double> array, final int inLeft,
-		final int inRight, final int k)
-	{
-
-		int left = inLeft;
-		int right = inRight;
-
-		while (true) {
-
-			if (right <= left + 1) {
-
-				if (right == left + 1 && array.get(right) < array.get(left)) {
-					swap(array, left, right);
-				}
-
-				return array.get(k);
-
-			}
-			final int middle = (left + right) >>> 1;
-			swap(array, middle, left + 1);
-
-			if (array.get(left) > array.get(right)) {
-				swap(array, left, right);
-			}
-
-			if (array.get(left + 1) > array.get(right)) {
-				swap(array, left + 1, right);
-			}
-
-			if (array.get(left) > array.get(left + 1)) {
-				swap(array, left, left + 1);
-			}
-
-			int i = left + 1;
-			int j = right;
-			final double pivot = array.get(left + 1);
-
-			while (true) {
-				do
-					++i;
-				while (array.get(i) < pivot);
-				do
-					--j;
-				while (array.get(j) > pivot);
-
-				if (j < i) {
-					break;
-				}
-
-				swap(array, i, j);
-			}
-
-			array.set(left + 1, array.get(j));
-			array.set(j, pivot);
-
-			if (j >= k) {
-				right = j - 1;
-			}
-
-			if (j <= k) {
-				left = i;
-			}
-		}
-	}
-
-	/** Helper method for swapping array entries */
-	private void swap(final List<Double> array, final int a, final int b) {
-		final double temp = array.get(a);
-		array.set(a, array.get(b));
-		array.set(b, temp);
+		op.compute1(input, output);
 	}
 }

--- a/src/main/java/net/imagej/ops/stats/DefaultQuantile.java
+++ b/src/main/java/net/imagej/ops/stats/DefaultQuantile.java
@@ -1,0 +1,149 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.stats;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link Op} to calculate the n-th {@code stats.percentile}.
+ * 
+ * @author Daniel Seebacher, University of Konstanz.
+ * @author Christian Dietz, University of Konstanz.
+ * @author Jan Eglinger
+ * @param <I> input type
+ * @param <O> output type
+ */
+@Plugin(type = Ops.Stats.Quantile.class, label = "Statistics: Quantile")
+public class DefaultQuantile<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractStatsOp<Iterable<I>, O> implements Ops.Stats.Quantile
+{
+
+	@Parameter(min = "0.0", max = "1.0")
+	private double quantile;
+	
+	@Override
+	public void compute1(final Iterable<I> input, final O output) {
+		final ArrayList<Double> statistics = new ArrayList<>();
+
+		final Iterator<I> it = input.iterator();
+		while (it.hasNext()) {
+			statistics.add(it.next().getRealDouble());
+		}
+
+		output.setReal(select(statistics, 0, statistics.size() - 1, (int) (statistics
+			.size() * quantile)));
+	}
+
+	/**
+	 * Returns the value of the kth lowest element. Do note that for nth lowest
+	 * element, k = n - 1.
+	 */
+	private double select(final ArrayList<Double> array, final int inLeft,
+		final int inRight, final int k)
+	{
+
+		int left = inLeft;
+		int right = inRight;
+
+		while (true) {
+
+			if (right <= left + 1) {
+
+				if (right == left + 1 && array.get(right) < array.get(left)) {
+					swap(array, left, right);
+				}
+
+				return array.get(k);
+
+			}
+			final int middle = (left + right) >>> 1;
+			swap(array, middle, left + 1);
+
+			if (array.get(left) > array.get(right)) {
+				swap(array, left, right);
+			}
+
+			if (array.get(left + 1) > array.get(right)) {
+				swap(array, left + 1, right);
+			}
+
+			if (array.get(left) > array.get(left + 1)) {
+				swap(array, left, left + 1);
+			}
+
+			int i = left + 1;
+			int j = right;
+			final double pivot = array.get(left + 1);
+
+			while (true) {
+				do
+					++i;
+				while (array.get(i) < pivot);
+				do
+					--j;
+				while (array.get(j) > pivot);
+
+				if (j < i) {
+					break;
+				}
+
+				swap(array, i, j);
+			}
+
+			array.set(left + 1, array.get(j));
+			array.set(j, pivot);
+
+			if (j >= k) {
+				right = j - 1;
+			}
+
+			if (j <= k) {
+				left = i;
+			}
+		}
+	}
+
+	/** Helper method for swapping array entries */
+	private void swap(final List<Double> array, final int a, final int b) {
+		final double temp = array.get(a);
+		array.set(a, array.get(b));
+		array.set(b, temp);
+	}
+}

--- a/src/main/java/net/imagej/ops/stats/StatsNamespace.java
+++ b/src/main/java/net/imagej/ops/stats/StatsNamespace.java
@@ -279,6 +279,20 @@ public class StatsNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.stats.DefaultQuantile.class)
+	public <T extends RealType<T>, O extends RealType<O>> O quantile(final Iterable<T> in, final double quantile) {
+		final O result =
+			(O) ops().run(net.imagej.ops.stats.DefaultQuantile.class, in, quantile);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.stats.DefaultQuantile.class)
+	public <T extends RealType<T>, O extends RealType<O>> O quantile(final O out, final Iterable<T> in, final double quantile) {
+		final O result =
+			(O) ops().run(net.imagej.ops.stats.DefaultQuantile.class, out, in, quantile);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.stats.IterableIntervalSize.class)
 	public <T extends RealType<T>, O extends RealType<O>> O size(
 		final IterableInterval<T> in)

--- a/src/test/java/net/imagej/ops/stats/StatisticsTest.java
+++ b/src/test/java/net/imagej/ops/stats/StatisticsTest.java
@@ -237,6 +237,12 @@ public class StatisticsTest extends AbstractOpTest {
 	}
 
 	@Test
+	public void testQuantile() {
+		Assert.assertEquals("0.5-th Quantile", 128d, ops.stats().quantile(randomlyFilledImg, 0.5d)
+				.getRealDouble(), 0.00001d);
+	}
+
+	@Test
 	public void testSkewness() {
 		Assert.assertEquals("Skewness", -0.0012661517853476312, ops.stats()
 			.skewness(randomlyFilledImg).getRealDouble(), 0.00001d);


### PR DESCRIPTION
The `stats.median` and `stats.percentile` ops now make use of `stats.quantile` via op chaining.