### PR TITLE
Refactor normalize

### DIFF
--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -239,7 +239,7 @@ public class ImageNamespace extends AbstractNamespace {
 		return ops().run(Ops.Image.Normalize.NAME, args);
 	}
 
-	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableComputer.class)
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class)
 	public
 		<T extends RealType<T>> IterableInterval<T> normalize(
 			final IterableInterval<T> out, final IterableInterval<T> in)
@@ -247,12 +247,12 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops()
-				.run(net.imagej.ops.image.normalize.NormalizeIterableComputer.class,
+				.run(net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class,
 					out, in);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableComputer.class)
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class)
 	public
 		<T extends RealType<T>> IterableInterval<T> normalize(
 			final IterableInterval<T> out, final IterableInterval<T> in,
@@ -261,12 +261,12 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIterableComputer.class, out,
+				net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class, out,
 				in, sourceMin);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableComputer.class)
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class)
 	public
 		<T extends RealType<T>> IterableInterval<T> normalize(
 			final IterableInterval<T> out, final IterableInterval<T> in,
@@ -275,12 +275,12 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIterableComputer.class, out,
+				net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class, out,
 				in, sourceMin, sourceMax);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableComputer.class)
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class)
 	public
 		<T extends RealType<T>> IterableInterval<T> normalize(
 			final IterableInterval<T> out, final IterableInterval<T> in,
@@ -289,12 +289,12 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIterableComputer.class, out,
+				net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class, out,
 				in, sourceMin, sourceMax, targetMin);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableComputer.class)
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class)
 	public
 		<T extends RealType<T>>
 		IterableInterval<T>
@@ -304,7 +304,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIterableComputer.class, out,
+				net.imagej.ops.image.normalize.NormalizeIterableIntervalComputer.class, out,
 				in, sourceMin, sourceMax, targetMin, targetMax);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/image/normalize/NormalizeIterableIntervalComputer.java
+++ b/src/main/java/net/imagej/ops/image/normalize/NormalizeIterableIntervalComputer.java
@@ -46,7 +46,7 @@ import org.scijava.plugin.Plugin;
  * @param <T>
  */
 @Plugin(type = Ops.Image.Normalize.class)
-public class NormalizeIterableComputer<T extends RealType<T>> extends
+public class NormalizeIterableIntervalComputer<T extends RealType<T>> extends
 	AbstractUnaryComputerOp<IterableInterval<T>, IterableInterval<T>> implements
 	Ops.Image.Normalize
 {

--- a/src/main/java/net/imagej/ops/image/normalize/NormalizeRealTypeComputer.java
+++ b/src/main/java/net/imagej/ops/image/normalize/NormalizeRealTypeComputer.java
@@ -30,18 +30,17 @@
 
 package net.imagej.ops.image.normalize;
 
-import net.imagej.ops.OpEnvironment;
 import net.imagej.ops.special.AbstractUnaryComputerOp;
 import net.imagej.ops.special.UnaryComputerOp;
-import net.imglib2.IterableInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Pair;
 
 /**
- * Simple {@link UnaryComputerOp} and {@link Converter} to perform a normalization.
+ * Simple {@link UnaryComputerOp} and {@link Converter} to perform a
+ * normalization.
  * 
  * @author Christian Dietz (University of Konstanz)
+ * @author Leon Yang
  */
 class NormalizeRealTypeComputer<T extends RealType<T>> extends
 	AbstractUnaryComputerOp<T, T> implements Converter<T, T>
@@ -49,47 +48,24 @@ class NormalizeRealTypeComputer<T extends RealType<T>> extends
 
 	private double targetMin, targetMax, sourceMin, factor;
 
-	public NormalizeRealTypeComputer(final OpEnvironment ops, final T sourceMin,
-		final T sourceMax, final T targetMin, final T targetMax,
-		final IterableInterval<T> input)
+	public NormalizeRealTypeComputer() {}
+
+	public NormalizeRealTypeComputer(final double sourceMin,
+		final double sourceMax, final double targetMin, final double targetMax)
 	{
-		double tmp = 0.0;
-		
-		if (sourceMin != null && sourceMax != null) {
-			this.sourceMin = sourceMin.getRealDouble();
-			tmp = sourceMax.getRealDouble();
-		} else {
-			final Pair<T,T> minMax = ops.stats().minMax(input);
-			if (sourceMin == null) {
-				this.sourceMin = minMax.getA().getRealDouble();
-			}
-			else {
-				this.sourceMin = sourceMin.getRealDouble();
-			}
-			if (sourceMax == null) {
-				tmp = minMax.getB().getRealDouble();
-			}
-			else {
-				tmp = sourceMax.getRealDouble();
-			}
-		}
+		setup(sourceMin, sourceMax, targetMin, targetMax);
+	}
 
-		if (targetMax == null) {
-			this.targetMax = input.firstElement().getMaxValue();
-		}
-		else {
-			this.targetMax = targetMax.getRealDouble();
-		}
+	public void setup(final double sourceMin, final double sourceMax,
+		final double targetMin, final double targetMax)
+	{
+		this.sourceMin = sourceMin;
+		final double tmp = sourceMax;
+		this.targetMin = targetMin;
+		this.targetMax = targetMax;
 
-		if (targetMin == null) {
-			this.targetMin = input.firstElement().getMinValue();
-		}
-		else {
-			this.targetMin = targetMin.getRealDouble();
-		}
-
-		this.factor =
-			1.0d / (tmp - this.sourceMin) * (this.targetMax - this.targetMin);
+		this.factor = 1.0d / (tmp - this.sourceMin) * (this.targetMax -
+			this.targetMin);
 	}
 
 	@Override

--- a/src/test/java/net/imagej/ops/image/normalize/NormalizeTest.java
+++ b/src/test/java/net/imagej/ops/image/normalize/NormalizeTest.java
@@ -33,6 +33,8 @@ package net.imagej.ops.image.normalize;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.util.Pair;
@@ -57,5 +59,16 @@ public class NormalizeTest extends AbstractOpTest {
 		assertEquals(minMax2.getA().get(), Byte.MIN_VALUE);
 		assertEquals(minMax2.getB().get(), Byte.MAX_VALUE);
 
+		final IterableInterval<ByteType> lazyOut = ops.image().normalize(in);
+		final IterableInterval<ByteType> notLazyOut = ops.image().normalize(in,
+			null, null, null, null, false);
+
+		final Cursor<ByteType> outCursor = out.cursor();
+		final Cursor<ByteType> lazyCursor = lazyOut.cursor();
+		final Cursor<ByteType> notLazyCursor = notLazyOut.cursor();
+		while (outCursor.hasNext()) {
+			assertEquals(outCursor.next().get(), lazyCursor.next().get());
+			assertEquals(outCursor.get().get(), notLazyCursor.next().get());
+		}
 	}
 }


### PR DESCRIPTION
This branch addresses one of the issue mentioned in #316 that the `Ops.Image.Normalize` ops could not implement `initialize` method unless they are refactored.

Now the logic for handling null parameters are moved to the upstream ops, the `NormalizeIterableIntervalComputer/Function`, so that it is feasible to initialize the helper ops. In order to make the NormalizeRealTypeComputer reusable, I also have to make the parameters of it modifiable through a method `setup(...)`. This is not very clean, but as this op is just a helper and not even a `Plugin`, I think adding this additional signature will not be too bad.

However, I am not able to merge the two ops into a `hybrid` in a nice and clean way, since the `function` one has an additional parameter `isLazy`. If the two ops are combined, all the computer method signature in the `ImageNamespace` will have to include an `isLazy` parameter, which does not make sense (`isLazy` is only used in Function compute1(...)).

I also make the Function op a `FunctionViaComputer`, since I think its logic works in that way.