### PR TITLE
Restore the binary inplace maps

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -58,6 +58,8 @@ import net.imagej.ops.special.SpecialOp;
 import net.imagej.ops.special.UnaryOutputFactory;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imagej.ops.stats.StatsNamespace;
 import net.imagej.ops.thread.ThreadNamespace;
@@ -690,6 +692,32 @@ public interface OpEnvironment extends Contextual {
 		final RandomAccessibleInterval<EO> result =
 			(RandomAccessibleInterval<EO>) run(
 				net.imagej.ops.map.MapIIAndRAIToRAI.class, out, in1, in2, op);
+		return result;
+	}
+
+	/** Executes the "map" operation on the given arguments. */
+	@OpMethod(ops = { net.imagej.ops.map.MapIIAndIIInplaceParallel.class,
+		net.imagej.ops.map.MapIIAndIIInplace.class })
+	default <EA> IterableInterval<EA> map(final IterableInterval<EA> arg,
+		final IterableInterval<EA> in, final BinaryInplaceOp<EA> op)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<EA> result = (IterableInterval<EA>) run(
+			net.imagej.ops.map.MapIIAndIIInplaceParallel.class, arg, in, op);
+		return result;
+	}
+
+	/** Executes the "map" operation on the given arguments. */
+	@OpMethod(ops = {
+		net.imagej.ops.map.MapIterableIntervalAndRAIInplaceParallel.class,
+		net.imagej.ops.map.MapIterableIntervalAndRAIInplace.class })
+	default <EA, EI> IterableInterval<EA> map(final IterableInterval<EA> arg,
+		final RandomAccessibleInterval<EI> in, final BinaryInplace1Op<EA, EI> op)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<EA> result = (IterableInterval<EA>) run(
+			net.imagej.ops.map.MapIterableIntervalAndRAIInplaceParallel.class, arg,
+			in, op);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.special.inplace.AbstractBinaryInplaceOp;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract base class for {@link MapBinaryInplace} implementations.
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of first, second inputs, and the outputs
+ * @param <PA> producer of first, second inputs, and the outputs
+ */
+public abstract class AbstractMapBinaryInplace<EA, PA> extends
+	AbstractBinaryInplaceOp<PA> implements
+	MapBinaryInplace<EA, BinaryInplaceOp<EA>>
+{
+
+	@Parameter
+	private BinaryInplaceOp<EA> op;
+
+	@Override
+	public BinaryInplaceOp<EA> getOp() {
+		return op;
+	}
+
+	@Override
+	public void setOp(final BinaryInplaceOp<EA> op) {
+		this.op = op;
+	}
+}

--- a/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace1.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace1.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.special.inplace.AbstractBinaryInplace1Op;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract base class for {@link MapBinaryInplace1} implementations.
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of first inputs + outputs
+ * @param <EI> element type of second inputs
+ * @param <PA> producer of first inputs + outputs
+ * @param <PI> producer of second inputs
+ */
+public abstract class AbstractMapBinaryInplace1<EA, EI, PA, PI> extends
+	AbstractBinaryInplace1Op<PA, PI> implements
+	MapBinaryInplace1<EA, EI, BinaryInplace1Op<EA, EI>>
+{
+
+	@Parameter
+	private BinaryInplace1Op<EA, EI> op;
+
+	@Override
+	public BinaryInplace1Op<EA, EI> getOp() {
+		return op;
+	}
+
+	@Override
+	public void setOp(final BinaryInplace1Op<EA, EI> op) {
+		this.op = op;
+	}
+}

--- a/src/main/java/net/imagej/ops/map/MapBinaryInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapBinaryInplace.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+
+/**
+ * Typed interface for "map" {@link BinaryInplaceOp}s.
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of inputs + outputs
+ * @param <OP> type of {@link BinaryInplaceOp} which processes each element
+ */
+public interface MapBinaryInplace<EA, OP extends BinaryInplaceOp<EA>> extends
+	MapOp<OP>
+{
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ops/map/MapBinaryInplace1.java
+++ b/src/main/java/net/imagej/ops/map/MapBinaryInplace1.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+
+/**
+ * Typed interface for "map" {@link BinaryInplace1Op}s.
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of first inputs + outputs
+ * @param <EI> element type of second inputs
+ * @param <OP> type of {@link BinaryInplace1Op} which processes each element
+ */
+public interface MapBinaryInplace1<EA, EI, OP extends BinaryInplace1Op<EA, EI>>
+	extends MapOp<OP>
+{
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link MapBinaryInplace} over 2 {@link IterableInterval}s
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of inputs + outputs
+ */
+@Plugin(type = Ops.Map.class, priority = Priority.HIGH_PRIORITY + 1)
+public class MapIIAndIIInplace<EA> extends
+	AbstractMapBinaryInplace<EA, IterableInterval<EA>> implements Contingent
+{
+
+	@Override
+	public boolean conforms() {
+		return in1().iterationOrder().equals(in2().iterationOrder());
+	}
+
+	@Override
+	public void mutate1(final IterableInterval<EA> arg,
+		final IterableInterval<EA> in)
+	{
+		final Cursor<EA> argCursor = arg.cursor();
+		final Cursor<EA> inCursor = in.cursor();
+		final BinaryInplaceOp<EA> op = getOp();
+		while (argCursor.hasNext()) {
+			op.mutate1(argCursor.next(), inCursor.next());
+		}
+	}
+
+	@Override
+	public void mutate2(final IterableInterval<EA> in,
+		final IterableInterval<EA> arg)
+	{
+		final Cursor<EA> argCursor = arg.cursor();
+		final Cursor<EA> inCursor = in.cursor();
+		final BinaryInplaceOp<EA> op = getOp();
+		while (argCursor.hasNext()) {
+			op.mutate2(inCursor.next(), argCursor.next());
+		}
+	}
+
+	/*
+	 * TODO: this will not work until Java 8 is fully supported by SciJava.
+	 * See https://github.com/scijava/scijava-common/pull/218
+	
+	@Override
+	public void mutate1(final IterableInterval<EA> arg,
+		final IterableInterval<EA> in)
+	{
+		mutateDispatch(arg, in, getOp()::mutate2);
+	}
+	
+	@Override
+	public void mutate2(final IterableInterval<EA> in,
+		final IterableInterval<EA> arg)
+	{
+		mutateDispatch(arg, in, getOp()::mutate1);
+	}
+	
+	private void mutateDispatch(final IterableInterval<EA> first,
+		final IterableInterval<EA> second, final BiConsumer<EA, EA> c)
+	{
+		final Cursor<EA> firstCursor = first.cursor();
+		final Cursor<EA> secondCursor = second.cursor();
+		while (firstCursor.hasNext()) {
+			c.accept(firstCursor.next(), secondCursor.next());
+		}
+	
+	}
+	*/
+}

--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
@@ -1,0 +1,165 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Parallel;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+import net.imagej.ops.thread.chunker.ChunkerOp;
+import net.imagej.ops.thread.chunker.CursorBasedChunk;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link MapBinaryInplace} over 2 {@link IterableInterval}s
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of inputs + outputs
+ */
+@Plugin(type = Ops.Map.class, priority = Priority.HIGH_PRIORITY + 3)
+public class MapIIAndIIInplaceParallel<EA> extends
+	AbstractMapBinaryInplace<EA, IterableInterval<EA>> implements Contingent,
+	Parallel
+{
+
+	@Override
+	public boolean conforms() {
+		return in1().iterationOrder().equals(in2().iterationOrder());
+	}
+
+	@Override
+	public void mutate1(final IterableInterval<EA> arg,
+		final IterableInterval<EA> in)
+	{
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
+
+			@Override
+			public void execute(final int startIndex, final int stepSize,
+				final int numSteps)
+			{
+				final Cursor<EA> inCursor = in.cursor();
+				final Cursor<EA> argCursor = arg.cursor();
+				final BinaryInplaceOp<EA> op = getOp();
+
+				setToStart(inCursor, startIndex);
+				setToStart(argCursor, startIndex);
+
+				int ctr = 0;
+				while (ctr < numSteps) {
+					op.mutate1(argCursor.get(), inCursor.get());
+					inCursor.jumpFwd(stepSize);
+					argCursor.jumpFwd(stepSize);
+					ctr++;
+				}
+			}
+		}, arg.size());
+	}
+
+	@Override
+	public void mutate2(final IterableInterval<EA> in,
+		final IterableInterval<EA> arg)
+	{
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
+
+			@Override
+			public void execute(final int startIndex, final int stepSize,
+				final int numSteps)
+			{
+				final Cursor<EA> inCursor = in.cursor();
+				final Cursor<EA> argCursor = arg.cursor();
+				final BinaryInplaceOp<EA> op = getOp();
+
+				setToStart(inCursor, startIndex);
+				setToStart(argCursor, startIndex);
+
+				int ctr = 0;
+				while (ctr < numSteps) {
+					op.mutate2(inCursor.get(), argCursor.get());
+					inCursor.jumpFwd(stepSize);
+					argCursor.jumpFwd(stepSize);
+					ctr++;
+				}
+			}
+		}, in.size());
+	}
+
+	/*
+	 * TODO: this will not work until Java 8 is fully supported by SciJava.
+	 * See https://github.com/scijava/scijava-common/pull/218
+	
+	@Override
+	public void mutate1(final IterableInterval<EA> arg,
+		final IterableInterval<EA> in)
+	{
+		final BinaryInplaceOp<EA> safe = getOp().getIndependentInstance();
+		mutateDispatch(arg, in, safe::mutate1);
+	}
+	
+	@Override
+	public void mutate2(final IterableInterval<EA> in,
+		final IterableInterval<EA> arg)
+	{
+		final BinaryInplaceOp<EA> safe = getOp().getIndependentInstance();
+		mutateDispatch(in, arg, safe::mutate2);
+	}
+	
+	private void mutateDispatch(final IterableInterval<EA> first,
+		final IterableInterval<EA> second, final BiConsumer<EA, EA> c)
+	{
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
+	
+			@Override
+			public void execute(final int startIndex, final int stepSize,
+				final int numSteps)
+			{
+				final Cursor<EA> firstCursor = first.cursor();
+				final Cursor<EA> secondCursor = second.cursor();
+	
+				setToStart(firstCursor, startIndex);
+				setToStart(secondCursor, startIndex);
+	
+				int ctr = 0;
+				while (ctr < numSteps) {
+					c.accept(firstCursor.get(), secondCursor.get());
+					firstCursor.jumpFwd(stepSize);
+					secondCursor.jumpFwd(stepSize);
+					ctr++;
+				}
+			}
+		}, first.size());
+	
+	}
+	*/
+}

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalAndRAIInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalAndRAIInplace.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.Intervals;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link MapBinaryInplace1} over {@link IterableInterval} and
+ * {@link RandomAccessibleInterval}
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of first inputs + outputs
+ * @param <EI> element type of second inputs
+ */
+@Plugin(type = Ops.Map.class, priority = Priority.HIGH_PRIORITY)
+public class MapIterableIntervalAndRAIInplace<EA, EI> extends
+	AbstractMapBinaryInplace1<EA, EI, IterableInterval<EA>, RandomAccessibleInterval<EI>>
+	implements Contingent
+{
+
+	@Override
+	public boolean conforms() {
+		return Intervals.equalDimensions(in1(), in2());
+	}
+
+	@Override
+	public void mutate1(final IterableInterval<EA> arg,
+		final RandomAccessibleInterval<EI> in)
+	{
+		final RandomAccess<EI> inAccess = in.randomAccess();
+		final Cursor<EA> argCursor = arg.localizingCursor();
+		final BinaryInplace1Op<EA, EI> op = getOp();
+
+		while (argCursor.hasNext()) {
+			argCursor.fwd();
+			inAccess.setPosition(argCursor);
+			op.mutate1(argCursor.get(), inAccess.get());
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/map/MapIterableIntervalAndRAIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableIntervalAndRAIInplaceParallel.java
@@ -1,0 +1,95 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.Parallel;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.thread.chunker.ChunkerOp;
+import net.imagej.ops.thread.chunker.CursorBasedChunk;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.util.Intervals;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link MapBinaryInplace1} over {@link IterableInterval} and
+ * {@link RandomAccessibleInterval}
+ * 
+ * @author Leon Yang
+ * @param <EA> element type of first inputs + outputs
+ * @param <EI> element type of second inputs
+ */
+@Plugin(type = Ops.Map.class, priority = Priority.HIGH_PRIORITY + 2)
+public class MapIterableIntervalAndRAIInplaceParallel<EA, EI> extends
+	AbstractMapBinaryInplace1<EA, EI, IterableInterval<EA>, RandomAccessibleInterval<EI>>
+	implements Contingent, Parallel
+{
+
+	@Override
+	public boolean conforms() {
+		return Intervals.equalDimensions(in1(), in2());
+	}
+
+	@Override
+	public void mutate1(final IterableInterval<EA> arg,
+		final RandomAccessibleInterval<EI> in)
+	{
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
+
+			@Override
+			public void execute(final int startIndex, final int stepSize,
+				final int numSteps)
+			{
+				final BinaryInplace1Op<EA, EI> safe = getOp().getIndependentInstance();
+				final Cursor<EA> argCursor = arg.localizingCursor();
+
+				setToStart(argCursor, startIndex);
+
+				final RandomAccess<EI> inAccess = in.randomAccess();
+
+				int ctr = 0;
+				while (ctr < numSteps) {
+					inAccess.setPosition(argCursor);
+					safe.mutate1(argCursor.get(), inAccess.get());
+					argCursor.jumpFwd(stepSize);
+					ctr++;
+				}
+			}
+		}, arg.size());
+	}
+
+}

--- a/src/test/java/net/imagej/ops/map/MapBinaryTest.java
+++ b/src/test/java/net/imagej/ops/map/MapBinaryTest.java
@@ -36,6 +36,9 @@ import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+import net.imagej.ops.special.inplace.Inplaces;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -178,5 +181,101 @@ public class MapBinaryTest extends AbstractOpTest {
 		}
 
 		ops.op(MapIIAndRAIToRAIParallel.class, outDiffDims, in1, in2, add);
+	}
+
+	// -- inplace map tests --
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMapIIAndIIInplace() {
+		final Img<ByteType> in1Copy = in1.copy();
+		final Img<ByteType> in2Copy = in2.copy();
+
+		final BinaryInplaceOp<Img<ByteType>> map = Inplaces.binary(ops,
+			MapIIAndIIInplace.class, in1Copy, in2Copy, add);
+
+		map.run(in1Copy, in2, in1Copy);
+		map.run(in1, in2Copy, in2Copy);
+
+		final Cursor<ByteType> in1Cursor = in1.cursor();
+		final Cursor<ByteType> in1CopyCursor = in1Copy.cursor();
+		final Cursor<ByteType> in2Cursor = in2.cursor();
+		final Cursor<ByteType> in2CopyCursor = in2Copy.cursor();
+
+		while (in1Cursor.hasNext()) {
+			final byte expected = (byte) (in1Cursor.next().get() + in2Cursor.next()
+				.get());
+			assertEquals(expected, in1CopyCursor.next().get());
+			assertEquals(expected, in2CopyCursor.next().get());
+		}
+
+		map.run(in1, in2, out);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMapIIAndIIInplaceParallel() {
+		final Img<ByteType> in1Copy = in1.copy();
+		final Img<ByteType> in2Copy = in2.copy();
+
+		final BinaryInplaceOp<Img<ByteType>> map = Inplaces.binary(ops,
+			MapIIAndIIInplaceParallel.class, in1Copy, in2Copy, add);
+
+		map.run(in1Copy, in2, in1Copy);
+		map.run(in1, in2Copy, in2Copy);
+
+		final Cursor<ByteType> in1Cursor = in1.cursor();
+		final Cursor<ByteType> in1CopyCursor = in1Copy.cursor();
+		final Cursor<ByteType> in2Cursor = in2.cursor();
+		final Cursor<ByteType> in2CopyCursor = in2Copy.cursor();
+
+		while (in1Cursor.hasNext()) {
+			final byte expected = (byte) (in1Cursor.next().get() + in2Cursor.next()
+				.get());
+			assertEquals(expected, in1CopyCursor.next().get());
+			assertEquals(expected, in2CopyCursor.next().get());
+		}
+
+		map.run(in1, in2, out);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMapIterableIntervalAndRAIInplace() {
+		final Img<ByteType> in1Copy = in1.copy();
+
+		final BinaryInplace1Op<Img<ByteType>, Img<ByteType>> map = Inplaces.binary1(
+			ops, MapIterableIntervalAndRAIInplace.class, in1Copy, in2, add);
+
+		map.run(in1Copy, in2);
+
+		final Cursor<ByteType> in1Cursor = in1.cursor();
+		final Cursor<ByteType> in1CopyCursor = in1Copy.cursor();
+		final Cursor<ByteType> in2Cursor = in2.cursor();
+
+		while (in1Cursor.hasNext()) {
+			assertEquals((byte) (in1Cursor.next().get() + in2Cursor.next().get()),
+				in1CopyCursor.next().get());
+		}
+
+		map.run(in1, in2, in2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMapIterableIntervalAndRAIInplaceParallel() {
+		final Img<ByteType> in1Copy = in1.copy();
+
+		final BinaryInplace1Op<Img<ByteType>, Img<ByteType>> map = Inplaces.binary1(
+			ops, MapIterableIntervalAndRAIInplaceParallel.class, in1Copy, in2, add);
+
+		map.run(in1Copy, in2);
+
+		final Cursor<ByteType> in1Cursor = in1.cursor();
+		final Cursor<ByteType> in1CopyCursor = in1Copy.cursor();
+		final Cursor<ByteType> in2Cursor = in2.cursor();
+
+		while (in1Cursor.hasNext()) {
+			assertEquals((byte) (in1Cursor.next().get() + in2Cursor.next().get()),
+				in1CopyCursor.next().get());
+		}
+
+		map.run(in1, in2, in2);
 	}
 }


### PR DESCRIPTION
This effectively reverts commit 065a638d45b623361b69dbf50670a3b266a98162, and brings the binary inplace maps up to the latest API.