### PR TITLE
Removed unnecessary computations from local thresholding

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/apply/LocalThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/LocalThreshold.java
@@ -81,13 +81,7 @@ public class LocalThreshold<T extends RealType<T>>
 	public void compute1(final RandomAccessibleInterval<T> input,
 		final RandomAccessibleInterval<BitType> output)
 	{
-		RandomAccessibleInterval<T> extendedInput = input;
-
-		if (outOfBounds != null) {
-			extendedInput = Views.interval(Views.extend(input, outOfBounds), input);
-		}
-
-		mapper.compute1(extendedInput, output);
+		mapper.compute0(output);
 	}
 
 }


### PR DESCRIPTION
Resulting from the restructuring of `Unary/Binary/NullaryOps` the input of local thresholding ops was computed a second time.