### PR TITLE
small create kernel refactoring

### DIFF
--- a/src/main/java/net/imagej/ops/create/AbstractCreateGaussianKernel.java
+++ b/src/main/java/net/imagej/ops/create/AbstractCreateGaussianKernel.java
@@ -1,5 +1,5 @@
 /*
- * #%L
+* #%L
  * ImageJ software for multidimensional image processing and analysis.
  * %%
  * Copyright (C) 2014 - 2016 Board of Regents of the University of
@@ -30,41 +30,74 @@
 
 package net.imagej.ops.create;
 
-import net.imagej.ops.AbstractOp;
-import net.imglib2.img.Img;
-import net.imglib2.img.ImgFactory;
-import net.imglib2.type.Type;
+import net.imagej.ops.Contingent;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 
-import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 
 /**
- * Abstract convenience op for generating a symmetric kernel
- * 
+ * Abstract class for kernel generation from sigma and <b> calibrated units
+ * </b>. The specified sigma and calibration is used to determine the
+ * dimensionality of the kernel and to map it on a pixel grid.
+ *
  * @author Brian Northan
  * @param <T>
  */
-public abstract class AbstractCreateSymmetricKernel<T extends ComplexType<T>>
-	extends AbstractOp
+public abstract class AbstractCreateGaussianKernel<T extends ComplexType<T> & NativeType<T>>
+	extends AbstractCreateKernelImg<T, DoubleType, ArrayImgFactory<DoubleType>>
+	implements Contingent
 {
 
-	@Parameter(required = false)
-	protected Type<T> outType;
-
-	@Parameter(required = false)
-	protected ImgFactory<T> fac;
-
-	@Parameter(type = ItemIO.OUTPUT)
-	protected Img<T> output;
-
 	@Parameter
-	protected int numDimensions;
-
-	@Parameter
-	protected double sigma;
+	protected double[] sigma;
 
 	@Parameter(required = false)
 	protected double[] calibration;
+
+	protected int numDimensions;
+
+	@Override
+	public void run() {
+
+		numDimensions = sigma.length;
+
+		if (calibration == null) {
+			calibration = new double[numDimensions];
+
+			for (int i = 0; i < numDimensions; i++) {
+				calibration[i] = 1.0;
+			}
+		}
+
+		createKernel();
+	}
+
+	@Override
+	public boolean conforms() {
+
+		if (calibration != null) {
+			if (calibration.length != sigma.length) {
+				return false;
+			}
+		}
+
+		// if outType is not null make sure it is a supported type
+		if (getOutType() != null) {
+			final Object tmp = getOutType();
+			if ((tmp instanceof FloatType) || (tmp instanceof DoubleType) ||
+				(tmp instanceof ComplexFloatType) || (tmp instanceof ComplexDoubleType)) return true;
+			return false;
+		}
+
+		return true;
+	}
+
+	protected abstract void createKernel();
 
 }

--- a/src/main/java/net/imagej/ops/create/AbstractCreateGaussianKernel.java
+++ b/src/main/java/net/imagej/ops/create/AbstractCreateGaussianKernel.java
@@ -57,9 +57,6 @@ public abstract class AbstractCreateGaussianKernel<T extends ComplexType<T> & Na
 	@Parameter
 	protected double[] sigma;
 
-	@Parameter(required = false)
-	protected double[] calibration;
-
 	protected int numDimensions;
 
 	@Override
@@ -67,25 +64,11 @@ public abstract class AbstractCreateGaussianKernel<T extends ComplexType<T> & Na
 
 		numDimensions = sigma.length;
 
-		if (calibration == null) {
-			calibration = new double[numDimensions];
-
-			for (int i = 0; i < numDimensions; i++) {
-				calibration[i] = 1.0;
-			}
-		}
-
 		createKernel();
 	}
 
 	@Override
 	public boolean conforms() {
-
-		if (calibration != null) {
-			if (calibration.length != sigma.length) {
-				return false;
-			}
-		}
 
 		// if outType is not null make sure it is a supported type
 		if (getOutType() != null) {

--- a/src/main/java/net/imagej/ops/create/AbstractCreateSymmetricGaussianKernel.java
+++ b/src/main/java/net/imagej/ops/create/AbstractCreateSymmetricGaussianKernel.java
@@ -64,7 +64,4 @@ public abstract class AbstractCreateSymmetricGaussianKernel<T extends ComplexTyp
 	@Parameter
 	protected double sigma;
 
-	@Parameter(required = false)
-	protected double[] calibration;
-
 }

--- a/src/main/java/net/imagej/ops/create/AbstractCreateSymmetricGaussianKernel.java
+++ b/src/main/java/net/imagej/ops/create/AbstractCreateSymmetricGaussianKernel.java
@@ -1,5 +1,5 @@
 /*
-* #%L
+ * #%L
  * ImageJ software for multidimensional image processing and analysis.
  * %%
  * Copyright (C) 2014 - 2016 Board of Regents of the University of
@@ -30,74 +30,41 @@
 
 package net.imagej.ops.create;
 
-import net.imagej.ops.Contingent;
-import net.imglib2.img.array.ArrayImgFactory;
-import net.imglib2.type.NativeType;
+import net.imagej.ops.AbstractOp;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
-import net.imglib2.type.numeric.complex.ComplexDoubleType;
-import net.imglib2.type.numeric.complex.ComplexFloatType;
-import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.type.numeric.real.FloatType;
 
+import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 
 /**
- * Abstract class for kernel generation from sigma and <b> calibrated units
- * </b>. The specified sigma and calibration is used to determine the
- * dimensionality of the kernel and to map it on a pixel grid.
- *
+ * Abstract convenience op for generating a symmetric kernel
+ * 
  * @author Brian Northan
  * @param <T>
  */
-public abstract class AbstractCreateKernel<T extends ComplexType<T> & NativeType<T>>
-	extends AbstractCreateKernelImg<T, DoubleType, ArrayImgFactory<DoubleType>>
-	implements Contingent
+public abstract class AbstractCreateSymmetricGaussianKernel<T extends ComplexType<T>>
+	extends AbstractOp
 {
 
+	@Parameter(required = false)
+	protected Type<T> outType;
+
+	@Parameter(required = false)
+	protected ImgFactory<T> fac;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	protected Img<T> output;
+
 	@Parameter
-	protected double[] sigma;
+	protected int numDimensions;
+
+	@Parameter
+	protected double sigma;
 
 	@Parameter(required = false)
 	protected double[] calibration;
-
-	protected int numDimensions;
-
-	@Override
-	public void run() {
-
-		numDimensions = sigma.length;
-
-		if (calibration == null) {
-			calibration = new double[numDimensions];
-
-			for (int i = 0; i < numDimensions; i++) {
-				calibration[i] = 1.0;
-			}
-		}
-
-		createKernel();
-	}
-
-	@Override
-	public boolean conforms() {
-
-		if (calibration != null) {
-			if (calibration.length != sigma.length) {
-				return false;
-			}
-		}
-
-		// if outType is not null make sure it is a supported type
-		if (getOutType() != null) {
-			final Object tmp = getOutType();
-			if ((tmp instanceof FloatType) || (tmp instanceof DoubleType) ||
-				(tmp instanceof ComplexFloatType) || (tmp instanceof ComplexDoubleType)) return true;
-			return false;
-		}
-
-		return true;
-	}
-
-	protected abstract void createKernel();
 
 }

--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -416,20 +416,6 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "kernelGauss" operation on the given arguments. */
-	@OpMethod(
-		op = net.imagej.ops.create.kernelGauss.CreateKernelGaussSymmetric.class)
-	public <T extends ComplexType<T>> Img<T> kernelGauss(final Type<T> outType,
-		final ImgFactory<T> fac, final int numDimensions, final double sigma,
-		final double... calibration)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGaussSymmetric.class,
-				outType, fac, numDimensions, sigma, calibration);
-		return result;
-	}
 
 	/** Executes the "kernelGauss" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.create.kernelGauss.CreateKernelGauss.class)
@@ -469,19 +455,7 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "kernelGauss" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.create.kernelGauss.CreateKernelGauss.class)
-	public <T extends ComplexType<T> & NativeType<T>> Img<T> kernelGauss(
-		final Type<T> outType, final ImgFactory<T> fac, final double[] sigma,
-		final double... calibration)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGauss.class, outType,
-				fac, sigma, calibration);
-		return result;
-	}
+
 
 	// -- kernelLog --
 
@@ -534,21 +508,6 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 
 	/** Executes the "kernelLog" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric.class)
-	public
-		<T extends ComplexType<T>> Img<T> kernelLog(final Type<T> outType,
-			final ImgFactory<T> fac, final int numDimensions, final double sigma,
-			final double... calibration)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric.class,
-				outType, fac, numDimensions, sigma, calibration);
-		return result;
-	}
-
-	/** Executes the "kernelLog" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.create.kernelLog.CreateKernelLog.class)
 	public <T extends ComplexType<T> & NativeType<T>> Img<T> kernelLog(
 		final double... sigma)
@@ -584,18 +543,6 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "kernelLog" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.create.kernelLog.CreateKernelLog.class)
-	public <T extends ComplexType<T> & NativeType<T>> Img<T> kernelLog(
-		final Type<T> outType, final ImgFactory<T> fac, final double[] sigma,
-		final double... calibration)
-	{
-		@SuppressWarnings("unchecked")
-		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.kernelLog.CreateKernelLog.class,
-				outType, fac, sigma, calibration);
-		return result;
-	}
 
 	// -- labelingMapping --
 

--- a/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGauss.java
+++ b/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGauss.java
@@ -65,7 +65,7 @@ public class CreateKernelGauss<T extends ComplexType<T> & NativeType<T>>
 		final double[][] kernelArrays = new double[numDimensions][];
 
 		for (int d = 0; d < numDimensions; d++) {
-			sigmaPixels[d] = sigma[d] / calibration[d];
+			sigmaPixels[d] = sigma[d];
 
 			dims[d] = Math.max(3, (2 * (int) (3 * sigmaPixels[d] + 0.5) + 1));
 			kernelArrays[d] = Util.createGaussianKernel1DDouble(sigmaPixels[d], true);

--- a/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGauss.java
+++ b/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGauss.java
@@ -31,7 +31,7 @@
 package net.imagej.ops.create.kernelGauss;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.create.AbstractCreateKernel;
+import net.imagej.ops.create.AbstractCreateGaussianKernel;
 import net.imglib2.Cursor;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.NativeType;
@@ -54,7 +54,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.KernelGauss.class)
 public class CreateKernelGauss<T extends ComplexType<T> & NativeType<T>>
-	extends AbstractCreateKernel<T> implements Ops.Create.KernelGauss
+	extends AbstractCreateGaussianKernel<T> implements Ops.Create.KernelGauss
 {
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGaussSymmetric.java
+++ b/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGaussSymmetric.java
@@ -57,15 +57,7 @@ public class CreateKernelGaussSymmetric<T extends ComplexType<T>> extends
 			sigmas[d] = sigma;
 		}
 
-		if (calibration == null) {
-			calibration = new double[numDimensions];
-
-			for (int i = 0; i < numDimensions; i++) {
-				calibration[i] = 1.0;
-			}
-		}
-
 		output =
-			(Img<T>) ops().create().kernelGauss(outType, fac, sigmas, calibration);
+			(Img<T>) ops().create().kernelGauss(outType, fac, sigmas);
 	}
 }

--- a/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGaussSymmetric.java
+++ b/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGaussSymmetric.java
@@ -31,7 +31,7 @@
 package net.imagej.ops.create.kernelGauss;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.create.AbstractCreateSymmetricKernel;
+import net.imagej.ops.create.AbstractCreateSymmetricGaussianKernel;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.ComplexType;
 
@@ -46,7 +46,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.KernelGauss.class, priority = Priority.HIGH_PRIORITY)
 public class CreateKernelGaussSymmetric<T extends ComplexType<T>> extends
-	AbstractCreateSymmetricKernel<T> implements Ops.Create.KernelGauss
+	AbstractCreateSymmetricGaussianKernel<T> implements Ops.Create.KernelGauss
 {
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLog.java
+++ b/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLog.java
@@ -31,7 +31,7 @@
 package net.imagej.ops.create.kernelLog;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.create.AbstractCreateKernel;
+import net.imagej.ops.create.AbstractCreateGaussianKernel;
 import net.imglib2.Cursor;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.NativeType;
@@ -53,7 +53,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.KernelLog.class)
 public class CreateKernelLog<T extends ComplexType<T> & NativeType<T>> extends
-	AbstractCreateKernel<T> implements Ops.Create.KernelLog
+	AbstractCreateGaussianKernel<T> implements Ops.Create.KernelLog
 {
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLog.java
+++ b/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLog.java
@@ -63,7 +63,7 @@ public class CreateKernelLog<T extends ComplexType<T> & NativeType<T>> extends
 			// Optimal sigma for LoG approach and dimensionality.
 			final double sigma_optimal = sigma[i] / Math.sqrt(numDimensions);
 
-			sigmaPixels[i] = sigma_optimal / calibration[i];
+			sigmaPixels[i] = sigma_optimal;
 		}
 		final int n = sigmaPixels.length;
 		final long[] sizes = new long[n];
@@ -97,7 +97,7 @@ public class CreateKernelLog<T extends ComplexType<T> & NativeType<T>> extends
 			double mantissa = 0;
 			double exponent = 0;
 			for (int d = 0; d < coords.length; d++) {
-				final double x = calibration[d] * (coords[d] - middle[d]);
+				final double x = (coords[d] - middle[d]);
 				mantissa += -C * (x * x / sigma[0] / sigma[0] - 1d);
 				exponent += -x * x / 2d / sigma[0] / sigma[0];
 			}

--- a/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLogSymmetric.java
+++ b/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLogSymmetric.java
@@ -31,7 +31,7 @@
 package net.imagej.ops.create.kernelLog;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.create.AbstractCreateSymmetricKernel;
+import net.imagej.ops.create.AbstractCreateSymmetricGaussianKernel;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ComplexType;
 
@@ -46,7 +46,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Create.KernelLog.class, priority = Priority.HIGH_PRIORITY)
 public class CreateKernelLogSymmetric<T extends ComplexType<T> & NativeType<T>>
-	extends AbstractCreateSymmetricKernel<T> implements Ops.Create.KernelLog
+	extends AbstractCreateSymmetricGaussianKernel<T> implements Ops.Create.KernelLog
 {
 
 	@Override

--- a/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLogSymmetric.java
+++ b/src/main/java/net/imagej/ops/create/kernelLog/CreateKernelLogSymmetric.java
@@ -58,14 +58,6 @@ public class CreateKernelLogSymmetric<T extends ComplexType<T> & NativeType<T>>
 			sigmas[d] = sigma;
 		}
 
-		if (calibration == null) {
-			calibration = new double[numDimensions];
-
-			for (int i = 0; i < numDimensions; i++) {
-				calibration[i] = 1.0;
-			}
-		}
-
-		output = ops().create().kernelLog(outType, fac, sigmas, calibration);
+		output = ops().create().kernelLog(outType, fac, sigmas);
 	}
 }


### PR DESCRIPTION
I have renamed the abstract classes for the creation of gauss and log kernels, because not all kernels need a sigma to create them.
On top of that i talked with @dietzc about the calibration that is currently implemented in the gauss and log kernels and removed the corresponding parts from the implementation, since this can be replaced by processing the input image beforehand.
