### PR TITLE
Add method for extending RAIs keeping the interval

### DIFF
--- a/src/main/java/net/imagej/ops/special/chain/RAIs.java
+++ b/src/main/java/net/imagej/ops/special/chain/RAIs.java
@@ -44,6 +44,8 @@ import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.view.Views;
 
 /**
  * Utility class for working with {@link RandomAccessibleInterval}s.
@@ -66,6 +68,23 @@ public final class RAIs {
 	{
 		return (UnaryComputerOp) Computers.unary(ops, opType, RandomAccessibleInterval.class,
 			in == null ? RandomAccessibleInterval.class : in, otherArgs);
+	}
+
+	/**
+	 * Extends an input using an {@link OutOfBoundsFactory}, if available,
+	 * otherwise returns the unchanged input.
+	 *
+	 * @param in {@link RandomAccessibleInterval} that is to be extended
+	 * @param outOfBounds the factory that is used for extending
+	 * @return {@link RandomAccessibleInterval} extended using the
+	 *         {@link OutOfBoundsFactory} with the interval of in
+	 */
+	public static <T> RandomAccessibleInterval<T> extend(
+		final RandomAccessibleInterval<T> in,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
+	{
+		return outOfBounds == null ? in : Views.interval((Views.extend(in,
+			outOfBounds)), in);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/main/java/net/imagej/ops/threshold/apply/LocalThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/LocalThreshold.java
@@ -31,6 +31,7 @@
 package net.imagej.ops.threshold.apply;
 
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.chain.RAIs;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
@@ -40,7 +41,6 @@ import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.view.Views;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -48,14 +48,13 @@ import org.scijava.plugin.Plugin;
 /**
  * Apply a local thresholding method to an image, optionally using a out of
  * bounds strategy.
- * 
+ *
  * @author Jonathan Hale (University of Konstanz)
  * @author Martin Horn (University of Konstanz)
  * @author Stefan Helfrich (University of Konstanz)
  */
 @Plugin(type = Ops.Threshold.Apply.class)
-public class LocalThreshold<T extends RealType<T>>
-	extends
+public class LocalThreshold<T extends RealType<T>> extends
 	AbstractUnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<BitType>>
 	implements Ops.Threshold.Apply
 {
@@ -73,27 +72,15 @@ public class LocalThreshold<T extends RealType<T>>
 
 	@Override
 	public void initialize() {
-		mapper = Computers.unary(ops(), Ops.Map.class, out(), extIn(in()), method, shape);
+		mapper = Computers.unary(ops(), Ops.Map.class, out(), RAIs.extend(in(),
+			outOfBounds), method, shape);
 	}
 
 	@Override
 	public void compute1(final RandomAccessibleInterval<T> input,
 		final RandomAccessibleInterval<BitType> output)
 	{
-		mapper.compute1(extIn(input), output);
+		mapper.compute1(RAIs.extend(input, outOfBounds), output);
 	}
 
-	/**
-	 * Extends an input using an {@link OutOfBoundsFactory} if available,
-	 * otherwise returns the unchanged input.
-	 * 
-	 * @param input
-	 *            {@link RandomAccessibleInterval} that is to be extended
-	 * @return {@link RandomAccessibleInterval} extended using the
-	 *         {@link OutOfBoundsFactory}
-	 */
-	private RandomAccessibleInterval<T> extIn(final RandomAccessibleInterval<T> input) {
-		return outOfBounds == null ? in() : Views
-			.interval((Views.extend(in(), outOfBounds)), in());
-	}
 }


### PR DESCRIPTION
Extending a `RAI` with an `OutOfBoundsFactory` and setting the interval of the output to the interval of the input is a recurring pattern when working with `Neighborhoods`, e.g. local thresholding or filtering.

@ctrueden There are some style glitches in RAIs.java that could be fixed while at it. Should I do that?