### PR TITLE
Refactor apply threshold

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdImg.java
+++ b/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdImg.java
@@ -31,6 +31,7 @@
 package net.imagej.ops.threshold;
 
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.IterableInterval;
@@ -50,25 +51,25 @@ public abstract class AbstractApplyThresholdImg<T> extends
 {
 
 	protected UnaryFunctionOp<IterableInterval<T>, Histogram1d<T>> histCreator;
-	
+
 	protected UnaryFunctionOp<IterableInterval<T>, Img<BitType>> imgCreator;
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void initialize() {
+		applyThresholdComp = Computers.binary(ops(), Ops.Threshold.Apply.class,
+			out(), in(), in().firstElement());
 		histCreator = (UnaryFunctionOp) Functions.unary(ops(),
-				Ops.Image.Histogram.class, Histogram1d.class, in());
-		
-		imgCreator = (UnaryFunctionOp) Functions.unary(ops(),
-				Ops.Create.Img.class, Img.class, in(), new BitType() );
-		
+			Ops.Image.Histogram.class, Histogram1d.class, in());
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), new BitType());
 	}
 
 	// -- UnaryOutputFactory methods --
 
 	@Override
-	public Img<BitType> createOutput(final IterableInterval<T> input) {		
-		return imgCreator.compute1( input );
+	public Img<BitType> createOutput(final IterableInterval<T> input) {
+		return imgCreator.compute1(input);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdIterable.java
+++ b/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdIterable.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.threshold;
 
+import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
 import net.imglib2.type.logic.BitType;
 
@@ -45,9 +46,11 @@ public abstract class AbstractApplyThresholdIterable<T, I extends Iterable<T>, O
 	ApplyThresholdIterable<T, I, O>
 {
 
+	protected BinaryComputerOp<I, T, O> applyThresholdComp;
+
 	@Override
 	public void compute1(final I input, final O output) {
-		ops().threshold().apply(output, input, getThreshold(input));
+		applyThresholdComp.compute2(input, getThreshold(input), output);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThreshold.java
@@ -31,14 +31,14 @@
 package net.imagej.ops.threshold.apply;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
+import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -50,27 +50,26 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Threshold.Apply.class, priority = Priority.HIGH_PRIORITY)
 public class ApplyConstantThreshold<T extends RealType<T>> extends
-	AbstractUnaryComputerOp<Iterable<T>, Iterable<BitType>> implements
+	AbstractBinaryComputerOp<Iterable<T>, T, Iterable<BitType>> implements
 	Ops.Threshold.Apply
 {
 
-	@Parameter
-	private T threshold;
-	private UnaryComputerOp<T, BitType> applyThreshold;
+	private BinaryComputerOp<T, T, BitType> applyThreshold;
 	private UnaryComputerOp<Iterable<T>, Iterable<BitType>> mapper;
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void initialize() {
-		applyThreshold = (UnaryComputerOp<T, BitType>) Computers.unary(ops(),
-			ApplyThresholdComparable.class, BitType.class, threshold.getClass(),
-			threshold);
+		applyThreshold = Computers.binary(ops(), ApplyThresholdComparable.class,
+			BitType.class, in2(), in2());
 		mapper = Computers.unary(ops(), Ops.Map.class, out(), in(), applyThreshold);
 	}
 
 	@Override
-	public void compute1(final Iterable<T> input, final Iterable<BitType> output) {
-		mapper.compute1(input, output);
+	public void compute2(final Iterable<T> input1, final T input2,
+		final Iterable<BitType> output)
+	{
+		applyThreshold.setInput2(input2);
+		mapper.compute1(input1, output);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyThresholdComparable.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyThresholdComparable.java
@@ -31,31 +31,30 @@
 package net.imagej.ops.threshold.apply;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.threshold.ApplyThreshold;
 import net.imglib2.type.logic.BitType;
 
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Applies a threshold value to the given comparable object, producing a
- * {@link BitType} set to 1 iff the object compares above the threshold.
+ * Applies a threshold value (the second input) to the given comparable object,
+ * producing a {@link BitType} set to 1 iff the object compares above the
+ * threshold.
  *
  * @author Martin Horn (University of Konstanz)
  */
 @Plugin(type = Ops.Threshold.Apply.class)
 public class ApplyThresholdComparable<T> extends
-	AbstractUnaryComputerOp<Comparable<? super T>, BitType> implements
+	AbstractBinaryComputerOp<Comparable<? super T>, T, BitType> implements
 	ApplyThreshold<Comparable<? super T>, BitType>
 {
 
-	@Parameter
-	private T threshold;
-
 	@Override
-	public void compute1(final Comparable<? super T> input, final BitType output) {
-		output.set(input.compareTo(threshold) > 0);
+	public void compute2(final Comparable<? super T> input1, final T input2,
+		final BitType output)
+	{
+		output.set(input1.compareTo(input2) > 0);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyThresholdComparator.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyThresholdComparator.java
@@ -33,7 +33,7 @@ package net.imagej.ops.threshold.apply;
 import java.util.Comparator;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.threshold.ApplyThreshold;
 import net.imglib2.type.logic.BitType;
 
@@ -41,26 +41,24 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Applies a threshold value to the given object using the specified comparator,
- * producing a {@link BitType} set to 1 iff the object compares above the
- * threshold.
+ * Applies a threshold value (the second input) to the given object using the
+ * specified comparator, producing a {@link BitType} set to 1 iff the object
+ * compares above the threshold.
  *
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Threshold.Apply.class)
-public class ApplyThresholdComparator<T> extends AbstractUnaryComputerOp<T, BitType>
-	implements ApplyThreshold<T, BitType>
+public class ApplyThresholdComparator<T> extends
+	AbstractBinaryComputerOp<T, T, BitType> implements
+	ApplyThreshold<T, BitType>
 {
-
-	@Parameter
-	private T threshold;
 
 	@Parameter
 	private Comparator<? super T> comparator;
 
 	@Override
-	public void compute1(final T input, final BitType output) {
-		output.set(comparator.compare(input, threshold) > 0);
+	public void compute2(final T input1, final T input2, final BitType output) {
+		output.set(comparator.compare(input1, input2) > 0);
 	}
 
 }


### PR DESCRIPTION
The sole purpose of this branch is to `initialize` the op matching call in [`AbstractApplyThresholdIterable`](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdIterable.java#L50), which might not be called frequently, but each time, it will trigger a series of op matching calls, since it is a high level op.

This is achieved by making `ApplyThresholdComparable` and `ApplyConstantThreshold` binary ops. [This line of code](https://github.com/imagej/imagej-ops/blob/28ba5ab2fac591af6ac4d1a782b1705a94387943/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThreshold.java#L71) does not seem to be elegant to me, but I cannot come up with other ideas right now.