### PR TITLE
Add workaround for a bug in maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,14 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
+			<!--  Workaround for a bug in maven-compiler-plugin.
+			See https://issues.apache.org/jira/browse/MCOMPILER-209 -->
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<useIncrementalCompilation>false</useIncrementalCompilation>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>groovy-maven-plugin</artifactId>


### PR DESCRIPTION
`useIncrementalCompilation` feature is supposed to be turned on by default, but it is actually not working. However, this bug could not be easily recognized, since we all use the incremental build provided by Eclipse, and every call to `mvn` tells us the module is up to date.

However, when you modify a template (either, .vm or .list, which I did frequently recently), the auto-generated source files could not be incremental built by Eclipse, and therefore it triggers the complete recompilation of the project, which takes me about 40 extra seconds every time :-(

To generate this bug, just turn off Project -> Build Automatically, and modify 1 file and then call `mvn`. The whole project will be recompiled.

See https://issues.apache.org/jira/browse/MCOMPILER-209 for information about the bug.

It has been tested that the version 3.5 still has this bug, and that by doing this workaround, the useIncrementalCompilation feature is turned on. To verify, repeat the instruction above to generate the bug, and now it should show that "Compiling 1 source file to ..." and takes significantly less time to finish.

Not sure if there are better solutions, and whether projects need this workaround too. @ctrueden 