### PR TITLE
Fix ScaleImg bug of assumption about IterationOrder

### DIFF
--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -193,6 +193,32 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		ops = net.imagej.ops.create.imgFactory.DefaultCreateImgFactory.class)
+	public <T extends NativeType<T>> ImgFactory<T> imgFactory(
+		final Dimensions dims, final T type)
+	{
+		// NB: The generic typing of ImgFactory is broken; see:
+		// https://github.com/imglib/imglib2/issues/91
+		@SuppressWarnings("unchecked")
+		final ImgFactory<T> result = (ImgFactory<T>) ops().run(
+			net.imagej.ops.Ops.Create.ImgFactory.class, dims, type);
+		return result;
+	}
+
+	@OpMethod(
+		ops = net.imagej.ops.create.imgFactory.DefaultCreateImgFactory.class)
+	public <T extends NativeType<T>> ImgFactory<T> imgFactory(
+		final Dimensions dims, final T type, final int targetCellSize)
+	{
+		// NB: The generic typing of ImgFactory is broken; see:
+		// https://github.com/imglib/imglib2/issues/91
+		@SuppressWarnings("unchecked")
+		final ImgFactory<T> result = (ImgFactory<T>) ops().run(
+			net.imagej.ops.Ops.Create.ImgFactory.class, dims, type, targetCellSize);
+		return result;
+	}
+
+	@OpMethod(
 		ops = net.imagej.ops.create.imgFactory.CreateImgFactoryFromImg.class)
 	public <T extends NativeType<T>> ImgFactory<T> imgFactory(final Img<T> in) {
 		@SuppressWarnings("unchecked")

--- a/src/main/java/net/imagej/ops/create/img/CreateImgFromDimsAndType.java
+++ b/src/main/java/net/imagej/ops/create/img/CreateImgFromDimsAndType.java
@@ -59,8 +59,8 @@ public class CreateImgFromDimsAndType<T extends NativeType<T>> extends
 	@Override
 	public void initialize() {
 		if (factory == null) {
-			factory = in1() == null ? ops().create().imgFactory() :
-				ops().create().imgFactory(in1());
+			factory = in1() instanceof Img ? ops().create().imgFactory(in1()) :
+				ops().create().imgFactory(in1(), in2());
 		}
 	}
 

--- a/src/main/java/net/imagej/ops/create/imgFactory/DefaultCreateImgFactory.java
+++ b/src/main/java/net/imagej/ops/create/imgFactory/DefaultCreateImgFactory.java
@@ -33,11 +33,11 @@ package net.imagej.ops.create.imgFactory;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.function.AbstractNullaryFunctionOp;
 import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
 import net.imglib2.img.ImgFactory;
-import net.imglib2.img.array.ArrayImgFactory;
-import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.type.NativeType;
-import net.imglib2.util.Intervals;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Util;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -54,13 +54,26 @@ public class DefaultCreateImgFactory<T extends NativeType<T>> extends
 	AbstractNullaryFunctionOp<ImgFactory<T>> implements Ops.Create.ImgFactory
 {
 
+	/**
+	 * Dummy default dimensions.
+	 */
 	@Parameter(required = false)
-	private Dimensions dims;
+	private Dimensions dims = new FinalDimensions(1);
+
+	@SuppressWarnings("unchecked")
+	@Parameter(required = false)
+	private T type = (T) new DoubleType();
+
+	/**
+	 * This default cell size will force the utility method to calculate another
+	 * appropriate cell size depending on dims and type.
+	 */
+	@Parameter(required = false)
+	private int targetCellSize = Integer.MAX_VALUE;
 
 	@Override
 	public ImgFactory<T> compute0() {
-		return (dims == null || Intervals.numElements(dims) <= Integer.MAX_VALUE)
-			? new ArrayImgFactory<>() : new CellImgFactory<>();
+		return Util.getArrayOrCellImgFactory(dims, targetCellSize, type);
 	}
 
 }

--- a/src/test/java/net/imagej/ops/create/CreateImgTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgTest.java
@@ -41,6 +41,7 @@ import net.imglib2.FinalDimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellImg;
 import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.img.planar.PlanarImgs;
 import net.imglib2.type.logic.BitType;
@@ -235,6 +236,32 @@ public class CreateImgTest extends AbstractOpTest {
 
 		for (int i=0; i<dims.length; i++) {
 			assertEquals("Image Dimension " + i + ": ", dims[i].longValue(), res
+				.dimension(i));
+		}
+	}
+
+	/**
+	 * Make sure a {@link CellImg} with appropriate cell size is created given
+	 * large dimensions, i.e. number of elements more than 2^31-1. If default cell
+	 * size is used, this test will not pass in reasonable time.
+	 */
+	@Test
+	public void testCreateCellImg() {
+		// 2^28 is the estimation of the BitType CellImg size
+		if (Runtime.getRuntime().maxMemory() < (1 << 28)) {
+			System.out.println(
+				"Not enought heap memory for creating the minimum CellImg");
+			return;
+		}
+
+		final Dimensions dims = new FinalInterval(1 << 15, 1 << 16);
+
+		final Img<BitType> res = ops.create().img(dims, new BitType());
+
+		assertEquals("Image type is not CellImg", res instanceof CellImg, true);
+
+		for (int i = 0; i < dims.numDimensions(); i++) {
+			assertEquals("Image Dimension " + i + ": ", dims.dimension(i), res
 				.dimension(i));
 		}
 	}

--- a/src/test/java/net/imagej/ops/image/scale/ScaleImgTest.java
+++ b/src/test/java/net/imagej/ops/image/scale/ScaleImgTest.java
@@ -33,8 +33,11 @@ package net.imagej.ops.image.scale;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.interpolation.randomaccess.NLinearInterpolatorFactory;
 import net.imglib2.type.numeric.integer.ByteType;
 
@@ -63,4 +66,31 @@ public class ScaleImgTest extends AbstractOpTest {
 		assertEquals(inRA.get().get(), outRA.get().get());
 
 	}
+
+	/**
+	 * A small {@link CellImg} is given, and a different type of image is expected
+	 * as output.
+	 */
+	@Test
+	public void testDiffImgTypes() {
+		Img<ByteType> in = new CellImgFactory<ByteType>(5).create(
+			new FinalDimensions(10, 10), new ByteType());
+		RandomAccess<ByteType> inRA = in.randomAccess();
+		inRA.setPosition(new long[] { 5, 5 });
+		inRA.get().set((byte) 10);
+		
+		double[] scaleFactors = new double[] { 2, 2 };
+		Img<ByteType> out = ops.image().scale(in, scaleFactors,
+			new NLinearInterpolatorFactory<ByteType>());
+
+		assertEquals(out.dimension(0), 20);
+		assertEquals(out.dimension(1), 20);
+		
+		assertEquals(out instanceof CellImg, false);
+		
+		RandomAccess<ByteType> outRA = out.randomAccess();
+		outRA.setPosition(new long[] { 10, 10 });
+		assertEquals(outRA.get().get(), 10);
+	}
+
 }


### PR DESCRIPTION
See #314 

The previous code generate the output image using the image factory of the input image. Since the output image has different dimension of the input image, the result could cause errors. For example, scaling up an large size image, so that the result image has more number of pixels than Integer.MAX_VALUE.

However, this case rarely happens in practice (scaling up an already large image?), and I find that no test on this feature could be run in reasonable amount of time. One significant reason is that, creating an `CellImg` of size 50000x50000 takes too much time (I never see it finish. Takes at least a few minutes), while in comparison, creating two `ArrayImg` of size 50000x25000 takes a few seconds. I think this is due to the use of default cell size in `DefaultCreateImgFactory`. I will file another issue and work on that later.
