### PR TITLE
CenterAwareComputerOp as BinaryComputerOp

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -718,13 +718,13 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(
 		op = net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class)
-	default <I, O> RandomAccessibleInterval<O> map(
-		final RandomAccessibleInterval<O> out, final RandomAccessibleInterval<I> in,
+	default <I, O> IterableInterval<O> map(
+		final IterableInterval<O> out, final RandomAccessibleInterval<I> in,
 		final CenterAwareComputerOp<Iterable<I>, O> func, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<O> result =
-			(RandomAccessibleInterval<O>) run(
+		final IterableInterval<O> result =
+			(IterableInterval<O>) run(
 				net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class, out,
 				in, func, shape);
 		return result;

--- a/src/main/java/net/imagej/ops/filter/sigma/DefaultSigmaFilter.java
+++ b/src/main/java/net/imagej/ops/filter/sigma/DefaultSigmaFilter.java
@@ -72,23 +72,23 @@ public class DefaultSigmaFilter<T extends RealType<T>> extends
 			private UnaryComputerOp<Iterable<T>, DoubleType> variance;
 
 			@Override
-			public void compute1(Pair<T, Iterable<T>> input, T output) {
+			public void compute2(T center, Iterable<T> neighborhood, T output) {
 				if (variance == null) {
 					variance = Computers.unary(ops(), Ops.Stats.Variance.class,
-						DoubleType.class, input.getB());
+						DoubleType.class, neighborhood);
 				}
 
 				DoubleType varianceResult = new DoubleType();
-				variance.compute1(input.getB(), varianceResult);
+				variance.compute1(neighborhood, varianceResult);
 				double varianceValue = varianceResult.getRealDouble() * range;
 
-				final double centerValue = input.getA().getRealDouble();
+				final double centerValue = center.getRealDouble();
 				double sumAll = 0;
 				double sumWithin = 0;
 				long countAll = 0;
 				long countWithin = 0;
 
-				for (T neighbor : input.getB()) {
+				for (T neighbor : neighborhood) {
 					final double pixelValue = neighbor.getRealDouble();
 					final double diff = centerValue - pixelValue;
 

--- a/src/main/java/net/imagej/ops/map/neighborhood/AbstractCenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/AbstractCenterAwareComputerOp.java
@@ -30,16 +30,16 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
-import net.imglib2.util.Pair;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 
 /**
  * Abstract superclass for {@link CenterAwareComputerOp} implementations.
  * 
  * @author Jonathan Hale (University of Konstanz)
+ * @author Stefan Helfrich (University of Konstanz)
  */
 public abstract class AbstractCenterAwareComputerOp<I, O> extends
-	AbstractUnaryComputerOp<Pair<I, Iterable<I>>, O> implements
+	AbstractBinaryComputerOp<I, Iterable<I>, O> implements
 	CenterAwareComputerOp<I, O>
 {
 	// NB: Empty.

--- a/src/main/java/net/imagej/ops/map/neighborhood/AbstractMapCenterAwareComputer.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/AbstractMapCenterAwareComputer.java
@@ -30,24 +30,24 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import net.imagej.ops.map.MapUnaryComputer;
+import net.imagej.ops.map.MapBinaryComputer;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
-import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 
 /**
- * Abstract implementation of a {@link MapUnaryComputer} for {@link CenterAwareComputerOp}.
+ * Abstract implementation of a {@link MapBinaryComputer} for {@link CenterAwareComputerOp}.
  * 
  * @author Jonathan Hale (University of Konstanz)
+ * @author Stefan Helfrich (University of Konstanz)
  * @param <A> mapped on {@code <B>}
  * @param <B> mapped from {@code <A>}
  * @param <C> provides {@code <A>}s
  * @param <D> provides {@code <B>}s
  */
-public abstract class AbstractMapCenterAwareComputer<A, B, C, D> extends
-	AbstractUnaryComputerOp<C, D> implements
-	MapUnaryComputer<Pair<A, Iterable<A>>, B, CenterAwareComputerOp<A, B>>
+public abstract class AbstractMapCenterAwareComputer<A, B, C, D> 
+	extends AbstractUnaryComputerOp<C, D>
+	implements MapBinaryComputer<A, Iterable<A>, B, CenterAwareComputerOp<A, B>>
 {
 
 	@Parameter

--- a/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
@@ -30,19 +30,19 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imglib2.util.Pair;
+import net.imagej.ops.special.computer.BinaryComputerOp;
 
 /**
  * A <em>center aware computer</em> calculates a result from a given input and
  * its surrounding neighborhood, storing it into the specified output reference.
  * 
  * @author Jonathan Hale (University of Konstanz)
- * @param <I> type of input
+ * @author Stefan Helfrich (University of Konstanz)
+ * @param <I> type of input (implicitly assumes the center and the neighborhood are of the same type)
  * @param <O> type of output
  */
 public interface CenterAwareComputerOp<I, O> extends
-	UnaryComputerOp<Pair<I, Iterable<I>>, O>
+	BinaryComputerOp<I, Iterable<I>, O>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
@@ -38,7 +38,8 @@ import net.imagej.ops.special.computer.BinaryComputerOp;
  * 
  * @author Jonathan Hale (University of Konstanz)
  * @author Stefan Helfrich (University of Konstanz)
- * @param <I> type of input (implicitly assumes the center and the neighborhood are of the same type)
+ * @param <I> type of input (implicitly assumes that the center and the
+ *          neighborhood are of the same type)
  * @param <O> type of output
  */
 public interface CenterAwareComputerOp<I, O> extends

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -30,25 +30,15 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import java.util.Iterator;
-
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Ops.Map;
+import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
-import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
-import net.imglib2.Positionable;
-import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.RealPositionable;
-import net.imglib2.Sampler;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.Shape;
-import net.imglib2.util.Pair;
-import net.imglib2.util.ValuePair;
-import net.imglib2.view.Views;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
@@ -60,366 +50,34 @@ import org.scijava.plugin.Plugin;
  * corresponding pixel on the output {@link RandomAccessibleInterval}. Similar
  * to {@link MapNeighborhood}, but passes the center pixel to the op aswell.
  * 
- * @author Jonathan Hale
+ * @author Jonathan Hale (University of Konstanz)
+ * @author Stefan Helfrich (University of Konstanz)
  * @see OpService#map(RandomAccessibleInterval, RandomAccessibleInterval,
  *      CenterAwareComputerOp, Shape)
  * @see CenterAwareComputerOp
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 1)
-public class MapNeighborhoodWithCenter<I, O>
-	extends
-	AbstractMapCenterAwareComputer<I, O, RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
+public class MapNeighborhoodWithCenter<I, O> extends
+	AbstractMapCenterAwareComputer<I, O, RandomAccessibleInterval<I>, IterableInterval<O>>
 {
 
 	@Parameter
 	private Shape shape;
-	private UnaryComputerOp<NeighborhoodWithCenterIterableInterval, Iterable<O>> map;
-	
+
+	private BinaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<Neighborhood<I>>, IterableInterval<O>> map;
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
-		map = (UnaryComputerOp) Computers.unary(ops(), Map.class, Iterable.class,
-			NeighborhoodWithCenterIterableInterval.class, getOp());
+		map = (BinaryComputerOp) Computers.binary(ops(), Map.class, IterableInterval.class,
+			RandomAccessibleInterval.class, IterableInterval.class, getOp());
 	}
 
 	@Override
 	public void compute1(final RandomAccessibleInterval<I> input,
-		final RandomAccessibleInterval<O> output)
+		final IterableInterval<O> output)
 	{
-		map.compute1(new NeighborhoodWithCenterIterableInterval(
-			shape.neighborhoodsSafe(input), input), Views.iterable(output));
-	}
-
-	/**
-	 * IterableInterval wrapping a {@link IterableInterval}<{@link Neighborhood}>
-	 * and a {@link RandomAccessibleInterval}. Depending on the iterator order of
-	 * both, a matching cursor will be chosen appropriately.
-	 * 
-	 * @author Jonathan Hale (University of Konstanz)
-	 */
-	class NeighborhoodWithCenterIterableInterval implements
-		IterableInterval<Pair<I, Iterable<I>>>
-	{
-
-		private final IterableInterval<Neighborhood<I>> neighborhoods;
-		private final RandomAccessibleInterval<I> input;
-
-		public NeighborhoodWithCenterIterableInterval(
-			IterableInterval<Neighborhood<I>> neighborhoods,
-			RandomAccessibleInterval<I> input)
-		{
-			this.neighborhoods = neighborhoods;
-			this.input = input;
-		}
-
-		@Override
-		public Iterator<Pair<I, Iterable<I>>> iterator() {
-			return cursor();
-		}
-
-		@Override
-		public long size() {
-			return neighborhoods.size();
-		}
-
-		@Override
-		public Pair<I, Iterable<I>> firstElement() {
-			return cursor().next();
-		}
-
-		@Override
-		public Object iterationOrder() {
-			return neighborhoods.iterationOrder();
-		}
-
-		@Override
-		public double realMin(int d) {
-			return neighborhoods.realMin(d);
-		}
-
-		@Override
-		public void realMin(double[] min) {
-			neighborhoods.realMin(min);
-		}
-
-		@Override
-		public void realMin(RealPositionable min) {
-			neighborhoods.realMin(min);
-		}
-
-		@Override
-		public double realMax(int d) {
-			return neighborhoods.realMax(d);
-		}
-
-		@Override
-		public void realMax(double[] max) {
-			neighborhoods.realMax(max);
-		}
-
-		@Override
-		public void realMax(RealPositionable max) {
-			neighborhoods.realMax(max);
-		}
-
-		@Override
-		public int numDimensions() {
-			return neighborhoods.numDimensions();
-		}
-
-		@Override
-		public long min(int d) {
-			return neighborhoods.min(d);
-		}
-
-		@Override
-		public void min(long[] min) {
-			neighborhoods.min(min);
-		}
-
-		@Override
-		public void min(Positionable min) {
-			neighborhoods.min(min);
-		}
-
-		@Override
-		public long max(int d) {
-			return neighborhoods.max(d);
-		}
-
-		@Override
-		public void max(long[] max) {
-			neighborhoods.max(max);
-		}
-
-		@Override
-		public void max(Positionable max) {
-			neighborhoods.max(max);
-		}
-
-		@Override
-		public void dimensions(long[] dimensions) {
-			neighborhoods.dimensions(dimensions);
-		}
-
-		@Override
-		public long dimension(int d) {
-			return neighborhoods.dimension(d);
-		}
-
-		@Override
-		public Cursor<Pair<I, Iterable<I>>> cursor() {
-			return localizingCursor();
-		}
-
-		@Override
-		public Cursor<Pair<I, Iterable<I>>> localizingCursor() {
-			final IterableInterval<I> inputIterable = Views.iterable(input);
-
-			if (inputIterable.iterationOrder().equals(neighborhoods.iterationOrder()))
-			{
-				// optimizable through cursor use.
-				return new NeighborhoodWithCenterCursorII(neighborhoods, inputIterable);
-			}
-
-			return new NeighborhoodWithCenterCursorRA(neighborhoods, input);
-		}
-	}
-
-	/**
-	 * Abstract implementation for NeighborhoodWithCenterCursors. Contains the
-	 * common implementations for methods of the Cursors specific for
-	 * {@link RandomAccessibleInterval} and {@link IterableInterval}.
-	 * 
-	 * @author Jonathan Hale (University of Konstanz)
-	 */
-	abstract class AbstractNeighborhoodWithCenterCursor implements
-		Cursor<Pair<I, Iterable<I>>>
-	{
-
-		protected final Cursor<Neighborhood<I>> cNeigh;
-
-		public AbstractNeighborhoodWithCenterCursor(
-			IterableInterval<Neighborhood<I>> neighborhoods)
-		{
-			cNeigh = neighborhoods.localizingCursor();
-		}
-
-		public AbstractNeighborhoodWithCenterCursor(
-			AbstractNeighborhoodWithCenterCursor c)
-		{
-			cNeigh = c.cNeigh.copyCursor();
-		}
-
-		@Override
-		public boolean hasNext() {
-			return cNeigh.hasNext();
-		}
-
-		@Override
-		public Pair<I, Iterable<I>> next() {
-			fwd();
-			return get();
-		}
-
-		@Override
-		public void localize(float[] position) {
-			cNeigh.localize(position);
-		}
-
-		@Override
-		public void localize(double[] position) {
-			cNeigh.localize(position);
-		}
-
-		@Override
-		public float getFloatPosition(int d) {
-			return cNeigh.getFloatPosition(d);
-		}
-
-		@Override
-		public double getDoublePosition(int d) {
-			return cNeigh.getDoublePosition(d);
-		}
-
-		@Override
-		public int numDimensions() {
-			return cNeigh.numDimensions();
-		}
-
-		@Override
-		public Sampler<Pair<I, Iterable<I>>> copy() {
-			return copyCursor();
-		}
-
-		@Override
-		public void jumpFwd(long steps) {
-			cNeigh.jumpFwd(steps);
-		}
-
-		@Override
-		public void fwd() {
-			cNeigh.fwd();
-		}
-
-		@Override
-		public void reset() {
-			cNeigh.reset();
-		}
-
-		@Override
-		public void localize(int[] position) {
-			cNeigh.localize(position);
-		}
-
-		@Override
-		public void localize(long[] position) {
-			cNeigh.localize(position);
-		}
-
-		@Override
-		public int getIntPosition(int d) {
-			return cNeigh.getIntPosition(d);
-		}
-
-		@Override
-		public long getLongPosition(int d) {
-			return cNeigh.getLongPosition(d);
-		}
-
-		@Override
-		public void remove() {
-			// NB: no action.
-		}
-	}
-
-	/**
-	 * Cursor implementation for a {@link RandomAccessibleInterval} input. Should
-	 * be used when iteration order of input and output are not equal.
-	 * 
-	 * @author Jonathan Hale (University of Konstanz)
-	 */
-	class NeighborhoodWithCenterCursorRA extends
-		AbstractNeighborhoodWithCenterCursor
-	{
-
-		private final RandomAccess<I> raIn;
-
-		public NeighborhoodWithCenterCursorRA(
-			IterableInterval<Neighborhood<I>> neighborhoods,
-			RandomAccessibleInterval<I> input)
-		{
-			super(neighborhoods);
-			raIn = input.randomAccess();
-		}
-
-		public NeighborhoodWithCenterCursorRA(NeighborhoodWithCenterCursorRA c) {
-			super(c);
-			raIn = c.raIn.copyRandomAccess();
-		}
-
-		@Override
-		public final Pair<I, Iterable<I>> get() {
-			raIn.setPosition(cNeigh);
-			return new ValuePair<>(raIn.get(), cNeigh.get());
-		}
-
-		@Override
-		public Cursor<Pair<I, Iterable<I>>> copyCursor() {
-			return new NeighborhoodWithCenterCursorRA(this);
-		}
-	}
-
-	/**
-	 * Cursor implementation for a {@link IterableInterval} input. Should only be
-	 * used when iteration order of input and output are equal.
-	 * 
-	 * @author Jonathan Hale (University of Konstanz)
-	 */
-	class NeighborhoodWithCenterCursorII extends
-		AbstractNeighborhoodWithCenterCursor
-	{
-
-		private final Cursor<I> cIn;
-
-		public NeighborhoodWithCenterCursorII(
-			IterableInterval<Neighborhood<I>> neighborhoods, IterableInterval<I> input)
-		{
-			super(neighborhoods);
-			if (!input.iterationOrder().equals(neighborhoods.iterationOrder())) {
-				throw new IllegalArgumentException(
-					"Iteration order of neighborhood InterableInterval and input InterableInterval are not equal!");
-			}
-
-			cIn = input.cursor();
-		}
-
-		public NeighborhoodWithCenterCursorII(NeighborhoodWithCenterCursorII c) {
-			super(c);
-			cIn = c.cIn.copyCursor();
-		}
-
-		@Override
-		public final void fwd() {
-			super.fwd();
-			cIn.fwd();
-		}
-
-		@Override
-		public void jumpFwd(long steps) {
-			super.jumpFwd(steps);
-			cIn.jumpFwd(steps);
-		}
-
-		@Override
-		public final Pair<I, Iterable<I>> get() {
-			return new ValuePair<>(cIn.get(), cNeigh.get());
-		}
-
-		@Override
-		public Cursor<Pair<I, Iterable<I>>> copyCursor() {
-			return new NeighborhoodWithCenterCursorII(this);
-		}
+		map.compute2(input, shape.neighborhoodsSafe(input), output);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -427,124 +427,122 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.threshold.localContrast.LocalContrast.class)
 	public <T extends RealType<T>> BitType localContrast(final BitType out,
-		final Pair<T, Iterable<T>> in)
+		final T center, final Iterable<T> neighborhood)
 	{
-		final BitType result =
-			(BitType) ops().run(
-				net.imagej.ops.threshold.localContrast.LocalContrast.class, out, in);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localContrast.LocalContrast.class, out, center,
+			neighborhood);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localMean.LocalMean.class)
 	public <T extends RealType<T>> BitType localMean(final BitType out,
-		final Pair<T, Iterable<T>> in, final double c)
+		final T center, final Iterable<T> neighborhood, final double c)
 	{
-		final BitType result =
-			(BitType) ops().run(net.imagej.ops.threshold.localMean.LocalMean.class,
-				out, in, c);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localMean.LocalMean.class, out, center,
+			neighborhood, c);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localMedian.LocalMedian.class)
 	public <T extends RealType<T>> BitType localMedian(final BitType out,
-		final Pair<T, Iterable<T>> in, final double c)
+		final T center, final Iterable<T> neighborhood, final double c)
 	{
-		final BitType result =
-			(BitType) ops().run(
-				net.imagej.ops.threshold.localMedian.LocalMedian.class, out, in, c);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localMedian.LocalMedian.class, out, center,
+			neighborhood, c);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localMidGrey.LocalMidGrey.class)
 	public <T extends RealType<T>> BitType localMidGrey(final BitType out,
-		final Pair<T, Iterable<T>> in, final double c)
+		final T center, final Iterable<T> neighborhood, final double c)
 	{
-		final BitType result =
-			(BitType) ops().run(
-				net.imagej.ops.threshold.localMidGrey.LocalMidGrey.class, out, in, c);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localMidGrey.LocalMidGrey.class, out, center,
+			neighborhood, c);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localNiblack.LocalNiblack.class)
 	public <T extends RealType<T>> BitType localNiblack(final BitType out,
-		final Pair<T, Iterable<T>> in, final double c, final double k)
+		final T center, final Iterable<T> neighborhood, final double c, final double k)
 	{
-		final BitType result =
-			(BitType) ops()
-				.run(net.imagej.ops.threshold.localNiblack.LocalNiblack.class, out, in,
-					c, k);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localNiblack.LocalNiblack.class, out, center,
+			neighborhood, c, k);
 		return result;
 	}
 	
 	@OpMethod(op = net.imagej.ops.threshold.localBernsen.LocalBernsen.class)
 	public <T extends RealType<T>> BitType localBernsen(final BitType out,
-		final Pair<T, Iterable<T>> in, final double contrastThreshold,
+		final T center, final Iterable<T> neighborhood, final double contrastThreshold,
 		final double halfMaxValue)
 	{
-		final BitType result =
-			(BitType) ops().run(
-				net.imagej.ops.threshold.localBernsen.LocalBernsen.class, out, in,
-				contrastThreshold, halfMaxValue);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localBernsen.LocalBernsen.class, out, center,
+			neighborhood, contrastThreshold, halfMaxValue);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class)
 	public <T extends RealType<T>> BitType localPhansalkar(final BitType out,
-		final Pair<T, Iterable<T>> in, final double k, final double r)
+		final T center, final Iterable<T> neighborhood, final double k, final double r)
 	{
-		final BitType result =
-			(BitType) ops().run(net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class,
-				out, in, k, r);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class, out,
+			center, neighborhood, k, r);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class)
 	public <T extends RealType<T>> BitType localPhansalkar(final BitType out,
-		final Pair<T, Iterable<T>> in, final double k)
+		final T center, final Iterable<T> neighborhood, final double k)
 	{
-		final BitType result =
-			(BitType) ops().run(net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class,
-				out, in, k);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class, out,
+			center, neighborhood, k);
 		return result;
 	}
 	
 	@OpMethod(op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class)
 	public <T extends RealType<T>> BitType localPhansalkar(final BitType out,
-		final Pair<T, Iterable<T>> in)
+		final T center, final Iterable<T> neighborhood)
 	{
-		final BitType result =
-			(BitType) ops().run(net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class,
-				out, in);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localPhansalkar.LocalPhansalkar.class, out,
+			center, neighborhood);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvola.class)
 	public <T extends RealType<T>> BitType localSauvola(final BitType out,
-		final Pair<T, Iterable<T>> in, final double k, final double r)
+		final T center, final Iterable<T> neighborhood, final double k, final double r)
 	{
 		final BitType result =
 			(BitType) ops().run(net.imagej.ops.threshold.localSauvola.LocalSauvola.class,
-				out, in, k, r);
+				out, center, neighborhood, k, r);
 		return result;
 	}
 	
 	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvola.class)
 	public <T extends RealType<T>> BitType localSauvola(final BitType out,
-		final Pair<T, Iterable<T>> in, final double k)
+		final T center, final Iterable<T> neighborhood, final double k)
 	{
-		final BitType result =
-			(BitType) ops().run(net.imagej.ops.threshold.localSauvola.LocalSauvola.class,
-				out, in, k);
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.localSauvola.LocalSauvola.class, out, center,
+			neighborhood, k);
 		return result;
 	}
 	
 	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvola.class)
 	public <T extends RealType<T>> BitType localSauvola(final BitType out,
-		final Pair<T, Iterable<T>> in)
+		final T center, final Iterable<T> neighborhood)
 	{
 		final BitType result =
 			(BitType) ops().run(net.imagej.ops.threshold.localSauvola.LocalSauvola.class,
-				out, in);
+				out, center, neighborhood);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/localBernsen/LocalBernsen.java
+++ b/src/main/java/net/imagej/ops/threshold/localBernsen/LocalBernsen.java
@@ -66,13 +66,13 @@ public class LocalBernsen<T extends RealType<T>> extends
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void initialize() {
-		minMaxFunc = (UnaryFunctionOp) Functions.unary(ops(), Ops.Stats.MinMax.class, Pair.class, in().getB());
+		minMaxFunc = (UnaryFunctionOp) Functions.unary(ops(), Ops.Stats.MinMax.class, Pair.class, in2());
 	}
 
 	@Override
-	public void compute1(final Pair<T, Iterable<T>> input, final BitType output) {
+	public void compute2(final T center, final Iterable<T> neighborhood, final BitType output) {
 
-		final Pair<T, T> outputs = minMaxFunc.compute1(input.getB());
+		final Pair<T, T> outputs = minMaxFunc.compute1(neighborhood);
 		final double minValue = outputs.getA().getRealDouble();
 		final double maxValue = outputs.getB().getRealDouble();
 		final double midGrey = (maxValue + minValue) / 2.0;
@@ -81,7 +81,7 @@ public class LocalBernsen<T extends RealType<T>> extends
 			output.set(midGrey >= halfMaxValue);
 		}
 		else {
-			output.set(input.getA().getRealDouble() >= midGrey);
+			output.set(center.getRealDouble() >= midGrey);
 		}
 
 	}

--- a/src/main/java/net/imagej/ops/threshold/localContrast/LocalContrast.java
+++ b/src/main/java/net/imagej/ops/threshold/localContrast/LocalContrast.java
@@ -56,15 +56,15 @@ public class LocalContrast<T extends RealType<T>> extends
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void initialize() {
-		minMaxFunc = (UnaryFunctionOp)Functions.unary(ops(), Ops.Stats.MinMax.class, Pair.class, in().getB());
+		minMaxFunc = (UnaryFunctionOp)Functions.unary(ops(), Ops.Stats.MinMax.class, Pair.class, in2());
 	}
 
 	@Override
-	public void compute1(Pair<T, Iterable<T>> input, BitType output) {
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
 
-		final Pair<T, T> outputs = minMaxFunc.compute1(input.getB());
+		final Pair<T, T> outputs = minMaxFunc.compute1(neighborhood);
 
-		final double centerValue = input.getA().getRealDouble();
+		final double centerValue = center.getRealDouble();
 		final double diffMin = centerValue - outputs.getA().getRealDouble();
 		final double diffMax = outputs.getB().getRealDouble() - centerValue;
 

--- a/src/main/java/net/imagej/ops/threshold/localMean/LocalMean.java
+++ b/src/main/java/net/imagej/ops/threshold/localMean/LocalMean.java
@@ -37,7 +37,6 @@ import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -60,16 +59,16 @@ public class LocalMean<T extends RealType<T>> extends LocalThresholdMethod<T>
 
 	@Override
 	public void initialize() {
-			mean =  Computers.unary(ops(), Ops.Stats.Mean.class, DoubleType.class, in().getB());
+			mean =  Computers.unary(ops(), Ops.Stats.Mean.class, DoubleType.class, in2());
 	}
 	
 	@Override
-	public void compute1(final Pair<T, Iterable<T>> input, final BitType output) {
-
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+		
 		final DoubleType m = new DoubleType();
 
-		mean.compute1(input.getB(), m);
-		output.set(input.getA().getRealDouble() > m.getRealDouble() - c);
+		mean.compute1(neighborhood, m);
+		output.set(center.getRealDouble() > m.getRealDouble() - c);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/localMedian/LocalMedian.java
+++ b/src/main/java/net/imagej/ops/threshold/localMedian/LocalMedian.java
@@ -37,7 +37,6 @@ import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -59,14 +58,14 @@ public class LocalMedian<T extends RealType<T>> extends LocalThresholdMethod<T>
 
 	@Override
 	public void initialize() {
-		median = Computers.unary(ops(), Ops.Stats.Median.class, DoubleType.class, in().getB());
+		median = Computers.unary(ops(), Ops.Stats.Median.class, DoubleType.class, in2());
 	}
 
 	@Override
-	public void compute1(Pair<T, Iterable<T>> input, BitType output) {
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
 
 		final DoubleType m = new DoubleType();
-		median.compute1(input.getB(), m);
-		output.set(input.getA().getRealDouble() > m.getRealDouble() - c);
+		median.compute1(neighborhood, m);
+		output.set(center.getRealDouble() > m.getRealDouble() - c);
 	}
 }

--- a/src/main/java/net/imagej/ops/threshold/localMidGrey/LocalMidGrey.java
+++ b/src/main/java/net/imagej/ops/threshold/localMidGrey/LocalMidGrey.java
@@ -61,18 +61,18 @@ public class LocalMidGrey<T extends RealType<T>> extends
 	@Override
 	public void initialize() {
 		minMaxFunc =
-			(UnaryFunctionOp) Functions.unary(ops(), Ops.Stats.MinMax.class, Pair.class, in().getB());
+			(UnaryFunctionOp) Functions.unary(ops(), Ops.Stats.MinMax.class, Pair.class, in2());
 	}
 
 	@Override
-	public void compute1(final Pair<T, Iterable<T>> input, final BitType output) {
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
 
-		final Pair<T, T> outputs = minMaxFunc.compute1(input.getB());
+		final Pair<T, T> outputs = minMaxFunc.compute1(neighborhood);
 
 		final double minValue = outputs.getA().getRealDouble();
 		final double maxValue = outputs.getB().getRealDouble();
 
 		output
-			.set(input.getA().getRealDouble() > ((maxValue + minValue) / 2.0) - c);
+			.set(center.getRealDouble() > ((maxValue + minValue) / 2.0) - c);
 	}
 }

--- a/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblack.java
+++ b/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblack.java
@@ -37,7 +37,6 @@ import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -65,20 +64,20 @@ public class LocalNiblack<T extends RealType<T>> extends LocalThresholdMethod<T>
 	@Override
 	public void initialize() {
 		//FIXME: make sure Mean is used inStdDev.
-		mean = Computers.unary(ops(), Ops.Stats.Mean.class, new DoubleType(), in().getB());
-		stdDeviation = Computers.unary(ops(), Ops.Stats.StdDev.class, new DoubleType(), in().getB());
+		mean = Computers.unary(ops(), Ops.Stats.Mean.class, new DoubleType(), in2());
+		stdDeviation = Computers.unary(ops(), Ops.Stats.StdDev.class, new DoubleType(), in2());
 	}
 
 	@Override
-	public void compute1(final Pair<T, Iterable<T>> input, final BitType output) {
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
 
 		final DoubleType m = new DoubleType();
-		mean.compute1(input.getB(), m);
+		mean.compute1(neighborhood, m);
 
 		final DoubleType stdDev = new DoubleType();
-		stdDeviation.compute1(input.getB(), stdDev);
+		stdDeviation.compute1(neighborhood, stdDev);
 
-		output.set(input.getA().getRealDouble() > m.getRealDouble() + k * stdDev
+		output.set(center.getRealDouble() > m.getRealDouble() + k * stdDev
 			.getRealDouble() - c);
 	}
 }

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkar.java
@@ -39,7 +39,6 @@ import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -85,22 +84,22 @@ public class LocalPhansalkar<T extends RealType<T>> extends LocalThresholdMethod
 
 	@Override
 	public void initialize() {
-		mean = Computers.unary(ops(), Mean.class, DoubleType.class, in().getB());
-		stdDeviation = Computers.unary(ops(), StdDev.class, DoubleType.class, in().getB());
+		mean = Computers.unary(ops(), Mean.class, DoubleType.class, in2());
+		stdDeviation = Computers.unary(ops(), StdDev.class, DoubleType.class, in2());
 	}
 
 	@Override
-	public void compute1(final Pair<T, Iterable<T>> input, final BitType output) {
-
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+		
 		final DoubleType meanValue = new DoubleType();
-		mean.compute1(input.getB(), meanValue);
+		mean.compute1(neighborhood, meanValue);
 
 		final DoubleType stdDevValue = new DoubleType();
-		stdDeviation.compute1(input.getB(), stdDevValue);
+		stdDeviation.compute1(neighborhood, stdDevValue);
 
 		double threshold = meanValue.get() * (1.0d + p * Math.exp(-q * meanValue.get()) + k * ((stdDevValue.get()/r) - 1.0));
 		
-		output.set(input.getA().getRealDouble() >= threshold);
+		output.set(center.getRealDouble() >= threshold);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvola.java
@@ -39,7 +39,6 @@ import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
-import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -76,22 +75,22 @@ public class LocalSauvola<T extends RealType<T>> extends LocalThresholdMethod<T>
 
 	@Override
 	public void initialize() {
-		mean = Computers.unary(ops(), Mean.class, DoubleType.class, in().getB());
-		stdDeviation = Computers.unary(ops(), StdDev.class, DoubleType.class, in().getB());
+		mean = Computers.unary(ops(), Mean.class, DoubleType.class, in2());
+		stdDeviation = Computers.unary(ops(), StdDev.class, DoubleType.class, in2());
 	}
 
 	@Override
-	public void compute1(final Pair<T, Iterable<T>> input, final BitType output) {
+	public void compute2(T center, Iterable<T> neighborhood, BitType output) {
 
 		final DoubleType meanValue = new DoubleType();
-		mean.compute1(input.getB(), meanValue);
+		mean.compute1(neighborhood, meanValue);
 
 		final DoubleType stdDevValue = new DoubleType();
-		stdDeviation.compute1(input.getB(), stdDevValue);
+		stdDeviation.compute1(neighborhood, stdDevValue);
 
 		double threshold = meanValue.get() * (1.0d + k * ((Math.sqrt(stdDevValue.get())/r) - 1.0));
 
-		output.set(input.getA().getRealDouble() >= threshold);
+		output.set(center.getRealDouble() >= threshold);
 	}
 
 }

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -40,7 +40,6 @@ import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
-import net.imglib2.util.Pair;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -145,15 +144,15 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 	{
 
 		@Override
-		public void compute1(final Pair<ByteType, Iterable<ByteType>> input,
+		public void compute2(final ByteType center, final Iterable<ByteType> neighborhood,
 			final ByteType output)
 		{
-			ByteType a = input.getA();
+			ByteType a = center;
 
 			a.set((byte) 0);
 			output.set((byte) 0);
 
-			for (Iterator<ByteType> iter = input.getB().iterator(); iter.hasNext(); iter
+			for (Iterator<ByteType> iter = neighborhood.iterator(); iter.hasNext(); iter
 				.next())
 			{
 				output.inc();

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -89,19 +89,17 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testOpMethods() {
 		final BitType out = new BitType();
-		final Pair<ByteType, Iterable<ByteType>> in = new ValuePair<>(
-			new ByteType(), Arrays.asList(new ByteType(), new ByteType()));
 
-		ops.threshold().localBernsen(out, in, 1.0, Double.MAX_VALUE * 0.5);
-		ops.threshold().localContrast(out, in);
-		ops.threshold().localMean(out, in, 1.0);
-		ops.threshold().localMedian(out, in, 1.0);
-		ops.threshold().localMidGrey(out, in, 1.0);
-		ops.threshold().localNiblack(out, in, 1.0, 2.0);
-		ops.threshold().localPhansalkar(out, in, 0.25, 0.5);
-		ops.threshold().localPhansalkar(out, in);
-		ops.threshold().localSauvola(out, in, 0.5, 0.5);
-		ops.threshold().localSauvola(out, in);
+		ops.threshold().localBernsen(out, this.in.firstElement(), this.in, 1.0, Double.MAX_VALUE * 0.5);
+		ops.threshold().localContrast(out, this.in.firstElement(), this.in);
+		ops.threshold().localMean(out, this.in.firstElement(), this.in, 1.0);
+		ops.threshold().localMedian(out, this.in.firstElement(), this.in, 1.0);
+		ops.threshold().localMidGrey(out, this.in.firstElement(), this.in, 1.0);
+		ops.threshold().localNiblack(out, this.in.firstElement(), this.in, 1.0, 2.0);
+		ops.threshold().localPhansalkar(out, this.in.firstElement(), this.in, 0.25, 0.5);
+		ops.threshold().localPhansalkar(out, this.in.firstElement(), this.in);
+		ops.threshold().localSauvola(out, this.in.firstElement(), this.in, 0.5, 0.5);
+		ops.threshold().localSauvola(out, this.in.firstElement(), this.in);
 	}
 
 	/**
@@ -113,8 +111,8 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalBernsen.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 1.0,
-				Double.MAX_VALUE * 0.5), new RectangleShape(3, false),
+				ByteType.class, in, 1.0, Double.MAX_VALUE * 0.5),
+			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
 		assertEquals(out.firstElement().get(), true);
@@ -129,7 +127,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalContrast.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in)),
+				ByteType.class, in),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
@@ -145,7 +143,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalMean.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0),
+				ByteType.class, in, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
@@ -161,7 +159,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalMedian.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0),
+			  ByteType.class, in, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
@@ -177,7 +175,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalMidGrey.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0),
+				ByteType.class, in, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
@@ -193,7 +191,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalNiblack.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
+				ByteType.class, in, 0.0, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
@@ -209,7 +207,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalPhansalkar.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
+				ByteType.class, in, 0.0, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
@@ -225,7 +223,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			ops.op(LocalSauvola.class, BitType.class,
-				new ValuePair<ByteType, Iterable<ByteType>>(null, in), 0.0, 0.0),
+				ByteType.class, in, 0.0, 0.0),
 			new RectangleShape(3, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 


### PR DESCRIPTION
In the original implementation of `CenterAwareComputerOp` et al, those ops were implemented as `UnaryOp`s with a `Pair<T, Iterable<T>>` as sole input. With the advent of `BinaryComputerOp`s and the according maps, this special case (shadowing two inputs using `Pair`) and related implementations are no longer required.