### PR TITLE
Make op method extensible

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -312,7 +312,7 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "eval" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.eval.DefaultEval.class)
 	default Object eval(final String expression) {
-		final Object result = run(net.imagej.ops.eval.DefaultEval.class,
+		final Object result = run(net.imagej.ops.Ops.Eval.class,
 			expression);
 		return result;
 	}
@@ -320,7 +320,7 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "eval" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.eval.DefaultEval.class)
 	default Object eval(final String expression, final Map<String, Object> vars) {
-		final Object result = run(net.imagej.ops.eval.DefaultEval.class, expression,
+		final Object result = run(net.imagej.ops.Ops.Eval.class, expression,
 			vars);
 		return result;
 	}
@@ -334,7 +334,7 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "help" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.help.HelpForOp.class)
 	default String help(final Op op) {
-		final String result = (String) run(net.imagej.ops.help.HelpForOp.class, op);
+		final String result = (String) run(net.imagej.ops.Ops.Help.class, op);
 		return result;
 	}
 
@@ -342,7 +342,7 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = net.imagej.ops.help.HelpForNamespace.class)
 	default String help(final Namespace namespace) {
 		final String result = (String) run(
-			net.imagej.ops.help.HelpForNamespace.class, namespace);
+			net.imagej.ops.Ops.Help.class, namespace);
 		return result;
 	}
 
@@ -350,14 +350,14 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = net.imagej.ops.help.HelpCandidates.class)
 	default String help() {
 		final String result = (String) run(
-			net.imagej.ops.help.HelpCandidates.class);
+			net.imagej.ops.Ops.Help.class);
 		return result;
 	}
 
 	/** Executes the "help" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.help.HelpCandidates.class)
 	default String help(final String name) {
-		final String result = (String) run(net.imagej.ops.help.HelpCandidates.class,
+		final String result = (String) run(net.imagej.ops.Ops.Help.class,
 			name);
 		return result;
 	}
@@ -365,7 +365,7 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "help" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.help.HelpCandidates.class)
 	default String help(final String name, final Class<? extends Op> opType) {
-		final String result = (String) run(net.imagej.ops.help.HelpCandidates.class,
+		final String result = (String) run(net.imagej.ops.Ops.Help.class,
 			name, opType);
 		return result;
 	}
@@ -375,7 +375,7 @@ public interface OpEnvironment extends Contextual {
 	default String help(final String name, final Class<? extends Op> opType,
 		final Integer arity)
 	{
-		final String result = (String) run(net.imagej.ops.help.HelpCandidates.class,
+		final String result = (String) run(net.imagej.ops.Ops.Help.class,
 			name, opType, arity);
 		return result;
 	}
@@ -385,7 +385,7 @@ public interface OpEnvironment extends Contextual {
 	default String help(final String name, final Class<? extends Op> opType,
 		final Integer arity, final SpecialOp.Flavor flavor)
 	{
-		final String result = (String) run(net.imagej.ops.help.HelpCandidates.class,
+		final String result = (String) run(net.imagej.ops.Ops.Help.class,
 			name, opType, arity, flavor);
 		return result;
 	}
@@ -400,7 +400,7 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = net.imagej.ops.identity.DefaultIdentity.class)
 	default <A> A identity(final A arg) {
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.identity.DefaultIdentity.class,
+		final A result = (A) run(net.imagej.ops.Ops.Identity.class,
 			arg);
 		return result;
 	}
@@ -418,7 +418,7 @@ public interface OpEnvironment extends Contextual {
 		final UnaryOutputFactory<A, B> outputFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final C result = (C) run(net.imagej.ops.join.DefaultJoin2Computers.class,
+		final C result = (C) run(net.imagej.ops.Ops.Join.class,
 			out, in, first, second, outputFactory);
 		return result;
 	}
@@ -429,7 +429,7 @@ public interface OpEnvironment extends Contextual {
 		final UnaryInplaceOp<A> second)
 	{
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.join.DefaultJoin2Inplaces.class,
+		final A result = (A) run(net.imagej.ops.Ops.Join.class,
 			arg, first, second);
 		return result;
 	}
@@ -441,7 +441,7 @@ public interface OpEnvironment extends Contextual {
 		final UnaryOutputFactory<A, A> outputFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.join.DefaultJoinNComputers.class,
+		final A result = (A) run(net.imagej.ops.Ops.Join.class,
 			out, in, ops, outputFactory);
 		return result;
 	}
@@ -450,7 +450,7 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = net.imagej.ops.join.DefaultJoinNInplaces.class)
 	default <A> A join(final A arg, final List<? extends UnaryInplaceOp<A>> ops) {
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.join.DefaultJoinNInplaces.class,
+		final A result = (A) run(net.imagej.ops.Ops.Join.class,
 			arg, ops);
 		return result;
 	}
@@ -462,7 +462,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final B result = (B) run(
-			net.imagej.ops.join.DefaultJoinInplaceAndComputer.class, out, in, first,
+			net.imagej.ops.Ops.Join.class, out, in, first,
 			second);
 		return result;
 	}
@@ -474,7 +474,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final B result = (B) run(
-			net.imagej.ops.join.DefaultJoinComputerAndInplace.class, out, in, first,
+			net.imagej.ops.Ops.Join.class, out, in, first,
 			second);
 		return result;
 	}
@@ -489,7 +489,7 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = net.imagej.ops.loop.DefaultLoopInplace.class)
 	default <A> A loop(final A arg, final UnaryInplaceOp<A> op, final int n) {
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.loop.DefaultLoopInplace.class, arg,
+		final A result = (A) run(net.imagej.ops.Ops.Loop.class, arg,
 			op, n);
 		return result;
 	}
@@ -500,7 +500,7 @@ public interface OpEnvironment extends Contextual {
 		final UnaryOutputFactory<A, A> outputFactory, final int n)
 	{
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.loop.DefaultLoopComputer.class, out,
+		final A result = (A) run(net.imagej.ops.Ops.Loop.class, out,
 			in, op, outputFactory, n);
 		return result;
 	}
@@ -650,7 +650,7 @@ public interface OpEnvironment extends Contextual {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<EO> result =
 			(RandomAccessibleInterval<EO>) run(
-				net.imagej.ops.map.MapViewRAIToRAI.class, input, op, type);
+				net.imagej.ops.Ops.Map.class, input, op, type);
 		return result;
 	}
 
@@ -662,7 +662,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessible<EO> result = (RandomAccessible<EO>) run(
-			net.imagej.ops.map.MapViewRandomAccessToRandomAccess.class, input, op,
+			net.imagej.ops.Ops.Map.class, input, op,
 			type);
 		return result;
 	}
@@ -676,7 +676,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<EO> result = (IterableInterval<EO>) run(
-			net.imagej.ops.map.MapViewIIToII.class, input,
+			net.imagej.ops.Ops.Map.class, input,
 			op, type);
 		return result;
 	}
@@ -688,7 +688,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<A> result = (IterableInterval<A>) run(
-			net.imagej.ops.map.MapIIInplaceParallel.class, arg, op);
+			net.imagej.ops.Ops.Map.class, arg, op);
 		return result;
 	}
 
@@ -697,7 +697,7 @@ public interface OpEnvironment extends Contextual {
 	default <A> Iterable<A> map(final Iterable<A> arg, final UnaryInplaceOp<A> op) {
 		@SuppressWarnings("unchecked")
 		final Iterable<A> result = (Iterable<A>) run(
-			net.imagej.ops.map.MapIterableInplace.class, arg, op);
+			net.imagej.ops.Ops.Map.class, arg, op);
 		return result;
 	}
 
@@ -711,7 +711,7 @@ public interface OpEnvironment extends Contextual {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result =
 			(IterableInterval<O>) run(
-				net.imagej.ops.map.neighborhood.MapNeighborhood.class, out, in, op, shape);
+				net.imagej.ops.Ops.Map.class, out, in, op, shape);
 		return result;
 	}
 
@@ -725,7 +725,7 @@ public interface OpEnvironment extends Contextual {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result =
 			(IterableInterval<O>) run(
-				net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class, out, in, func, shape);
+				net.imagej.ops.Ops.Map.class, out, in, func, shape);
 		return result;
 	}
 
@@ -736,7 +736,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final Iterable<EO> result = (Iterable<EO>) run(
-			net.imagej.ops.map.MapIterableToIterable.class, out, in, op);
+			net.imagej.ops.Ops.Map.class, out, in, op);
 		return result;
 	}
 
@@ -748,7 +748,7 @@ public interface OpEnvironment extends Contextual {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<EA> result = (IterableInterval<EA>) run(
-			net.imagej.ops.map.MapIIAndIIInplaceParallel.class, arg, in, op);
+			net.imagej.ops.Ops.Map.class, arg, in, op);
 		return result;
 	}
 
@@ -804,7 +804,7 @@ public interface OpEnvironment extends Contextual {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) run(
-				net.imagej.ops.slicewise.SlicewiseRAI2RAI.class, out, in, op,
+				net.imagej.ops.Ops.Slicewise.class, out, in, op,
 				axisIndices);
 		return result;
 	}
@@ -819,7 +819,7 @@ public interface OpEnvironment extends Contextual {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) run(
-				net.imagej.ops.slicewise.SlicewiseRAI2RAI.class, out, in, op,
+				net.imagej.ops.Ops.Slicewise.class, out, in, op,
 				axisIndices, dropSingleDimensions);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/convert/ConvertNamespace.java
+++ b/src/main/java/net/imagej/ops/convert/ConvertNamespace.java
@@ -81,13 +81,13 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
-			net.imagej.ops.convert.clip.ClipRealTypes.class, out, in);
+			Ops.Convert.Clip.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = Ops.Convert.Copy.class)
 	public Object copy(final Object... args) {
-		return ops().run(Ops.Convert.Clip.class, args);
+		return ops().run(Ops.Convert.Copy.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.copy.CopyRealTypes.class)
@@ -96,7 +96,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
-			net.imagej.ops.convert.copy.CopyRealTypes.class, out, in);
+			Ops.Convert.Copy.class, out, in);
 		return result;
 	}
 
@@ -113,7 +113,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-			net.imagej.ops.convert.imageType.ConvertIIs.class, out, in,
+			Ops.Convert.ImageType.class, out, in,
 			typeConverter);
 		return result;
 	}
@@ -130,7 +130,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
-			net.imagej.ops.convert.normalizeScale.NormalizeScaleRealTypes.class, out,
+			Ops.Convert.NormalizeScale.class, out,
 			in);
 		return result;
 	}
@@ -146,7 +146,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(
-			net.imagej.ops.convert.scale.ScaleRealTypes.class, out, in);
+			Ops.Convert.Scale.class, out, in);
 		return result;
 	}
 
@@ -161,7 +161,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<BitType> result = (Img<BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Bit.class, in);
+			Ops.Convert.Bit.class, in);
 		return result;
 	}
 
@@ -171,21 +171,21 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<BitType> result = (Img<BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Bit.class, out, in);
+			Ops.Convert.Bit.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToBit.class)
 	public <C extends ComplexType<C>> BitType bit(final C in) {
 		final BitType result = (BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToBit.class, in);
+			Ops.Convert.Bit.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToBit.class)
 	public <C extends ComplexType<C>> BitType bit(final BitType out, final C in) {
 		final BitType result = (BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToBit.class, out, in);
+			Ops.Convert.Bit.class, out, in);
 		return result;
 	}
 
@@ -200,7 +200,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned2BitType> result = (Img<Unsigned2BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint2.class, in);
+			Ops.Convert.Uint2.class, in);
 		return result;
 	}
 
@@ -210,14 +210,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned2BitType> result = (Img<Unsigned2BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint2.class, out, in);
+			Ops.Convert.Uint2.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint2.class)
 	public <C extends ComplexType<C>> Unsigned2BitType uint2(final C in) {
 		final Unsigned2BitType result = (Unsigned2BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint2.class, in);
+			Ops.Convert.Uint2.class, in);
 		return result;
 	}
 
@@ -226,14 +226,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned2BitType out, final C in)
 	{
 		final Unsigned2BitType result = (Unsigned2BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint2.class, out, in);
+			Ops.Convert.Uint2.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint2.class)
 	public <T extends IntegerType<T>> Unsigned2BitType uint2(final T in) {
 		final Unsigned2BitType result = (Unsigned2BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint2.class, in);
+			Ops.Convert.Uint2.class, in);
 		return result;
 	}
 
@@ -242,7 +242,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned2BitType out, final T in)
 	{
 		final Unsigned2BitType result = (Unsigned2BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint2.class, out, in);
+			Ops.Convert.Uint2.class, out, in);
 		return result;
 	}
 
@@ -257,7 +257,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned4BitType> result = (Img<Unsigned4BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint4.class, in);
+			Ops.Convert.Uint4.class, in);
 		return result;
 	}
 
@@ -267,14 +267,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned4BitType> result = (Img<Unsigned4BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint4.class, out, in);
+			Ops.Convert.Uint4.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint4.class)
 	public <C extends ComplexType<C>> Unsigned4BitType uint4(final C in) {
 		final Unsigned4BitType result = (Unsigned4BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint4.class, in);
+			Ops.Convert.Uint4.class, in);
 		return result;
 	}
 
@@ -283,14 +283,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned4BitType out, final C in)
 	{
 		final Unsigned4BitType result = (Unsigned4BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint4.class, out, in);
+			Ops.Convert.Uint4.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint4.class)
 	public <T extends IntegerType<T>> Unsigned4BitType uint4(final T in) {
 		final Unsigned4BitType result = (Unsigned4BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint4.class, in);
+			Ops.Convert.Uint4.class, in);
 		return result;
 	}
 
@@ -299,7 +299,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned4BitType out, final T in)
 	{
 		final Unsigned4BitType result = (Unsigned4BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint4.class, out, in);
+			Ops.Convert.Uint4.class, out, in);
 		return result;
 	}
 
@@ -314,7 +314,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ByteType> result = (Img<ByteType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int8.class, in);
+			Ops.Convert.Int8.class, in);
 		return result;
 	}
 
@@ -324,14 +324,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ByteType> result = (Img<ByteType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint8.class, out, in);
+			Ops.Convert.Int8.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToInt8.class)
 	public <C extends ComplexType<C>> ByteType int8(final C in) {
 		final ByteType result = (ByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt8.class, in);
+			Ops.Convert.Int8.class, in);
 		return result;
 	}
 
@@ -340,14 +340,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final C in)
 	{
 		final ByteType result = (ByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt8.class, out, in);
+			Ops.Convert.Int8.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToInt8.class)
 	public <T extends IntegerType<T>> ByteType int8(final T in) {
 		final ByteType result = (ByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt8.class, in);
+			Ops.Convert.Int8.class, in);
 		return result;
 	}
 
@@ -356,7 +356,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final T in)
 	{
 		final ByteType result = (ByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt8.class, out, in);
+			Ops.Convert.Int8.class, out, in);
 		return result;
 	}
 
@@ -371,7 +371,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedByteType> result = (Img<UnsignedByteType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint8.class, in);
+			Ops.Convert.Uint8.class, in);
 		return result;
 	}
 
@@ -381,14 +381,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedByteType> result = (Img<UnsignedByteType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint8.class, out, in);
+			Ops.Convert.Uint8.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint8.class)
 	public <C extends ComplexType<C>> UnsignedByteType uint8(final C in) {
 		final UnsignedByteType result = (UnsignedByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint8.class, in);
+			Ops.Convert.Uint8.class, in);
 		return result;
 	}
 
@@ -397,14 +397,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedByteType out, final C in)
 	{
 		final UnsignedByteType result = (UnsignedByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint8.class, out, in);
+			Ops.Convert.Uint8.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint8.class)
 	public <T extends IntegerType<T>> UnsignedByteType uint8(final T in) {
 		final UnsignedByteType result = (UnsignedByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint8.class, in);
+			Ops.Convert.Uint8.class, in);
 		return result;
 	}
 
@@ -413,7 +413,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedByteType out, final T in)
 	{
 		final UnsignedByteType result = (UnsignedByteType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint8.class, out, in);
+			Ops.Convert.Uint8.class, out, in);
 		return result;
 	}
 
@@ -428,7 +428,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned12BitType> result = (Img<Unsigned12BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint12.class, in);
+			Ops.Convert.Uint12.class, in);
 		return result;
 	}
 
@@ -438,14 +438,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned12BitType> result = (Img<Unsigned12BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint12.class, out, in);
+			Ops.Convert.Uint12.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint12.class)
 	public <C extends ComplexType<C>> Unsigned12BitType uint12(final C in) {
 		final Unsigned12BitType result = (Unsigned12BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint12.class, in);
+			Ops.Convert.Uint12.class, in);
 		return result;
 	}
 
@@ -454,14 +454,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned12BitType out, final C in)
 	{
 		final Unsigned12BitType result = (Unsigned12BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint12.class, out, in);
+			Ops.Convert.Uint12.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint12.class)
 	public <T extends IntegerType<T>> Unsigned12BitType uint12(final T in) {
 		final Unsigned12BitType result = (Unsigned12BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint12.class, in);
+			Ops.Convert.Uint12.class, in);
 		return result;
 	}
 
@@ -470,7 +470,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned12BitType out, final T in)
 	{
 		final Unsigned12BitType result = (Unsigned12BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint12.class, out, in);
+			Ops.Convert.Uint12.class, out, in);
 		return result;
 	}
 
@@ -485,7 +485,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ShortType> result = (Img<ShortType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int16.class, in);
+			Ops.Convert.Int16.class, in);
 		return result;
 	}
 
@@ -495,14 +495,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ShortType> result = (Img<ShortType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int16.class, out, in);
+			Ops.Convert.Int16.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToInt16.class)
 	public <C extends ComplexType<C>> ShortType int16(final C in) {
 		final ShortType result = (ShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt16.class, in);
+			Ops.Convert.Int16.class, in);
 		return result;
 	}
 
@@ -511,14 +511,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final C in)
 	{
 		final ShortType result = (ShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt16.class, out, in);
+			Ops.Convert.Int16.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToInt16.class)
 	public <T extends IntegerType<T>> ShortType int16(final T in) {
 		final ShortType result = (ShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt16.class, in);
+			Ops.Convert.Int16.class, in);
 		return result;
 	}
 
@@ -527,7 +527,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final T in)
 	{
 		final ShortType result = (ShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt16.class, out, in);
+			Ops.Convert.Int16.class, out, in);
 		return result;
 	}
 
@@ -542,7 +542,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedShortType> result = (Img<UnsignedShortType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint16.class, in);
+			Ops.Convert.Uint16.class, in);
 		return result;
 	}
 
@@ -552,14 +552,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedShortType> result = (Img<UnsignedShortType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint16.class, out, in);
+			Ops.Convert.Uint16.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint16.class)
 	public <C extends ComplexType<C>> UnsignedShortType uint16(final C in) {
 		final UnsignedShortType result = (UnsignedShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint16.class, in);
+			Ops.Convert.Uint16.class, in);
 		return result;
 	}
 
@@ -568,14 +568,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedShortType out, final C in)
 	{
 		final UnsignedShortType result = (UnsignedShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint16.class, out, in);
+			Ops.Convert.Uint16.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint16.class)
 	public <T extends IntegerType<T>> UnsignedShortType uint16(final T in) {
 		final UnsignedShortType result = (UnsignedShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint16.class, in);
+			Ops.Convert.Uint16.class, in);
 		return result;
 	}
 
@@ -584,7 +584,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedShortType out, final T in)
 	{
 		final UnsignedShortType result = (UnsignedShortType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint16.class, out, in);
+			Ops.Convert.Uint16.class, out, in);
 		return result;
 	}
 
@@ -599,7 +599,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<IntType> result = (Img<IntType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int32.class, in);
+			Ops.Convert.Int32.class, in);
 		return result;
 	}
 
@@ -609,14 +609,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<IntType> result = (Img<IntType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int32.class, out, in);
+			Ops.Convert.Int32.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToInt32.class)
 	public <T extends IntegerType<T>> IntType int32(final T in) {
 		final IntType result = (IntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt32.class, in);
+			Ops.Convert.Int32.class, in);
 		return result;
 	}
 
@@ -625,14 +625,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final T in)
 	{
 		final IntType result = (IntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt32.class, out, in);
+			Ops.Convert.Int32.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToInt32.class)
 	public <C extends ComplexType<C>> IntType int32(final C in) {
 		final IntType result = (IntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt32.class, in);
+			Ops.Convert.Int32.class, in);
 		return result;
 	}
 
@@ -641,7 +641,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final C in)
 	{
 		final IntType result = (IntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt32.class, out, in);
+			Ops.Convert.Int32.class, out, in);
 		return result;
 	}
 
@@ -656,7 +656,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedIntType> result = (Img<UnsignedIntType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint32.class, in);
+			Ops.Convert.Uint32.class, in);
 		return result;
 	}
 
@@ -666,14 +666,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedIntType> result = (Img<UnsignedIntType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint32.class, out, in);
+			Ops.Convert.Uint32.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint32.class)
 	public <C extends ComplexType<C>> UnsignedIntType uint32(final C in) {
 		final UnsignedIntType result = (UnsignedIntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint32.class, in);
+			Ops.Convert.Uint32.class, in);
 		return result;
 	}
 
@@ -682,14 +682,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedIntType out, final C in)
 	{
 		final UnsignedIntType result = (UnsignedIntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint32.class, out, in);
+			Ops.Convert.Uint32.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint32.class)
 	public <T extends IntegerType<T>> UnsignedIntType uint32(final T in) {
 		final UnsignedIntType result = (UnsignedIntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint32.class, in);
+			Ops.Convert.Uint32.class, in);
 		return result;
 	}
 
@@ -698,7 +698,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedIntType out, final T in)
 	{
 		final UnsignedIntType result = (UnsignedIntType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint32.class, out, in);
+			Ops.Convert.Uint32.class, out, in);
 		return result;
 	}
 
@@ -713,7 +713,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<LongType> result = (Img<LongType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int64.class, in);
+			Ops.Convert.Int64.class, in);
 		return result;
 	}
 
@@ -723,14 +723,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<LongType> result = (Img<LongType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Int64.class, out, in);
+			Ops.Convert.Int64.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToInt64.class)
 	public <C extends ComplexType<C>> LongType int64(final C in) {
 		final LongType result = (LongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt64.class, in);
+			Ops.Convert.Int64.class, in);
 		return result;
 	}
 
@@ -739,14 +739,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final C in)
 	{
 		final LongType result = (LongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToInt64.class, out, in);
+			Ops.Convert.Int64.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToInt64.class)
 	public <T extends IntegerType<T>> LongType int64(final T in) {
 		final LongType result = (LongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt64.class, in);
+			Ops.Convert.Int64.class, in);
 		return result;
 	}
 
@@ -755,7 +755,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final T in)
 	{
 		final LongType result = (LongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToInt64.class, out, in);
+			Ops.Convert.Int64.class, out, in);
 		return result;
 	}
 
@@ -770,7 +770,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedLongType> result = (Img<UnsignedLongType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint64.class, in);
+			Ops.Convert.Uint64.class, in);
 		return result;
 	}
 
@@ -780,14 +780,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<UnsignedLongType> result = (Img<UnsignedLongType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint64.class, out, in);
+			Ops.Convert.Uint64.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint64.class)
 	public <C extends ComplexType<C>> UnsignedLongType uint64(final C in) {
 		final UnsignedLongType result = (UnsignedLongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint64.class, in);
+			Ops.Convert.Uint64.class, in);
 		return result;
 	}
 
@@ -796,14 +796,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedLongType out, final C in)
 	{
 		final UnsignedLongType result = (UnsignedLongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint64.class, out, in);
+			Ops.Convert.Uint64.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint64.class)
 	public <T extends IntegerType<T>> UnsignedLongType uint64(final T in) {
 		final UnsignedLongType result = (UnsignedLongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint64.class, in);
+			Ops.Convert.Uint64.class, in);
 		return result;
 	}
 
@@ -812,7 +812,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedLongType out, final T in)
 	{
 		final UnsignedLongType result = (UnsignedLongType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint64.class, out, in);
+			Ops.Convert.Uint64.class, out, in);
 		return result;
 	}
 
@@ -827,7 +827,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned128BitType> result = (Img<Unsigned128BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint128.class, in);
+			Ops.Convert.Uint128.class, in);
 		return result;
 	}
 
@@ -837,14 +837,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<Unsigned128BitType> result = (Img<Unsigned128BitType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Uint128.class, out, in);
+			Ops.Convert.Uint128.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToUint128.class)
 	public <T extends IntegerType<T>> Unsigned128BitType uint128(final T in) {
 		final Unsigned128BitType result = (Unsigned128BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint128.class, in);
+			Ops.Convert.Uint128.class, in);
 		return result;
 	}
 
@@ -853,14 +853,14 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned128BitType out, final T in)
 	{
 		final Unsigned128BitType result = (Unsigned128BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.IntegerToUint128.class, out, in);
+			Ops.Convert.Uint128.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToUint128.class)
 	public <C extends ComplexType<C>> Unsigned128BitType uint128(final C in) {
 		final Unsigned128BitType result = (Unsigned128BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint128.class, in);
+			Ops.Convert.Uint128.class, in);
 		return result;
 	}
 
@@ -869,7 +869,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned128BitType out, final C in)
 	{
 		final Unsigned128BitType result = (Unsigned128BitType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToUint128.class, out, in);
+			Ops.Convert.Uint128.class, out, in);
 		return result;
 	}
 
@@ -884,7 +884,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<FloatType> result = (Img<FloatType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Float32.class, in);
+			Ops.Convert.Float32.class, in);
 		return result;
 	}
 
@@ -894,14 +894,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<FloatType> result = (Img<FloatType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Float32.class, out, in);
+			Ops.Convert.Float32.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToFloat32.class)
 	public <C extends ComplexType<C>> FloatType float32(final C in) {
 		final FloatType result = (FloatType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToFloat32.class, in);
+			Ops.Convert.Float32.class, in);
 		return result;
 	}
 
@@ -910,7 +910,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final C in)
 	{
 		final FloatType result = (FloatType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToFloat32.class, out, in);
+			Ops.Convert.Float32.class, out, in);
 		return result;
 	}
 
@@ -925,7 +925,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexFloatType> result = (Img<ComplexFloatType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Cfloat32.class, in);
+			Ops.Convert.Cfloat32.class, in);
 		return result;
 	}
 
@@ -935,14 +935,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexFloatType> result = (Img<ComplexFloatType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Cfloat32.class, out, in);
+			Ops.Convert.Cfloat32.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToCfloat32.class)
 	public <C extends ComplexType<C>> ComplexFloatType cfloat32(final C in) {
 		final ComplexFloatType result = (ComplexFloatType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToCfloat32.class, in);
+			Ops.Convert.Cfloat32.class, in);
 		return result;
 	}
 
@@ -951,7 +951,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final ComplexFloatType out, final C in)
 	{
 		final ComplexFloatType result = (ComplexFloatType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToCfloat32.class, out, in);
+			Ops.Convert.Cfloat32.class, out, in);
 		return result;
 	}
 
@@ -966,7 +966,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<DoubleType> result = (Img<DoubleType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Float64.class, in);
+			Ops.Convert.Float64.class, in);
 		return result;
 	}
 
@@ -976,14 +976,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<DoubleType> result = (Img<DoubleType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Float64.class, out, in);
+			Ops.Convert.Float64.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToFloat64.class)
 	public <C extends ComplexType<C>> DoubleType float64(final C in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToFloat64.class, in);
+			Ops.Convert.Float64.class, in);
 		return result;
 	}
 
@@ -992,7 +992,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final C in)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToFloat64.class, out, in);
+			Ops.Convert.Float64.class, out, in);
 		return result;
 	}
 
@@ -1007,7 +1007,7 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexDoubleType> result = (Img<ComplexDoubleType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Cfloat64.class, in);
+			Ops.Convert.Cfloat64.class, in);
 		return result;
 	}
 
@@ -1017,14 +1017,14 @@ public class ConvertNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexDoubleType> result = (Img<ComplexDoubleType>) ops().run(
-			net.imagej.ops.convert.ConvertImages.Cfloat64.class, out, in);
+			Ops.Convert.Cfloat64.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.ComplexToCfloat64.class)
 	public <C extends ComplexType<C>> ComplexDoubleType cfloat64(final C in) {
 		final ComplexDoubleType result = (ComplexDoubleType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToCfloat64.class, in);
+			Ops.Convert.Cfloat64.class, in);
 		return result;
 	}
 
@@ -1033,7 +1033,7 @@ public class ConvertNamespace extends AbstractNamespace {
 		final ComplexDoubleType out, final C in)
 	{
 		final ComplexDoubleType result = (ComplexDoubleType) ops().run(
-			net.imagej.ops.convert.ConvertTypes.ComplexToCfloat64.class, out, in);
+			Ops.Convert.Cfloat64.class, out, in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/copy/CopyNamespace.java
+++ b/src/main/java/net/imagej/ops/copy/CopyNamespace.java
@@ -117,7 +117,7 @@ public class CopyNamespace extends AbstractNamespace {
 	public <T> IterableInterval<T> iterableInterval(final IterableInterval<T> in) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-				net.imagej.ops.copy.CopyII.class, in);
+				net.imagej.ops.Ops.Copy.IterableInterval.class, in);
 		return result;
 	}
 
@@ -128,7 +128,7 @@ public class CopyNamespace extends AbstractNamespace {
 			final IterableInterval<T> out, final IterableInterval<T> in) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-				net.imagej.ops.copy.CopyII.class, out, in);
+				net.imagej.ops.Ops.Copy.IterableInterval.class, out, in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -110,7 +110,7 @@ public class CreateNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.create.img.CreateImgFromDimsAndType.class, in1, in2);
+			net.imagej.ops.Ops.Create.Img.class, in1, in2);
 		return result;
 	}
 
@@ -120,7 +120,7 @@ public class CreateNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.create.img.CreateImgFromDimsAndType.class, in1, in2,
+			net.imagej.ops.Ops.Create.Img.class, in1, in2,
 			factory);
 		return result;
 	}
@@ -129,7 +129,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public <T extends NativeType<T>> Img<T> img(final IterableInterval<T> in) {
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.create.img.CreateImgFromII.class, in);
+			net.imagej.ops.Ops.Create.Img.class, in);
 		return result;
 	}
 
@@ -139,7 +139,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public <T extends NativeType<T>> Img<T> img(final Img<T> in) {
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.create.img.CreateImgFromImg.class, in);
+			net.imagej.ops.Ops.Create.Img.class, in);
 		return result;
 	}
 
@@ -147,7 +147,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public Img<DoubleType> img(final Interval interval) {
 		@SuppressWarnings("unchecked")
 		final Img<DoubleType> result = (Img<DoubleType>) ops().run(
-			net.imagej.ops.create.img.CreateImgFromInterval.class, interval);
+			net.imagej.ops.Ops.Create.Img.class, interval);
 		return result;
 	}
 
@@ -157,7 +157,7 @@ public class CreateNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-			net.imagej.ops.create.img.CreateImgFromRAI.class, in);
+			net.imagej.ops.Ops.Create.Img.class, in);
 		return result;
 	}
 
@@ -174,7 +174,7 @@ public class CreateNamespace extends AbstractNamespace {
 		// https://github.com/imglib/imglib2/issues/91
 		@SuppressWarnings("unchecked")
 		final ImgFactory<T> result = (ImgFactory<T>) ops().run(
-			net.imagej.ops.create.imgFactory.DefaultCreateImgFactory.class);
+			net.imagej.ops.Ops.Create.ImgFactory.class);
 		return result;
 	}
 
@@ -215,7 +215,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims);
+				Ops.Create.ImgLabeling.class, dims);
 		return result;
 	}
 
@@ -227,7 +227,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
+				Ops.Create.ImgLabeling.class, dims,
 				outType);
 		return result;
 	}
@@ -240,7 +240,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
+				Ops.Create.ImgLabeling.class, dims,
 				outType, fac);
 		return result;
 	}
@@ -254,7 +254,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class, dims,
+				Ops.Create.ImgLabeling.class, dims,
 				outType, fac, maxNumLabelSets);
 		return result;
 	}
@@ -267,7 +267,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				Ops.Create.ImgLabeling.class,
 				interval);
 		return result;
 	}
@@ -280,7 +280,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				Ops.Create.ImgLabeling.class,
 				interval, outType);
 		return result;
 	}
@@ -293,7 +293,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				Ops.Create.ImgLabeling.class,
 				interval, outType, fac);
 		return result;
 	}
@@ -307,7 +307,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, T> result =
 			(ImgLabeling<L, T>) ops().run(
-				net.imagej.ops.create.imgLabeling.CreateImgLabelingFromInterval.class,
+				Ops.Create.ImgLabeling.class,
 				interval, outType, fac, maxNumLabelSets);
 		return result;
 	}
@@ -324,7 +324,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgPlus<T> result =
 			(ImgPlus<T>) ops().run(
-				net.imagej.ops.create.imgPlus.DefaultCreateImgPlus.class, img);
+				Ops.Create.ImgPlus.class, img);
 		return result;
 	}
 
@@ -335,7 +335,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgPlus<T> result =
 			(ImgPlus<T>) ops()
-				.run(net.imagej.ops.create.imgPlus.DefaultCreateImgPlus.class, img,
+				.run(Ops.Create.ImgPlus.class, img,
 					metadata);
 		return result;
 	}
@@ -352,7 +352,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public IntegerType integerType() {
 		final IntegerType result =
 			(IntegerType) ops().run(
-				net.imagej.ops.create.integerType.DefaultCreateIntegerType.class);
+				Ops.Create.IntegerType.class);
 		return result;
 	}
 
@@ -361,7 +361,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public IntegerType integerType(final long maxValue) {
 		final IntegerType result =
 			(IntegerType) ops().run(
-				net.imagej.ops.create.integerType.DefaultCreateIntegerType.class,
+				Ops.Create.IntegerType.class,
 				maxValue);
 		return result;
 	}
@@ -378,7 +378,7 @@ public class CreateNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.create.kernel.CreateKernel.class)
 	public <T extends ComplexType<T>> Img<T> kernel(final double[]... values) {
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(net.imagej.ops.create.kernel.CreateKernel.class,
+		final Img<T> result = (Img<T>) ops().run(net.imagej.ops.Ops.Create.Kernel.class, 
 				new Object[] { values });
 		return result;
 	}
@@ -387,7 +387,7 @@ public class CreateNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.create.kernel.CreateKernel.class)
 	public <T extends ComplexType<T>> Img<T> kernel(final T outType, final double[]... values) {
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(net.imagej.ops.create.kernel.CreateKernel.class, outType, values);
+		final Img<T> result = (Img<T>) ops().run(net.imagej.ops.Ops.Create.Kernel.class, outType, values);
 		return result;
 	}
 
@@ -396,7 +396,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public <T extends ComplexType<T>> Img<T> kernel(final T outType, final ImgFactory<T> fac,
 			final double[]... values) {
 		@SuppressWarnings("unchecked")
-		final Img<T> result = (Img<T>) ops().run(net.imagej.ops.create.kernel.CreateKernel.class, outType, fac, values);
+		final Img<T> result = (Img<T>) ops().run(net.imagej.ops.Ops.Create.Kernel.class, outType, fac, values);
 		return result;
 	}
 
@@ -417,7 +417,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGaussSymmetric.class,
+				Ops.Create.KernelGauss.class,
 				numDimensions, sigma);
 		return result;
 	}
@@ -431,7 +431,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGaussSymmetric.class,
+				Ops.Create.KernelGauss.class,
 				outType, numDimensions, sigma);
 		return result;
 	}
@@ -445,7 +445,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGaussSymmetric.class,
+				Ops.Create.KernelGauss.class,
 				outType, fac, numDimensions, sigma);
 		return result;
 	}
@@ -459,7 +459,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGauss.class, sigma);
+				Ops.Create.KernelGauss.class, sigma);
 		return result;
 	}
 
@@ -471,7 +471,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGauss.class, outType,
+				Ops.Create.KernelGauss.class, outType,
 				sigma);
 		return result;
 	}
@@ -484,7 +484,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelGauss.CreateKernelGauss.class, outType,
+				Ops.Create.KernelGauss.class, outType,
 				fac, sigma);
 		return result;
 	}
@@ -508,7 +508,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric.class,
+				Ops.Create.KernelLog.class,
 				numDimensions, sigma);
 		return result;
 	}
@@ -522,7 +522,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric.class,
+				Ops.Create.KernelLog.class,
 				outType, numDimensions, sigma);
 		return result;
 	}
@@ -536,7 +536,7 @@ public class CreateNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
 			(Img<T>) ops().run(
-				net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric.class,
+				Ops.Create.KernelLog.class,
 				outType, fac, numDimensions, sigma);
 		return result;
 	}
@@ -548,7 +548,7 @@ public class CreateNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.kernelLog.CreateKernelLog.class,
+			(Img<T>) ops().run(Ops.Create.KernelLog.class,
 				sigma);
 		return result;
 	}
@@ -560,7 +560,7 @@ public class CreateNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.kernelLog.CreateKernelLog.class,
+			(Img<T>) ops().run(Ops.Create.KernelLog.class,
 				outType, sigma);
 		return result;
 	}
@@ -572,7 +572,7 @@ public class CreateNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<T> result =
-			(Img<T>) ops().run(net.imagej.ops.create.kernelLog.CreateKernelLog.class,
+			(Img<T>) ops().run(Ops.Create.KernelLog.class,
 				outType, fac, sigma);
 		return result;
 	}
@@ -593,7 +593,7 @@ public class CreateNamespace extends AbstractNamespace {
 		final LabelingMapping<L> result =
 			(LabelingMapping<L>) ops()
 				.run(
-					net.imagej.ops.create.labelingMapping.DefaultCreateLabelingMapping.class);
+					Ops.Create.LabelingMapping.class);
 		return result;
 	}
 
@@ -605,7 +605,7 @@ public class CreateNamespace extends AbstractNamespace {
 		final LabelingMapping<L> result =
 			(LabelingMapping<L>) ops()
 				.run(
-					net.imagej.ops.create.labelingMapping.DefaultCreateLabelingMapping.class,
+					Ops.Create.LabelingMapping.class,
 					maxNumSets);
 		return result;
 	}
@@ -615,7 +615,7 @@ public class CreateNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.create.nativeType.DefaultCreateNativeType.class)
 	public DoubleType nativeType() {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.create.nativeType.DefaultCreateNativeType.class);
+			net.imagej.ops.Ops.Create.NativeType.class);
 		return result;
 	}
 
@@ -624,7 +624,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public <T extends NativeType<T>> T nativeType(final Class<T> type) {
 		@SuppressWarnings("unchecked")
 		final T result = (T) ops().run(
-			net.imagej.ops.create.nativeType.CreateNativeTypeFromClass.class, type);
+			net.imagej.ops.Ops.Create.NativeType.class, type);
 		return result;
 	}
 
@@ -634,7 +634,7 @@ public class CreateNamespace extends AbstractNamespace {
 	public <T> T object(final Class<T> in) {
 		@SuppressWarnings("unchecked")
 		final T result = (T) ops().run(
-			net.imagej.ops.create.object.CreateObjectFromClass.class, in);
+			net.imagej.ops.Ops.Create.Object.class, in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -68,7 +68,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class, null, in,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class, null, in,
 				kernel, maxIterations);
 		return result;
 	}
@@ -80,7 +80,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, maxIterations);
 		return result;
 	}
@@ -93,7 +93,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, maxIterations);
 		return result;
 	}
@@ -107,7 +107,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, maxIterations);
 		return result;
 	}
@@ -122,7 +122,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, maxIterations);
 		return result;
 	}
@@ -137,7 +137,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType,
 				maxIterations);
 		return result;
@@ -154,7 +154,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				maxIterations);
 		return result;
@@ -172,7 +172,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, maxIterations);
 		return result;
@@ -191,7 +191,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, fftFactory, maxIterations);
 		return result;
@@ -210,7 +210,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, fftFactory, maxIterations, nonCirculant);
 		return result;
@@ -230,7 +230,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, fftFactory, maxIterations, nonCirculant, accelerate);
 		return result;
@@ -244,7 +244,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final int maxIterations, final Interval imgConvolutionInterval,
 			final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, maxIterations, imgConvolutionInterval, imgFactory);
 
 	}
@@ -257,7 +257,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final int maxIterations, final Interval imgConvolutionInterval,
 			final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, maxIterations,
 			imgConvolutionInterval, imgFactory);
 
@@ -271,7 +271,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Img<C> fftInput, final int maxIterations,
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, maxIterations,
 			imgConvolutionInterval, imgFactory);
 
@@ -285,7 +285,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Img<C> fftInput, final Img<C> fftKernel, final int maxIterations,
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, maxIterations,
 			imgConvolutionInterval, imgFactory);
 
@@ -300,7 +300,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<O> output, final int maxIterations,
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			maxIterations, imgConvolutionInterval, imgFactory);
 	}
@@ -315,7 +315,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final int maxIterations, final Interval imgConvolutionInterval,
 			final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, maxIterations, imgConvolutionInterval, imgFactory);
 
@@ -331,7 +331,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final boolean performKernelFFT, final int maxIterations,
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory);
@@ -348,7 +348,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			boolean performInputFFT, boolean performKernelFFT, int maxIterations,
 			Interval imgConvolutionInterval, ImgFactory<O> imgFactory, Dimensions k)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k);
@@ -366,7 +366,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			Interval imgConvolutionInterval, ImgFactory<O> imgFactory, Dimensions k,
 			Dimensions l)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l);
@@ -384,7 +384,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			Interval imgConvolutionInterval, ImgFactory<O> imgFactory, Dimensions k,
 			Dimensions l, boolean noncirculant)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, noncirculant);
@@ -402,7 +402,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			Interval imgConvolutionInterval, ImgFactory<O> imgFactory, Dimensions k,
 			Dimensions l, boolean noncirculant, boolean accelerate)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, noncirculant, accelerate);
@@ -420,7 +420,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			Dimensions l, boolean noncirculant, boolean accelerate,
 			OutOfBoundsFactory<O, RandomAccessibleInterval<O>> obfOutput)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, noncirculant, accelerate, obfOutput);
@@ -442,7 +442,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				in, kernel, maxIterations, regularizationFactor);
 		return result;
 	}
@@ -455,7 +455,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, maxIterations, regularizationFactor);
 		return result;
 	}
@@ -468,7 +468,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, maxIterations, regularizationFactor);
 		return result;
 	}
@@ -482,7 +482,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, maxIterations,
 				regularizationFactor);
 		return result;
@@ -498,7 +498,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, maxIterations,
 				regularizationFactor);
 		return result;
@@ -515,7 +515,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType,
 				maxIterations, regularizationFactor);
 		return result;
@@ -532,7 +532,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				maxIterations, regularizationFactor);
 		return result;
@@ -551,7 +551,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, maxIterations, regularizationFactor);
 		return result;
@@ -570,7 +570,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, fftFactory, maxIterations, regularizationFactor);
 		return result;
@@ -590,7 +590,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, fftFactory, maxIterations, regularizationFactor, nonCirculant);
 		return result;
@@ -610,7 +610,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final Img<O> result =
-			(Img<O>) ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVImg.class,
+			(Img<O>) ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 				out, in, kernel, borderSize, obfInput, obfKernel, outType, outFactory,
 				fftType, fftFactory, maxIterations, regularizationFactor, nonCirculant, accelerate);
 		return result;
@@ -623,7 +623,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final int maxIterations, final Interval imgConvolutionInterval,
 			final ImgFactory<O> imgFactory, final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, maxIterations, imgConvolutionInterval, imgFactory,
 			regularizationFactor);
 	}
@@ -636,7 +636,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final int maxIterations, final Interval imgConvolutionInterval,
 			final ImgFactory<O> imgFactory, final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, maxIterations,
 			imgConvolutionInterval, imgFactory, regularizationFactor);
 	}
@@ -650,7 +650,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory,
 			final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, maxIterations,
 			imgConvolutionInterval, imgFactory, regularizationFactor);
 	}
@@ -664,7 +664,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory,
 			final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, maxIterations,
 			imgConvolutionInterval, imgFactory, regularizationFactor);
 	}
@@ -679,7 +679,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory,
 			final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			maxIterations, imgConvolutionInterval, imgFactory, regularizationFactor);
 	}
@@ -694,7 +694,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final int maxIterations, final Interval imgConvolutionInterval,
 			final ImgFactory<O> imgFactory, final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, maxIterations, imgConvolutionInterval, imgFactory,
 			regularizationFactor);
@@ -711,7 +711,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory,
 			final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, regularizationFactor);
@@ -728,7 +728,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory,
 			final Dimensions k, final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, regularizationFactor);
@@ -745,7 +745,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Interval imgConvolutionInterval, final ImgFactory<O> imgFactory,
 			final Dimensions k, final Dimensions l, final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, regularizationFactor);
@@ -763,7 +763,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Dimensions k, final Dimensions l, final boolean nonCirculant,
 			final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, nonCirculant, regularizationFactor);
@@ -781,7 +781,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final Dimensions k, final Dimensions l, final boolean nonCirculant,
 			final boolean accelerate, final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, nonCirculant, accelerate, regularizationFactor);
@@ -801,7 +801,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final OutOfBoundsFactory<O, RandomAccessibleInterval<O>> obfOutput,
 			final float regularizationFactor)
 	{
-		ops().run(net.imagej.ops.deconvolve.RichardsonLucyTVRAI.class,
+		ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class,
 			raiExtendedInput, raiExtendedKernel, fftInput, fftKernel, output,
 			performInputFFT, performKernelFFT, maxIterations, imgConvolutionInterval,
 			imgFactory, k, l, nonCirculant, accelerate, obfOutput,

--- a/src/main/java/net/imagej/ops/features/haralick/HaralickNamespace.java
+++ b/src/main/java/net/imagej/ops/features/haralick/HaralickNamespace.java
@@ -59,7 +59,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultASM.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.ASM.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -70,7 +70,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultASM.class, out, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.ASM.class, out, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -82,7 +82,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultClusterPromenence.class, in,
+			net.imagej.ops.Ops.Haralick.ClusterPromenence.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -94,7 +94,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final int distance, final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultClusterPromenence.class, out, in,
+			net.imagej.ops.Ops.Haralick.ClusterPromenence.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -105,7 +105,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultClusterShade.class, in,
+			net.imagej.ops.Ops.Haralick.ClusterShade.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -116,7 +116,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultClusterShade.class, out, in,
+			net.imagej.ops.Ops.Haralick.ClusterShade.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -127,7 +127,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultContrast.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.Contrast.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -138,7 +138,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultContrast.class, out, in,
+			net.imagej.ops.Ops.Haralick.Contrast.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -149,7 +149,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultCorrelation.class, in,
+			net.imagej.ops.Ops.Haralick.Correlation.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -160,7 +160,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultCorrelation.class, out, in,
+			net.imagej.ops.Ops.Haralick.Correlation.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -172,7 +172,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultDifferenceEntropy.class, in,
+			net.imagej.ops.Ops.Haralick.DifferenceEntropy.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -184,7 +184,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final int distance, final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultDifferenceEntropy.class, out, in,
+			net.imagej.ops.Ops.Haralick.DifferenceEntropy.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -196,7 +196,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultDifferenceVariance.class, in,
+			net.imagej.ops.Ops.Haralick.DifferenceVariance.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -208,7 +208,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final int distance, final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultDifferenceVariance.class, out, in,
+			net.imagej.ops.Ops.Haralick.DifferenceVariance.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -219,7 +219,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultEntropy.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.Entropy.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -230,7 +230,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultEntropy.class, out, in,
+			net.imagej.ops.Ops.Haralick.Entropy.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -241,7 +241,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultICM1.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.ICM1.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -252,7 +252,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultICM1.class, out, in,
+			net.imagej.ops.Ops.Haralick.ICM1.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -263,7 +263,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultICM2.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.ICM2.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -274,7 +274,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultICM2.class, out, in,
+			net.imagej.ops.Ops.Haralick.ICM2.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -285,7 +285,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultIFDM.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.IFDM.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -296,7 +296,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultIFDM.class, out, in,
+			net.imagej.ops.Ops.Haralick.IFDM.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -307,7 +307,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultMaxProbability.class, in,
+			net.imagej.ops.Ops.Haralick.MaxProbability.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -318,7 +318,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultMaxProbability.class, out, in,
+			net.imagej.ops.Ops.Haralick.MaxProbability.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -329,7 +329,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultSumAverage.class, in,
+			net.imagej.ops.Ops.Haralick.SumAverage.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -340,7 +340,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultSumAverage.class, out, in,
+			net.imagej.ops.Ops.Haralick.SumAverage.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -351,7 +351,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultSumEntropy.class, in,
+			net.imagej.ops.Ops.Haralick.SumEntropy.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -362,7 +362,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultSumEntropy.class, out, in,
+			net.imagej.ops.Ops.Haralick.SumEntropy.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -373,7 +373,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultSumVariance.class, in,
+			net.imagej.ops.Ops.Haralick.SumVariance.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -384,7 +384,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultSumVariance.class, out, in,
+			net.imagej.ops.Ops.Haralick.SumVariance.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -396,7 +396,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultTextureHomogeneity.class, in,
+			net.imagej.ops.Ops.Haralick.TextureHomogeneity.class, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -408,7 +408,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final int distance, final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultTextureHomogeneity.class, out, in,
+			net.imagej.ops.Ops.Haralick.TextureHomogeneity.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}
@@ -419,7 +419,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultVariance.class, in, numGreyLevels,
+			net.imagej.ops.Ops.Haralick.Variance.class, in, numGreyLevels,
 			distance, orientation);
 		return result;
 	}
@@ -430,7 +430,7 @@ public class HaralickNamespace extends AbstractNamespace {
 		final MatrixOrientation orientation)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.features.haralick.DefaultVariance.class, out, in,
+			net.imagej.ops.Ops.Haralick.Variance.class, out, in,
 			numGreyLevels, distance, orientation);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/features/lbp2d/LBPNamespace.java
+++ b/src/main/java/net/imagej/ops/features/lbp2d/LBPNamespace.java
@@ -61,7 +61,7 @@ public class LBPNamespace extends AbstractNamespace {
 		final int histogramSize)
 	{
 		final ArrayList<LongType> result = (ArrayList<LongType>) ops().run(
-			net.imagej.ops.features.lbp2d.DefaultLBP2D.class, in, distance,
+			net.imagej.ops.Ops.LBP.LBP2D.class, in, distance,
 			histogramSize);
 		return result;
 	}
@@ -73,7 +73,7 @@ public class LBPNamespace extends AbstractNamespace {
 		final int distance, final int histogramSize)
 	{
 		final ArrayList<LongType> result = (ArrayList<LongType>) ops().run(
-			net.imagej.ops.features.lbp2d.DefaultLBP2D.class, out, in, distance,
+			net.imagej.ops.Ops.LBP.LBP2D.class, out, in, distance,
 			histogramSize);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/features/tamura2d/TamuraNamespace.java
+++ b/src/main/java/net/imagej/ops/features/tamura2d/TamuraNamespace.java
@@ -55,7 +55,7 @@ public class TamuraNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.tamura2d.DefaultContrastFeature.class)
 	public <I extends RealType<I>, O extends RealType<O>> O contrast(final RandomAccessibleInterval<I> in) {
 
-		final O result = (O) ops().run(net.imagej.ops.features.tamura2d.DefaultContrastFeature.class, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Tamura.Contrast.class, in);
 
 		return result;
 	}
@@ -64,7 +64,7 @@ public class TamuraNamespace extends AbstractNamespace {
 	public <I extends RealType<I>, O extends RealType<O>> O contrast(final O out,
 			final RandomAccessibleInterval<I> in) {
 
-		final O result = (O) ops().run(net.imagej.ops.features.tamura2d.DefaultContrastFeature.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Tamura.Contrast.class, out, in);
 
 		return result;
 	}
@@ -72,7 +72,7 @@ public class TamuraNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.tamura2d.DefaultDirectionalityFeature.class)
 	public <I extends RealType<I>, O extends RealType<O>> O directionality(final RandomAccessibleInterval<I> in,
 			final int histogramSize) {
-		final O result = (O) ops().run(net.imagej.ops.features.tamura2d.DefaultDirectionalityFeature.class, in,
+		final O result = (O) ops().run(net.imagej.ops.Ops.Tamura.Directionality.class, in,
 				histogramSize);
 		return result;
 	}
@@ -80,7 +80,7 @@ public class TamuraNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.tamura2d.DefaultDirectionalityFeature.class)
 	public <I extends RealType<I>, O extends RealType<O>> O directionality(final O out,
 			final RandomAccessibleInterval<I> in, final int histogramSize) {
-		final O result = (O) ops().run(net.imagej.ops.features.tamura2d.DefaultDirectionalityFeature.class, out, in,
+		final O result = (O) ops().run(net.imagej.ops.Ops.Tamura.Directionality.class, out, in,
 				histogramSize);
 		return result;
 	}
@@ -88,7 +88,7 @@ public class TamuraNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.tamura2d.DefaultCoarsenessFeature.class)
 	public <I extends RealType<I>, O extends RealType<O>> O coarseness(final RandomAccessibleInterval<I> in) {
 
-		final O result = (O) ops().run(net.imagej.ops.features.tamura2d.DefaultCoarsenessFeature.class, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Tamura.Coarseness.class, in);
 
 		return result;
 	}
@@ -97,7 +97,7 @@ public class TamuraNamespace extends AbstractNamespace {
 	public <I extends RealType<I>, O extends RealType<O>> O coarseness(final O out,
 			final RandomAccessibleInterval<I> in) {
 
-		final O result = (O) ops().run(net.imagej.ops.features.tamura2d.DefaultCoarsenessFeature.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Tamura.Coarseness.class, out, in);
 
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/features/zernike/ZernikeNamespace.java
+++ b/src/main/java/net/imagej/ops/features/zernike/ZernikeNamespace.java
@@ -55,7 +55,7 @@ public class ZernikeNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.zernike.DefaultPhaseFeature.class)
 	public <T extends RealType<T>, O extends RealType<O>> O phase(final IterableInterval<T> in, final int order,
 			final int repitition) {
-		final O result = (O) ops().run(net.imagej.ops.features.zernike.DefaultPhaseFeature.class, in, order,
+		final O result = (O) ops().run(net.imagej.ops.Ops.Zernike.Phase.class, in, order,
 				repitition);
 		return result;
 	}
@@ -63,7 +63,7 @@ public class ZernikeNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.zernike.DefaultPhaseFeature.class)
 	public <T extends RealType<T>, O extends RealType<O> > O phase(final O out, final IterableInterval<T> in, final int order,
 			final int repitition) {
-		final O result = (O) ops().run(net.imagej.ops.features.zernike.DefaultPhaseFeature.class, out, in, order,
+		final O result = (O) ops().run(net.imagej.ops.Ops.Zernike.Phase.class, out, in, order,
 				repitition);
 		return result;
 	}
@@ -71,7 +71,7 @@ public class ZernikeNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.zernike.DefaultMagnitudeFeature.class)
 	public <T extends RealType<T>, O extends RealType<O>> O magnitude(final IterableInterval<T> in, final int order,
 			final int repitition) {
-		final O result = (O) ops().run(net.imagej.ops.features.zernike.DefaultMagnitudeFeature.class, in, order,
+		final O result = (O) ops().run(net.imagej.ops.Ops.Zernike.Magnitude.class, in, order,
 				repitition);
 		return result;
 	}
@@ -79,7 +79,7 @@ public class ZernikeNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.features.zernike.DefaultMagnitudeFeature.class)
 	public <T extends RealType<T>, O extends RealType<O>> O magnitude(final O out, final IterableInterval<T> in, final int order,
 			final int repitition) {
-		final O result = (O) ops().run(net.imagej.ops.features.zernike.DefaultMagnitudeFeature.class, out, in, order,
+		final O result = (O) ops().run(net.imagej.ops.Ops.Zernike.Magnitude.class, out, in, order,
 				repitition);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/geom/GeomNamespace.java
+++ b/src/main/java/net/imagej/ops/geom/GeomNamespace.java
@@ -68,7 +68,7 @@ public class GeomNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultSurfacePixelCount.class)
 	public DoubleType boundarypixelcount(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultSurfacePixelCount.class, in);
+			net.imagej.ops.Ops.Geometric.BoundaryPixelCount.class, in);
 		return result;
 	}
 
@@ -76,7 +76,7 @@ public class GeomNamespace extends AbstractNamespace {
 		op = net.imagej.ops.geom.geom2d.BoundaryPixelCountConvexHullPolygon.class)
 	public DoubleType boundarypixelcountconvexhull(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.BoundaryPixelCountConvexHullPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.BoundaryPixelCountConvexHull.class, in);
 		return result;
 	}
 
@@ -84,91 +84,91 @@ public class GeomNamespace extends AbstractNamespace {
 		op = net.imagej.ops.geom.geom3d.BoundaryPixelCountConvexHullMesh.class)
 	public DoubleType boundarypixelcountconvexhull(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.BoundaryPixelCountConvexHullMesh.class, in);
+			net.imagej.ops.Ops.Geometric.BoundaryPixelCountConvexHull.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultSurfaceArea.class)
 	public DoubleType boundarysize(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultSurfaceArea.class, in);
+			net.imagej.ops.Ops.Geometric.BoundarySize.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultPerimeterLength.class)
 	public DoubleType boundarysize(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultPerimeterLength.class, in);
+			net.imagej.ops.Ops.Geometric.BoundarySize.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.BoundarySizeConvexHullPolygon.class)
 	public DoubleType boundarysizeconvexhull(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.BoundarySizeConvexHullPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.BoundarySizeConvexHull.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.BoundarySizeConvexHullMesh.class)
 	public DoubleType boundarysizeconvexhull(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.BoundarySizeConvexHullMesh.class, in);
+			net.imagej.ops.Ops.Geometric.BoundarySizeConvexHull.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.BoxivityPolygon.class)
 	public DoubleType boxivity(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.BoxivityPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.Boxivity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.BoxivityMesh.class)
 	public DoubleType boxivity(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.BoxivityMesh.class, in);
+			net.imagej.ops.Ops.Geometric.Boxivity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.CentroidLabelRegion.class)
 	public RealLocalizable centroid(final LabelRegion<?> in) {
 		final RealLocalizable result = (RealLocalizable) ops().run(
-			net.imagej.ops.geom.CentroidLabelRegion.class, in);
+			net.imagej.ops.Ops.Geometric.Centroid.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.CentroidII.class)
 	public RealLocalizable centroid(final IterableInterval<?> in) {
 		final RealLocalizable result = (RealLocalizable) ops().run(
-			net.imagej.ops.geom.CentroidII.class, in);
+			net.imagej.ops.Ops.Geometric.Centroid.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.CentroidPolygon.class)
 	public RealLocalizable centroid(final Polygon in) {
 		final RealLocalizable result = (RealLocalizable) ops().run(
-			net.imagej.ops.geom.CentroidPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.Centroid.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.CentroidMesh.class)
 	public RealLocalizable centroid(final Mesh in) {
 		final RealLocalizable result = (RealLocalizable) ops().run(
-			net.imagej.ops.geom.CentroidMesh.class, in);
+			net.imagej.ops.Ops.Geometric.Centroid.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultCircularity.class)
 	public DoubleType circularity(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultCircularity.class, in);
+			net.imagej.ops.Ops.Geometric.Circularity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultCompactness.class)
 	public DoubleType compactness(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultCompactness.class, in);
+			net.imagej.ops.Ops.Geometric.Compactness.class, in);
 		return result;
 	}
 
@@ -178,7 +178,7 @@ public class GeomNamespace extends AbstractNamespace {
 		final boolean isInverted)
 	{
 		final Polygon result = (Polygon) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultContour.class, in, useJacobs,
+			net.imagej.ops.Ops.Geometric.Contour.class, in, useJacobs,
 			isInverted);
 		return result;
 	}
@@ -200,21 +200,21 @@ public class GeomNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.geom.geom2d.ConvexityPolygon.class)
 	public DoubleType convexity(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.ConvexityPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.Convexity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.ConvexityMesh.class)
 	public DoubleType convexity(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.ConvexityMesh.class, in);
+			net.imagej.ops.Ops.Geometric.Convexity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultEccentricity.class)
 	public DoubleType eccentricity(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultEccentricity.class, in);
+			net.imagej.ops.Ops.Geometric.Eccentricity.class, in);
 		return result;
 	}
 
@@ -223,21 +223,21 @@ public class GeomNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Pair<RealLocalizable, RealLocalizable> result =
 			(Pair<RealLocalizable, RealLocalizable>) ops().run(
-				net.imagej.ops.geom.geom2d.DefaultFeret.class, in);
+				net.imagej.ops.Ops.Geometric.Feret.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultFeretsAngle.class)
 	public DoubleType feretsangle(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultFeretsAngle.class, in);
+			net.imagej.ops.Ops.Geometric.FeretsAngle.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultFeretsDiameter.class)
 	public DoubleType feretsdiameter(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultFeretsDiameter.class, in);
+			net.imagej.ops.Ops.Geometric.FeretsDiameter.class, in);
 		return result;
 	}
 
@@ -246,21 +246,21 @@ public class GeomNamespace extends AbstractNamespace {
 		final IterableRegion<B> in)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultMainElongation.class, in);
+			net.imagej.ops.Ops.Geometric.MainElongation.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultElongation.class)
 	public DoubleType mainelongation(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultElongation.class, in);
+			net.imagej.ops.Ops.Geometric.MainElongation.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultMajorAxis.class)
 	public DoubleType majoraxis(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultMajorAxis.class, in);
+			net.imagej.ops.Ops.Geometric.MajorAxis.class, in);
 		return result;
 	}
 
@@ -269,7 +269,7 @@ public class GeomNamespace extends AbstractNamespace {
 		final RandomAccessibleInterval<T> in)
 	{
 		final Mesh result = (Mesh) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultMarchingCubes.class, in);
+			net.imagej.ops.Ops.Geometric.MarchingCubes.class, in);
 		return result;
 	}
 
@@ -278,7 +278,7 @@ public class GeomNamespace extends AbstractNamespace {
 		final RandomAccessibleInterval<T> in, final double isolevel)
 	{
 		final Mesh result = (Mesh) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultMarchingCubes.class, in, isolevel);
+			net.imagej.ops.Ops.Geometric.MarchingCubes.class, in, isolevel);
 		return result;
 	}
 
@@ -288,7 +288,7 @@ public class GeomNamespace extends AbstractNamespace {
 		final VertexInterpolator interpolatorClass)
 	{
 		final Mesh result = (Mesh) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultMarchingCubes.class, in, isolevel,
+			net.imagej.ops.Ops.Geometric.MarchingCubes.class, in, isolevel,
 			interpolatorClass);
 		return result;
 	}
@@ -298,35 +298,35 @@ public class GeomNamespace extends AbstractNamespace {
 		final IterableRegion<B> in)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultMedianElongation.class, in);
+			net.imagej.ops.Ops.Geometric.MedianElongation.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultMinorAxis.class)
 	public DoubleType minoraxis(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultMinorAxis.class, in);
+			net.imagej.ops.Ops.Geometric.MinorAxis.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultRoundness.class)
 	public DoubleType roundness(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultRoundness.class, in);
+			net.imagej.ops.Ops.Geometric.Roundness.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.RugosityPolygon.class)
 	public DoubleType rugosity(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.RugosityPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.Rugosity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.RugosityMesh.class)
 	public DoubleType rugosity(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.RugosityMesh.class, in);
+			net.imagej.ops.Ops.Geometric.Rugosity.class, in);
 		return result;
 	}
 
@@ -335,7 +335,7 @@ public class GeomNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Pair<DoubleType, DoubleType> result =
 			(Pair<DoubleType, DoubleType>) ops().run(
-				net.imagej.ops.geom.geom2d.DefaultMinorMajorAxis.class, in);
+				net.imagej.ops.Ops.Geometric.SecondMultiVariate.class, in);
 		return result;
 	}
 
@@ -345,42 +345,42 @@ public class GeomNamespace extends AbstractNamespace {
 	{
 		final CovarianceOf2ndMultiVariate3D result =
 			(CovarianceOf2ndMultiVariate3D) ops().run(
-				net.imagej.ops.geom.geom3d.DefaultSecondMultiVariate3D.class, in);
+				net.imagej.ops.Ops.Geometric.SecondMultiVariate.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultSizePolygon.class)
 	public DoubleType size(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultSizePolygon.class, in);
+			net.imagej.ops.Ops.Geometric.Size.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.SizeII.class)
 	public DoubleType size(final IterableInterval<?> in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.SizeII.class, in);
+			net.imagej.ops.Ops.Geometric.Size.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.mesh.DefaultVolume.class)
 	public DoubleType size(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.mesh.DefaultVolume.class, in);
+			net.imagej.ops.Ops.Geometric.Size.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.SizeConvexHullMesh.class)
 	public DoubleType sizeconvexhull(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.SizeConvexHullMesh.class, in);
+			net.imagej.ops.Ops.Geometric.SizeConvexHull.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.SizeConvexHullPolygon.class)
 	public DoubleType sizeconvexhull(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.SizeConvexHullPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.SizeConvexHull.class, in);
 		return result;
 	}
 
@@ -388,21 +388,21 @@ public class GeomNamespace extends AbstractNamespace {
 		op = net.imagej.ops.geom.geom2d.DefaultSmallestEnclosingRectangle.class)
 	public Polygon smallestenclosingboundingbox(final Polygon in) {
 		final Polygon result = (Polygon) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultSmallestEnclosingRectangle.class, in);
+			net.imagej.ops.Ops.Geometric.SmallestEnclosingBoundingBox.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.SolidityPolygon.class)
 	public DoubleType solidity(final Polygon in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom2d.SolidityPolygon.class, in);
+			net.imagej.ops.Ops.Geometric.Solidity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.SolidityMesh.class)
 	public DoubleType solidity(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.SolidityMesh.class, in);
+			net.imagej.ops.Ops.Geometric.Solidity.class, in);
 		return result;
 	}
 
@@ -411,21 +411,21 @@ public class GeomNamespace extends AbstractNamespace {
 		final IterableRegion<B> in)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultSpareness.class, in);
+			net.imagej.ops.Ops.Geometric.Spareness.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultSphericity.class)
 	public DoubleType sphericity(final Mesh in) {
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.geom.geom3d.DefaultSphericity.class, in);
+			net.imagej.ops.Ops.Geometric.Sphericity.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultBoundingBox.class)
 	public Polygon boundingbox(final Polygon in) {
 		final Polygon result = (Polygon) ops().run(
-			net.imagej.ops.geom.geom2d.DefaultBoundingBox.class, in);
+			net.imagej.ops.Ops.Geometric.BoundingBox.class, in);
 		return result;
 	}
 
@@ -435,7 +435,7 @@ public class GeomNamespace extends AbstractNamespace {
 		final double p1Value, final double p2Value, final double isolevel)
 	{
 		final double[] result = (double[]) ops().run(
-			net.imagej.ops.geom.geom3d.mesh.DefaultVertexInterpolator.class, p1, p2,
+			net.imagej.ops.Ops.Geometric.VertexInterpolator.class, p1, p2,
 			p1Value, p2Value, isolevel);
 		return result;
 	}
@@ -446,14 +446,14 @@ public class GeomNamespace extends AbstractNamespace {
 		final double p1Value, final double p2Value)
 	{
 		final double[] result = (double[]) ops().run(
-			net.imagej.ops.geom.geom3d.mesh.BitTypeVertexInterpolator.class, p1, p2,
+			net.imagej.ops.Ops.Geometric.VertexInterpolator.class, p1, p2,
 			p1Value, p2Value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.DefaultCenterOfGravity.class)
 	public <T extends RealType<T>> RealLocalizable centerofgravity(final IterableInterval<T> in) {
-		final RealLocalizable result = (RealLocalizable) ops().run(net.imagej.ops.geom.DefaultCenterOfGravity.class,
+		final RealLocalizable result = (RealLocalizable) ops().run(net.imagej.ops.Ops.Geometric.CenterOfGravity.class,
 				in);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -62,14 +62,14 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "ascii" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.ASCII.class)
 	public Object ascii(final Object... args) {
-		return ops().run(Ops.Image.ASCII.NAME, args);
+		return ops().run(Ops.Image.ASCII.class, args);
 	}
 
 	/** Executes the "ascii" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.ascii.DefaultASCII.class)
 	public <T extends RealType<T>> String ascii(final IterableInterval<T> image) {
 		final String result = (String) ops().run(
-				net.imagej.ops.image.ascii.DefaultASCII.class, image);
+				net.imagej.ops.Ops.Image.ASCII.class, image);
 		return result;
 	}
 
@@ -79,7 +79,7 @@ public class ImageNamespace extends AbstractNamespace {
 		final T min)
 	{
 		final String result = (String) ops().run(
-				net.imagej.ops.image.ascii.DefaultASCII.class, image, min);
+				net.imagej.ops.Ops.Image.ASCII.class, image, min);
 		return result;
 	}
 
@@ -89,7 +89,7 @@ public class ImageNamespace extends AbstractNamespace {
 		final T min, final T max)
 	{
 		final String result = (String) ops().run(
-				net.imagej.ops.image.ascii.DefaultASCII.class, image, min, max);
+				net.imagej.ops.Ops.Image.ASCII.class, image, min, max);
 		return result;
 	}
 
@@ -112,7 +112,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "crop" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Crop.class)
 	public Object crop(final Object... args) {
-		return ops().run(Ops.Image.Crop.NAME, args);
+		return ops().run(Ops.Image.Crop.class, args);
 	}
 
 	/** Executes the "crop" operation on the given arguments. */
@@ -121,7 +121,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final Interval interval) {
 		@SuppressWarnings("unchecked")
 		final ImgPlus<T> result = (ImgPlus<T>) ops().run(
-				net.imagej.ops.image.crop.CropImgPlus.class, in, interval);
+				net.imagej.ops.Ops.Image.Crop.class, in, interval);
 		return result;
 	}
 
@@ -131,7 +131,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final Interval interval, final boolean dropSingleDimensions) {
 		@SuppressWarnings("unchecked")
 		final ImgPlus<T> result = (ImgPlus<T>) ops().run(
-				net.imagej.ops.image.crop.CropImgPlus.class, in, interval,
+				net.imagej.ops.Ops.Image.Crop.class, in, interval,
 				dropSingleDimensions);
 		return result;
 	}
@@ -142,7 +142,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<T> in, final Interval interval) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(net.imagej.ops.image.crop.CropRAI.class, in, interval);
+				.run(net.imagej.ops.Ops.Image.Crop.class, in, interval);
 		return result;
 	}
 
@@ -153,7 +153,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final boolean dropSingleDimensions) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(net.imagej.ops.image.crop.CropRAI.class, in, interval,
+				.run(net.imagej.ops.Ops.Image.Crop.class, in, interval,
 						dropSingleDimensions);
 		return result;
 	}
@@ -163,7 +163,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "equation" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Equation.class)
 	public Object equation(final Object... args) {
-		return ops().run(Ops.Image.Equation.NAME, args);
+		return ops().run(Ops.Image.Equation.class, args);
 	}
 
 	/** Executes the "equation" operation on the given arguments. */
@@ -171,7 +171,7 @@ public class ImageNamespace extends AbstractNamespace {
 	public <T extends RealType<T>> IterableInterval<T> equation(final String in) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-				net.imagej.ops.image.equation.DefaultEquation.class, in);
+				net.imagej.ops.Ops.Image.Equation.class, in);
 		return result;
 	}
 
@@ -181,7 +181,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final IterableInterval<T> out, final String in) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-				net.imagej.ops.image.equation.DefaultEquation.class, out, in);
+				net.imagej.ops.Ops.Image.Equation.class, out, in);
 		return result;
 	}
 
@@ -190,7 +190,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "histogram" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Histogram.class)
 	public Object histogram(final Object... args) {
-		return ops().run(Ops.Image.Histogram.NAME, args);
+		return ops().run(Ops.Image.Histogram.class, args);
 	}
 
 	/** Executes the "histogram" operation on the given arguments. */
@@ -198,7 +198,7 @@ public class ImageNamespace extends AbstractNamespace {
 	public <T extends RealType<T>> Histogram1d<T> histogram(final Iterable<T> in) {
 		@SuppressWarnings("unchecked")
 		final Histogram1d<T> result = (Histogram1d<T>) ops().run(
-				net.imagej.ops.image.histogram.HistogramCreate.class, in);
+				net.imagej.ops.Ops.Image.Histogram.class, in);
 		return result;
 	}
 
@@ -208,7 +208,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final Iterable<T> in, final int numBins) {
 		@SuppressWarnings("unchecked")
 		final Histogram1d<T> result = (Histogram1d<T>) ops().run(
-				net.imagej.ops.image.histogram.HistogramCreate.class, in,
+				net.imagej.ops.Ops.Image.Histogram.class, in,
 				numBins);
 		return result;
 	}
@@ -218,7 +218,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "invert" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Invert.class)
 	public Object invert(final Object... args) {
-		return ops().run(Ops.Image.Invert.NAME, args);
+		return ops().run(Ops.Image.Invert.class, args);
 	}
 
 	/** Executes the "invert" operation on the given arguments. */
@@ -227,7 +227,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final IterableInterval<O> out, final IterableInterval<I> in) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.image.invert.InvertII.class, out,
+				net.imagej.ops.Ops.Image.Invert.class, out,
 				in);
 		return result;
 	}
@@ -237,7 +237,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "normalize" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Normalize.class)
 	public Object normalize(final Object... args) {
-		return ops().run(Ops.Image.Normalize.NAME, args);
+		return ops().run(Ops.Image.Normalize.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
@@ -248,7 +248,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops()
-				.run(net.imagej.ops.image.normalize.NormalizeIIComputer.class,
+				.run(net.imagej.ops.Ops.Image.Normalize.class,
 					out, in);
 		return result;
 	}
@@ -262,7 +262,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIComputer.class, out,
+				net.imagej.ops.Ops.Image.Normalize.class, out,
 				in, sourceMin);
 		return result;
 	}
@@ -276,7 +276,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIComputer.class, out,
+				net.imagej.ops.Ops.Image.Normalize.class, out,
 				in, sourceMin, sourceMax);
 		return result;
 	}
@@ -290,7 +290,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIComputer.class, out,
+				net.imagej.ops.Ops.Image.Normalize.class, out,
 				in, sourceMin, sourceMax, targetMin);
 		return result;
 	}
@@ -305,7 +305,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIComputer.class, out,
+				net.imagej.ops.Ops.Image.Normalize.class, out,
 				in, sourceMin, sourceMax, targetMin, targetMax);
 		return result;
 	}
@@ -319,7 +319,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIFunction.class,
+				net.imagej.ops.Ops.Image.Normalize.class,
 				in);
 		return result;
 	}
@@ -333,7 +333,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIFunction.class,
+				net.imagej.ops.Ops.Image.Normalize.class,
 				in, sourceMin);
 		return result;
 	}
@@ -347,7 +347,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIFunction.class,
+				net.imagej.ops.Ops.Image.Normalize.class,
 				in, sourceMin, sourceMax);
 		return result;
 	}
@@ -362,7 +362,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIFunction.class,
+				net.imagej.ops.Ops.Image.Normalize.class,
 				in, sourceMin, sourceMax, targetMin);
 		return result;
 	}
@@ -377,7 +377,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIFunction.class,
+				net.imagej.ops.Ops.Image.Normalize.class,
 				in, sourceMin, sourceMax, targetMin, targetMax);
 		return result;
 	}
@@ -392,7 +392,7 @@ public class ImageNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
-				net.imagej.ops.image.normalize.NormalizeIIFunction.class,
+				net.imagej.ops.Ops.Image.Normalize.class,
 				in, sourceMin, sourceMax, targetMin, targetMax, isLazy);
 		return result;
 	}
@@ -402,7 +402,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "project" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Project.class)
 	public Object project(final Object... args) {
-		return ops().run(Ops.Image.Project.NAME, args);
+		return ops().run(Ops.Image.Project.class, args);
 	}
 
 	/** Executes the "project" operation on the given arguments. */
@@ -423,7 +423,7 @@ public class ImageNamespace extends AbstractNamespace {
 	/** Executes the "scale" operation on the given arguments. */
 	@OpMethod(op = Ops.Image.Scale.class)
 	public Object scale(final Object... args) {
-		return ops().run(Ops.Image.Scale.NAME, args);
+		return ops().run(Ops.Image.Scale.class, args);
 	}
 
 	/** Executes the "scale" operation on the given arguments. */
@@ -433,7 +433,7 @@ public class ImageNamespace extends AbstractNamespace {
 			final InterpolatorFactory<T, RandomAccessible<T>> interpolator) {
 		@SuppressWarnings("unchecked")
 		final Img<T> result = (Img<T>) ops().run(
-				net.imagej.ops.image.scale.ScaleImg.class, in, scaleFactors,
+				net.imagej.ops.Ops.Image.Scale.class, in, scaleFactors,
 				interpolator);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/imagemoments/ImageMomentsNamespace.java
+++ b/src/main/java/net/imagej/ops/imagemoments/ImageMomentsNamespace.java
@@ -79,7 +79,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment01.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment01.class,
 					in);
 		return result;
 	}
@@ -93,7 +93,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment01.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment01.class,
 					out, in);
 		return result;
 	}
@@ -107,7 +107,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment02.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment02.class,
 					in);
 		return result;
 	}
@@ -121,7 +121,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment02.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment02.class,
 					out, in);
 		return result;
 	}
@@ -135,7 +135,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment03.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment03.class,
 					in);
 		return result;
 	}
@@ -149,7 +149,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment03.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment03.class,
 					out, in);
 		return result;
 	}
@@ -163,7 +163,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment10.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment10.class,
 					in);
 		return result;
 	}
@@ -177,7 +177,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment10.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment10.class,
 					out, in);
 		return result;
 	}
@@ -214,7 +214,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment12.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment12.class,
 					in);
 		return result;
 	}
@@ -228,7 +228,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment12.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment12.class,
 					out, in);
 		return result;
 	}
@@ -242,7 +242,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment20.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment20.class,
 					in);
 		return result;
 	}
@@ -256,7 +256,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment20.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment20.class,
 					out, in);
 		return result;
 	}
@@ -270,7 +270,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment21.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment21.class,
 					in);
 		return result;
 	}
@@ -284,7 +284,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment21.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment21.class,
 					out, in);
 		return result;
 	}
@@ -298,7 +298,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment30.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment30.class,
 					in);
 		return result;
 	}
@@ -312,7 +312,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.centralmoments.DefaultCentralMoment30.class,
+					net.imagej.ops.Ops.ImageMoments.CentralMoment30.class,
 					out, in);
 		return result;
 	}
@@ -322,7 +322,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment00.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment00.class,
 				in);
 		return result;
 	}
@@ -332,7 +332,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment00.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment00.class,
 				out, in);
 		return result;
 	}
@@ -342,7 +342,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment01.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment01.class,
 				in);
 		return result;
 	}
@@ -352,7 +352,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment01.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment01.class,
 				out, in);
 		return result;
 	}
@@ -362,7 +362,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment10.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment10.class,
 				in);
 		return result;
 	}
@@ -372,7 +372,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment10.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment10.class,
 				out, in);
 		return result;
 	}
@@ -382,7 +382,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment11.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment11.class,
 				in);
 		return result;
 	}
@@ -392,7 +392,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.moments.DefaultMoment11.class,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.Moment11.class,
 				out, in);
 		return result;
 	}
@@ -406,7 +406,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment02.class,
 					in);
 		return result;
 	}
@@ -420,7 +420,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment02.class,
 					out, in);
 		return result;
 	}
@@ -434,7 +434,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment03.class,
 					in);
 		return result;
 	}
@@ -448,7 +448,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment03.class,
 					out, in);
 		return result;
 	}
@@ -462,7 +462,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment11.class,
 					in);
 		return result;
 	}
@@ -476,7 +476,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment11.class,
 					out, in);
 		return result;
 	}
@@ -490,7 +490,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment12.class,
 					in);
 		return result;
 	}
@@ -504,7 +504,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment12.class,
 					out, in);
 		return result;
 	}
@@ -518,7 +518,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment20.class,
 					in);
 		return result;
 	}
@@ -532,7 +532,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment20.class,
 					out, in);
 		return result;
 	}
@@ -546,7 +546,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment21.class,
 					in);
 		return result;
 	}
@@ -560,7 +560,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment21.class,
 					out, in);
 		return result;
 	}
@@ -574,7 +574,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment30.class,
 					in);
 		return result;
 	}
@@ -588,7 +588,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O result =
 			(O) ops()
 				.run(
-					net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30.class,
+					net.imagej.ops.Ops.ImageMoments.NormalizedCentralMoment30.class,
 					out, in);
 		return result;
 	}
@@ -598,7 +598,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment1.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment1.class, in);
 		return result;
 	}
 
@@ -607,7 +607,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment1.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment1.class, out,
 				in);
 		return result;
 	}
@@ -617,7 +617,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment2.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment2.class, in);
 		return result;
 	}
 
@@ -626,7 +626,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment2.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment2.class, out,
 				in);
 		return result;
 	}
@@ -636,7 +636,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment3.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment3.class, in);
 		return result;
 	}
 
@@ -645,7 +645,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment3.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment3.class, out,
 				in);
 		return result;
 	}
@@ -655,7 +655,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment4.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment4.class, in);
 		return result;
 	}
 
@@ -664,7 +664,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment4.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment4.class, out,
 				in);
 		return result;
 	}
@@ -674,7 +674,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment5.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment5.class, in);
 		return result;
 	}
 
@@ -683,7 +683,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment5.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment5.class, out,
 				in);
 		return result;
 	}
@@ -693,7 +693,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment6.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment6.class, in);
 		return result;
 	}
 
@@ -702,7 +702,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment6.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment6.class, out,
 				in);
 		return result;
 	}
@@ -712,7 +712,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment7.class, in);
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment7.class, in);
 		return result;
 	}
 
@@ -721,7 +721,7 @@ public class ImageMomentsNamespace extends AbstractNamespace {
 		final O out, final IterableInterval<I> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.imagemoments.hu.DefaultHuMoment7.class, out,
+			(O) ops().run(net.imagej.ops.Ops.ImageMoments.HuMoment7.class, out,
 				in);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
+++ b/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
@@ -65,7 +65,7 @@ public class LabelingNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, I> result =
 			(ImgLabeling<L, I>) ops().run(
-				net.imagej.ops.labeling.cca.DefaultCCA.class, out, in, element,
+				net.imagej.ops.Ops.Labeling.CCA.class, out, in, element,
 				labelGenerator);
 		return result;
 	}
@@ -78,7 +78,7 @@ public class LabelingNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, I> result =
 			(ImgLabeling<L, I>) ops().run(
-				net.imagej.ops.labeling.cca.DefaultCCA.class, out, in, element);
+				net.imagej.ops.Ops.Labeling.CCA.class, out, in, element);
 		return result;
 	}
 
@@ -90,7 +90,7 @@ public class LabelingNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final ImgLabeling<L, I> result =
 			(ImgLabeling<L, I>) ops().run(
-				net.imagej.ops.labeling.cca.DefaultCCA.class, in, element);
+				net.imagej.ops.Ops.Labeling.CCA.class, in, element);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -94,7 +94,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Abs.class)
 	public <I extends RealType<I>, O extends RealType<O>> O abs(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Abs.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Abs.class, out, in);
 		return result;
 	}
 
@@ -183,7 +183,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <T extends NumericType<T>> IterableInterval<T> add(final IterableInterval<T> out,
 			final IterableInterval<T> in1, final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result = (IterableInterval<T>) ops().run(net.imagej.ops.math.IIToIIOutputII.Add.class,
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(net.imagej.ops.Ops.Math.Add.class,
 				out, in1, in2);
 		return result;
 	}
@@ -192,7 +192,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <T extends NumericType<T>> IterableInterval<T> add(final IterableInterval<T> in1,
 			final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result = (IterableInterval<T>) ops().run(net.imagej.ops.math.IIToIIOutputII.Add.class,
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(net.imagej.ops.Ops.Math.Add.class,
 				in1, in2);
 		return result;
 	}
@@ -208,7 +208,7 @@ public class MathNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Add.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Add.class, in1, in2);
 		return result;
 	}
 
@@ -217,7 +217,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Add.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Add.class, out, in1, in2);
 		return result;
 	}
 
@@ -225,7 +225,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <T extends NumericType<T>> IterableInterval<T> add(final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Add.class, in, value);
+				.run(net.imagej.ops.Ops.Math.Add.class, in, value);
 		return result;
 	}
 
@@ -234,7 +234,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Add.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Add.class, out, in, value);
 		return result;
 	}
 
@@ -247,7 +247,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Add.class)
 	public <I extends RealType<I>, O extends RealType<O>> O add(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Add.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Add.class, out, in, constant);
 		return result;
 	}
 
@@ -255,7 +255,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O add(final O out, final I1 in1,
 			final I2 in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Add.class, out, in1, in2);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Add.class, out, in1, in2);
 		return result;
 	}
 
@@ -277,7 +277,7 @@ public class MathNamespace extends AbstractNamespace {
 	public PlanarImg<DoubleType, DoubleArray> add(final PlanarImg<DoubleType, DoubleArray> image, final double value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<DoubleType, DoubleArray> result = (PlanarImg<DoubleType, DoubleArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.AddDouble.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Add.class, image, value);
 		return result;
 	}
 
@@ -285,7 +285,7 @@ public class MathNamespace extends AbstractNamespace {
 	public PlanarImg<FloatType, FloatArray> add(final PlanarImg<FloatType, FloatArray> image, final float value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<FloatType, FloatArray> result = (PlanarImg<FloatType, FloatArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.AddFloat.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Add.class, image, value);
 		return result;
 	}
 
@@ -321,14 +321,14 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputRAI.Add.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Add.class, out, in, value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
 	public <T extends NumericType<T>> T add(final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Add.class, in, b);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Add.class, in, b);
 		return result;
 	}
 
@@ -355,7 +355,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.AndConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O and(final O out, final I in, final long constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.AndConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.And.class, out, in, constant);
 		return result;
 	}
 
@@ -363,7 +363,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O and(final O out, final I1 in1,
 			final I2 in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.And.class, out, in1, in2);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.And.class, out, in1, in2);
 		return result;
 	}
 
@@ -381,7 +381,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arccos.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccos(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccos.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccos.class, out, in);
 		return result;
 	}
 
@@ -393,7 +393,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arccosh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccosh(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccosh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccosh.class, out, in);
 		return result;
 	}
 
@@ -405,7 +405,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arccot.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccot(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccot.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccot.class, out, in);
 		return result;
 	}
 
@@ -417,7 +417,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arccoth.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccoth(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccoth.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccoth.class, out, in);
 		return result;
 	}
 
@@ -429,7 +429,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arccsc.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccsc(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccsc.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccsc.class, out, in);
 		return result;
 	}
 
@@ -441,7 +441,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arccsch.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccsch(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arccsch.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccsch.class, out, in);
 		return result;
 	}
 
@@ -453,7 +453,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsec.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arcsec(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsec.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arcsec.class, out, in);
 		return result;
 	}
 
@@ -465,7 +465,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsech.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arcsech(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsech.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arcsech.class, out, in);
 		return result;
 	}
 
@@ -483,7 +483,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsin.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arcsin(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsin.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arcsin.class, out, in);
 		return result;
 	}
 
@@ -495,7 +495,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arcsinh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arcsinh(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arcsinh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arcsinh.class, out, in);
 		return result;
 	}
 
@@ -513,7 +513,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arctan.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arctan(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arctan.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arctan.class, out, in);
 		return result;
 	}
 
@@ -525,7 +525,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Arctanh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arctanh(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Arctanh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arctanh.class, out, in);
 		return result;
 	}
 
@@ -543,7 +543,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Ceil.class)
 	public <I extends RealType<I>, O extends RealType<O>> O ceil(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Ceil.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Ceil.class, out, in);
 		return result;
 	}
 
@@ -578,7 +578,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Cos.class)
 	public <I extends RealType<I>, O extends RealType<O>> O cos(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Cos.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Cos.class, out, in);
 		return result;
 	}
 
@@ -596,7 +596,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Cosh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O cosh(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Cosh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Cosh.class, out, in);
 		return result;
 	}
 
@@ -608,7 +608,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Cot.class)
 	public <I extends RealType<I>, O extends RealType<O>> O cot(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Cot.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Cot.class, out, in);
 		return result;
 	}
 
@@ -620,7 +620,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Coth.class)
 	public <I extends RealType<I>, O extends RealType<O>> O coth(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Coth.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Coth.class, out, in);
 		return result;
 	}
 
@@ -632,7 +632,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Csc.class)
 	public <I extends RealType<I>, O extends RealType<O>> O csc(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Csc.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Csc.class, out, in);
 		return result;
 	}
 
@@ -644,7 +644,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Csch.class)
 	public <I extends RealType<I>, O extends RealType<O>> O csch(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Csch.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Csch.class, out, in);
 		return result;
 	}
 
@@ -662,7 +662,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.CubeRoot.class)
 	public <I extends RealType<I>, O extends RealType<O>> O cubeRoot(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.CubeRoot.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.CubeRoot.class, out, in);
 		return result;
 	}
 
@@ -750,7 +750,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToIIOutputII.Divide.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Divide.class, out, in1, in2);
 		return result;
 	}
 
@@ -759,7 +759,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToIIOutputII.Divide.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Divide.class, in1, in2);
 		return result;
 	}
 
@@ -774,7 +774,7 @@ public class MathNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Divide.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Divide.class, in1, in2);
 		return result;
 	}
 
@@ -783,7 +783,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Divide.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Divide.class, out, in1, in2);
 		return result;
 	}
 
@@ -791,7 +791,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <T extends NumericType<T>> IterableInterval<T> divide(final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Divide.class, in, value);
+				.run(net.imagej.ops.Ops.Math.Divide.class, in, value);
 		return result;
 	}
 
@@ -800,7 +800,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Divide.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Divide.class, out, in, value);
 		return result;
 	}
 
@@ -814,7 +814,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I extends RealType<I>, O extends RealType<O>> O divide(final O out, final I in, final double constant,
 			final double dbzVal) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Divide.class, out, in, constant, dbzVal);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Divide.class, out, in, constant, dbzVal);
 		return result;
 	}
 
@@ -822,7 +822,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O divide(final O out, final I1 in1,
 			final I2 in2, final double dbzVal) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Divide.class, out, in1, in2, dbzVal);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Divide.class, out, in1, in2, dbzVal);
 		return result;
 	}
 
@@ -845,7 +845,7 @@ public class MathNamespace extends AbstractNamespace {
 			final double value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<DoubleType, DoubleArray> result = (PlanarImg<DoubleType, DoubleArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.DivideDouble.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Divide.class, image, value);
 		return result;
 	}
 
@@ -853,7 +853,7 @@ public class MathNamespace extends AbstractNamespace {
 	public PlanarImg<FloatType, FloatArray> divide(final PlanarImg<FloatType, FloatArray> image, final float value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<FloatType, FloatArray> result = (PlanarImg<FloatType, FloatArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.DivideFloat.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Divide.class, image, value);
 		return result;
 	}
 
@@ -889,21 +889,21 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputRAI.Divide.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Divide.class, out, in, value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Divide.class)
 	public <T extends NumericType<T>> T divide(final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Divide.class, in, b);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Divide.class, in, b);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Divide.class)
 	public <T extends NumericType<T>> T divide(final T out, final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Divide.class, out, in, b);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Divide.class, out, in, b);
 		return result;
 	}
 
@@ -916,7 +916,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Exp.class)
 	public <I extends RealType<I>, O extends RealType<O>> O exp(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Exp.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Exp.class, out, in);
 		return result;
 	}
 
@@ -928,7 +928,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.ExpMinusOne.class)
 	public <I extends RealType<I>, O extends RealType<O>> O expMinusOne(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.ExpMinusOne.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.ExpMinusOne.class, out, in);
 		return result;
 	}
 
@@ -946,7 +946,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Floor.class)
 	public <I extends RealType<I>, O extends RealType<O>> O floor(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Floor.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Floor.class, out, in);
 		return result;
 	}
 
@@ -958,7 +958,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.GammaConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O gamma(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.GammaConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Gamma.class, out, in, constant);
 		return result;
 	}
 
@@ -971,7 +971,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I extends RealType<I>, O extends RealType<O>> O invert(final O out, final I in, final double specifiedMin,
 			final double specifiedMax) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Invert.class, out, in, specifiedMin, specifiedMax);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Invert.class, out, in, specifiedMin, specifiedMax);
 		return result;
 	}
 
@@ -1006,7 +1006,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Log.class)
 	public <I extends RealType<I>, O extends RealType<O>> O log(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Log.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Log.class, out, in);
 		return result;
 	}
 
@@ -1024,7 +1024,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Log10.class)
 	public <I extends RealType<I>, O extends RealType<O>> O log10(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Log10.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Log10.class, out, in);
 		return result;
 	}
 
@@ -1036,7 +1036,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Log2.class)
 	public <I extends RealType<I>, O extends RealType<O>> O log2(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Log2.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Log2.class, out, in);
 		return result;
 	}
 
@@ -1054,7 +1054,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.LogOnePlusX.class)
 	public <I extends RealType<I>, O extends RealType<O>> O logOnePlusX(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.LogOnePlusX.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.LogOnePlusX.class, out, in);
 		return result;
 	}
 
@@ -1090,7 +1090,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.MaxConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O max(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.MaxConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Max.class, out, in, constant);
 		return result;
 	}
 
@@ -1126,7 +1126,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.MinConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O min(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.MinConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Min.class, out, in, constant);
 		return result;
 	}
 
@@ -1212,7 +1212,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToIIOutputII.Multiply.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, out, in1, in2);
 		return result;
 	}
 
@@ -1221,7 +1221,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToIIOutputII.Multiply.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, in1, in2);
 		return result;
 	}
 
@@ -1236,7 +1236,7 @@ public class MathNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Multiply.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, in1, in2);
 		return result;
 	}
 
@@ -1245,7 +1245,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Multiply.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, out, in1, in2);
 		return result;
 	}
 
@@ -1253,7 +1253,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <T extends NumericType<T>> IterableInterval<T> multiply(final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Multiply.class, in, value);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, in, value);
 		return result;
 	}
 
@@ -1262,7 +1262,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Multiply.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, out, in, value);
 		return result;
 	}
 
@@ -1275,7 +1275,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Multiply.class)
 	public <I extends RealType<I>, O extends RealType<O>> O multiply(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Multiply.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Multiply.class, out, in, constant);
 		return result;
 	}
 
@@ -1283,7 +1283,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O multiply(final O out,
 			final I1 in1, final I2 in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Multiply.class, out, in1, in2);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Multiply.class, out, in1, in2);
 		return result;
 	}
 
@@ -1306,7 +1306,7 @@ public class MathNamespace extends AbstractNamespace {
 			final double value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<DoubleType, DoubleArray> result = (PlanarImg<DoubleType, DoubleArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.MultiplyDouble.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, image, value);
 		return result;
 	}
 
@@ -1314,7 +1314,7 @@ public class MathNamespace extends AbstractNamespace {
 	public PlanarImg<FloatType, FloatArray> multiply(final PlanarImg<FloatType, FloatArray> image, final float value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<FloatType, FloatArray> result = (PlanarImg<FloatType, FloatArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.MultiplyFloat.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, image, value);
 		return result;
 	}
 
@@ -1352,14 +1352,14 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputRAI.Multiply.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Multiply.class, out, in, value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class)
 	public <T extends NumericType<T>> T multiply(final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, in, b);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Multiply.class, in, b);
 		return result;
 	}
 
@@ -1374,7 +1374,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.NearestInt.class)
 	public <I extends RealType<I>, O extends RealType<O>> O nearestInt(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.NearestInt.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.NearestInt.class, out, in);
 		return result;
 	}
 
@@ -1410,7 +1410,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Negate.class)
 	public <I extends RealType<I>, O extends RealType<O>> O negate(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Negate.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Negate.class, out, in);
 		return result;
 	}
 
@@ -1434,7 +1434,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.OrConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O or(final O out, final I in, final long constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.OrConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Or.class, out, in, constant);
 		return result;
 	}
 
@@ -1442,7 +1442,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O or(final O out, final I1 in1,
 			final I2 in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Or.class, out, in1, in2);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Or.class, out, in1, in2);
 		return result;
 	}
 
@@ -1460,7 +1460,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.PowerConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O power(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.PowerConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Power.class, out, in, constant);
 		return result;
 	}
 
@@ -1472,14 +1472,14 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.RandomGaussian.class)
 	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.RandomGaussian.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.RandomGaussian.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.RealMath.RandomGaussian.class)
 	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(final O out, final I in, final long seed) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.RandomGaussian.class, out, in, seed);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.RandomGaussian.class, out, in, seed);
 		return result;
 	}
 
@@ -1491,14 +1491,14 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.RandomUniform.class)
 	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.RandomUniform.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.RandomUniform.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.RealMath.RandomUniform.class)
 	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(final O out, final I in, final long seed) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.RandomUniform.class, out, in, seed);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.RandomUniform.class, out, in, seed);
 		return result;
 	}
 
@@ -1510,7 +1510,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Reciprocal.class)
 	public <I extends RealType<I>, O extends RealType<O>> O reciprocal(final O out, final I in, final double dbzVal) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Reciprocal.class, out, in, dbzVal);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Reciprocal.class, out, in, dbzVal);
 		return result;
 	}
 
@@ -1580,7 +1580,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Round.class)
 	public <I extends RealType<I>, O extends RealType<O>> O round(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Round.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Round.class, out, in);
 		return result;
 	}
 
@@ -1592,7 +1592,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sec.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sec(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sec.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sec.class, out, in);
 		return result;
 	}
 
@@ -1604,7 +1604,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sech.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sech(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sech.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sech.class, out, in);
 		return result;
 	}
 
@@ -1628,7 +1628,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Signum.class)
 	public <I extends RealType<I>, O extends RealType<O>> O signum(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Signum.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Signum.class, out, in);
 		return result;
 	}
 
@@ -1646,7 +1646,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sin.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sin(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sin.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sin.class, out, in);
 		return result;
 	}
 
@@ -1658,7 +1658,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sinc.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sinc(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sinc.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sinc.class, out, in);
 		return result;
 	}
 
@@ -1670,7 +1670,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.SincPi.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sincPi(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.SincPi.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.SincPi.class, out, in);
 		return result;
 	}
 
@@ -1688,7 +1688,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sinh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sinh(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sinh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sinh.class, out, in);
 		return result;
 	}
 
@@ -1700,7 +1700,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sqr.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sqr(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sqr.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sqr.class, out, in);
 		return result;
 	}
 
@@ -1718,7 +1718,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Sqrt.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sqrt(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Sqrt.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sqrt.class, out, in);
 		return result;
 	}
 
@@ -1730,7 +1730,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Step.class)
 	public <I extends RealType<I>, O extends RealType<O>> O step(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Step.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Step.class, out, in);
 		return result;
 	}
 
@@ -1819,7 +1819,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToIIOutputII.Subtract.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, out, in1, in2);
 		return result;
 	}
 
@@ -1828,7 +1828,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToIIOutputII.Subtract.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, in1, in2);
 		return result;
 	}
 
@@ -1843,7 +1843,7 @@ public class MathNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Subtract.class, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, in1, in2);
 		return result;
 	}
 
@@ -1852,7 +1852,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in1, final RandomAccessibleInterval<T> in2) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.IIToRAIOutputII.Subtract.class, out, in1, in2);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, out, in1, in2);
 		return result;
 	}
 
@@ -1860,7 +1860,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <T extends NumericType<T>> IterableInterval<T> subtract(final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Subtract.class, in, value);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, in, value);
 		return result;
 	}
 
@@ -1869,7 +1869,7 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputII.Subtract.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, out, in, value);
 		return result;
 	}
 
@@ -1882,7 +1882,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Subtract.class)
 	public <I extends RealType<I>, O extends RealType<O>> O subtract(final O out, final I in, final double constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Subtract.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Subtract.class, out, in, constant);
 		return result;
 	}
 
@@ -1890,7 +1890,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O subtract(final O out,
 			final I1 in1, final I2 in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Subtract.class, out, in1, in2);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Subtract.class, out, in1, in2);
 		return result;
 	}
 
@@ -1914,7 +1914,7 @@ public class MathNamespace extends AbstractNamespace {
 			final double value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<DoubleType, DoubleArray> result = (PlanarImg<DoubleType, DoubleArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.SubtractDouble.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, image, value);
 		return result;
 	}
 
@@ -1922,7 +1922,7 @@ public class MathNamespace extends AbstractNamespace {
 	public PlanarImg<FloatType, FloatArray> subtract(final PlanarImg<FloatType, FloatArray> image, final float value) {
 		@SuppressWarnings("unchecked")
 		final PlanarImg<FloatType, FloatArray> result = (PlanarImg<FloatType, FloatArray>) ops()
-				.run(net.imagej.ops.math.ConstantToPlanarImage.SubtractFloat.class, image, value);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, image, value);
 		return result;
 	}
 
@@ -1959,14 +1959,14 @@ public class MathNamespace extends AbstractNamespace {
 			final IterableInterval<T> in, final T value) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(net.imagej.ops.math.ConstantToIIOutputRAI.Subtract.class, out, in, value);
+				.run(net.imagej.ops.Ops.Math.Subtract.class, out, in, value);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class)
 	public <T extends NumericType<T>> T subtract(final T in, final T b) {
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, in, b);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Subtract.class, in, b);
 		return result;
 	}
 
@@ -1980,14 +1980,14 @@ public class MathNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleTan.class)
 	public double tan(final double a) {
-		final double result = (Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleTan.class, a);
+		final double result = (Double) ops().run(net.imagej.ops.Ops.Math.Tan.class, a);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.RealMath.Tan.class)
 	public <I extends RealType<I>, O extends RealType<O>> O tan(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Tan.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Tan.class, out, in);
 		return result;
 	}
 
@@ -1998,14 +1998,14 @@ public class MathNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleTanh.class)
 	public double tanh(final double a) {
-		final double result = (Double) ops().run(net.imagej.ops.math.PrimitiveMath.DoubleTanh.class, a);
+		final double result = (Double) ops().run(net.imagej.ops.Ops.Math.Tanh.class, a);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.math.RealMath.Tanh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O tanh(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Tanh.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Tanh.class, out, in);
 		return result;
 	}
 
@@ -2017,7 +2017,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.Ulp.class)
 	public <I extends RealType<I>, O extends RealType<O>> O ulp(final O out, final I in) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.Ulp.class, out, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Ulp.class, out, in);
 		return result;
 	}
 
@@ -2058,7 +2058,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealMath.XorConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O xor(final O out, final I in, final long constant) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealMath.XorConstant.class, out, in, constant);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Xor.class, out, in, constant);
 		return result;
 	}
 
@@ -2066,7 +2066,7 @@ public class MathNamespace extends AbstractNamespace {
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O xor(final O out, final I1 in1,
 			final I2 in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Xor.class, out, in1, in2);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Xor.class, out, in1, in2);
 		return result;
 	}
 
@@ -2078,7 +2078,7 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.NumericTypeNullaryMath.Zero.class)
 	public <T extends NumericType<T>> T zero(final T out) {
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(net.imagej.ops.math.NumericTypeNullaryMath.Zero.class, out);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Zero.class, out);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -254,14 +254,6 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Add.class)
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O add(final O out, final I1 in1,
 			final I2 in2) {
-		final Class<?> outClass = out.getClass();
-		final Class<?> in1Class = in1.getClass();
-		final Class<?> in2Class = in2.getClass();
-		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
-			@SuppressWarnings("unchecked")
-			final O result = (O) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out, in1, in2);
-			return result;
-		}
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Add.class, out, in1, in2);
 		return result;
@@ -341,18 +333,10 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Add.class)
-	public <I1 extends NumericType<I1>, I2 extends NumericType<I2>, O extends NumericType<O>> O add(final O out,
-			final I1 in1, final I2 in2) {
-		final Class<?> outClass = out.getClass();
-		final Class<?> in1Class = in1.getClass();
-		final Class<?> in2Class = in2.getClass();
-		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
-			@SuppressWarnings("unchecked")
-			final O result = (O) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Add.class, out, in1, in2);
-			return result;
-		}
+	public <T extends NumericType<T>> T add(final T out,
+			final T in1, final T in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Add.class, out, in1, in2);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Add.class, out, in1, in2);
 		return result;
 	}
 
@@ -1298,14 +1282,6 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Multiply.class)
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O multiply(final O out,
 			final I1 in1, final I2 in2) {
-		final Class<?> outClass = out.getClass();
-		final Class<?> in1Class = in1.getClass();
-		final Class<?> in2Class = in2.getClass();
-		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
-			@SuppressWarnings("unchecked")
-			final O result = (O) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, out, in1, in2);
-			return result;
-		}
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Multiply.class, out, in1, in2);
 		return result;
@@ -1388,18 +1364,10 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class)
-	public <I1 extends NumericType<I1>, I2 extends NumericType<I2>, O extends NumericType<O>> O multiply(final O out,
-			final I1 in1, final I2 in2) {
-		final Class<?> outClass = out.getClass();
-		final Class<?> in1Class = in1.getClass();
-		final Class<?> in2Class = in2.getClass();
-		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
-			@SuppressWarnings("unchecked")
-			final O result = (O) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Multiply.class, out, in1, in2);
-			return result;
-		}
+	public <T extends NumericType<T>> T multiply(final T out,
+			final T in1, final T in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Multiply.class, out, in1, in2);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Multiply.class, out, in1, in2);
 		return result;
 	}
 
@@ -1921,14 +1889,6 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.math.RealBinaryMath.Subtract.class)
 	public <I1 extends RealType<I1>, I2 extends RealType<I2>, O extends RealType<O>> O subtract(final O out,
 			final I1 in1, final I2 in2) {
-		final Class<?> outClass = out.getClass();
-		final Class<?> in1Class = in1.getClass();
-		final Class<?> in2Class = in2.getClass();
-		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
-			@SuppressWarnings("unchecked")
-			final O result = (O) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, out, in1, in2);
-			return result;
-		}
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.math.RealBinaryMath.Subtract.class, out, in1, in2);
 		return result;
@@ -2011,18 +1971,10 @@ public class MathNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class)
-	public <I1 extends NumericType<I1>, I2 extends NumericType<I2>, O extends NumericType<O>> O subtract(final O out,
-			final I1 in1, final I2 in2) {
-		final Class<?> outClass = out.getClass();
-		final Class<?> in1Class = in1.getClass();
-		final Class<?> in2Class = in2.getClass();
-		if (outClass.equals(in1Class) && outClass.equals(in2Class)) {
-			@SuppressWarnings("unchecked")
-			final O result = (O) ops().run(net.imagej.ops.math.NumericTypeBinaryMath.Subtract.class, out, in1, in2);
-			return result;
-		}
+	public <T extends NumericType<T>> T  subtract(final T out,
+			final T in1, final T in2) {
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Subtract.class, out, in1, in2);
+		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Subtract.class, out, in1, in2);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/stats/StatsNamespace.java
+++ b/src/main/java/net/imagej/ops/stats/StatsNamespace.java
@@ -95,7 +95,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultKurtosis.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Kurtosis.class, in);
 		return result;
 	}
 
@@ -104,7 +104,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultKurtosis.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Kurtosis.class, out, in);
 		return result;
 	}
 
@@ -148,7 +148,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultMedian.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Median.class, in);
 		return result;
 	}
 
@@ -157,7 +157,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultMedian.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Median.class, out, in);
 		return result;
 	}
 
@@ -181,7 +181,7 @@ public class StatsNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.stats.DefaultMinMax.class)
 	public <T extends RealType<T>> Pair<T,T> minMax(final Iterable<T> in) {
 		final Pair<T,T> result =
-			(Pair<T,T>) ops().run(net.imagej.ops.stats.DefaultMinMax.class, in);
+			(Pair<T,T>) ops().run(net.imagej.ops.Ops.Stats.MinMax.class, in);
 		return result;
 	}
 
@@ -190,7 +190,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultMoment1AboutMean.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Moment1AboutMean.class, in);
 		return result;
 	}
 
@@ -200,7 +200,7 @@ public class StatsNamespace extends AbstractNamespace {
 	{
 		final O result =
 			(O) ops()
-				.run(net.imagej.ops.stats.DefaultMoment1AboutMean.class, out, in);
+				.run(net.imagej.ops.Ops.Stats.Moment1AboutMean.class, out, in);
 		return result;
 	}
 
@@ -209,7 +209,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultMoment2AboutMean.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Moment2AboutMean.class, in);
 		return result;
 	}
 
@@ -219,7 +219,7 @@ public class StatsNamespace extends AbstractNamespace {
 	{
 		final O result =
 			(O) ops()
-				.run(net.imagej.ops.stats.DefaultMoment2AboutMean.class, out, in);
+				.run(net.imagej.ops.Ops.Stats.Moment2AboutMean.class, out, in);
 		return result;
 	}
 
@@ -228,7 +228,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultMoment3AboutMean.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Moment3AboutMean.class, in);
 		return result;
 	}
 
@@ -238,7 +238,7 @@ public class StatsNamespace extends AbstractNamespace {
 	{
 		final O result =
 			(O) ops()
-				.run(net.imagej.ops.stats.DefaultMoment3AboutMean.class, out, in);
+				.run(net.imagej.ops.Ops.Stats.Moment3AboutMean.class, out, in);
 		return result;
 	}
 
@@ -247,7 +247,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultMoment4AboutMean.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Moment4AboutMean.class, in);
 		return result;
 	}
 
@@ -257,7 +257,7 @@ public class StatsNamespace extends AbstractNamespace {
 	{
 		final O result =
 			(O) ops()
-				.run(net.imagej.ops.stats.DefaultMoment4AboutMean.class, out, in);
+				.run(net.imagej.ops.Ops.Stats.Moment4AboutMean.class, out, in);
 		return result;
 	}
 
@@ -266,7 +266,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in, final double percent)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultPercentile.class, in, percent);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Percentile.class, in, percent);
 		return result;
 	}
 
@@ -275,21 +275,21 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in, final double percent)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultPercentile.class, out, in, percent);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Percentile.class, out, in, percent);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.stats.DefaultQuantile.class)
 	public <T extends RealType<T>, O extends RealType<O>> O quantile(final Iterable<T> in, final double quantile) {
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultQuantile.class, in, quantile);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Quantile.class, in, quantile);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.stats.DefaultQuantile.class)
 	public <T extends RealType<T>, O extends RealType<O>> O quantile(final O out, final Iterable<T> in, final double quantile) {
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultQuantile.class, out, in, quantile);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Quantile.class, out, in, quantile);
 		return result;
 	}
 
@@ -298,7 +298,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final IterableInterval<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.IISize.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Size.class, in);
 		return result;
 	}
 
@@ -307,7 +307,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final IterableInterval<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.IISize.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Size.class, out, in);
 		return result;
 	}
 
@@ -315,7 +315,7 @@ public class StatsNamespace extends AbstractNamespace {
 	public <T extends RealType<T>, O extends RealType<O>> O size(
 		final Iterable<T> in)
 	{
-		final O result = (O) ops().run(net.imagej.ops.stats.DefaultSize.class, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Stats.Size.class, in);
 		return result;
 	}
 
@@ -324,7 +324,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSize.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Size.class, out, in);
 		return result;
 	}
 
@@ -333,7 +333,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSkewness.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Skewness.class, in);
 		return result;
 	}
 
@@ -342,7 +342,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSkewness.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Skewness.class, out, in);
 		return result;
 	}
 
@@ -369,7 +369,7 @@ public class StatsNamespace extends AbstractNamespace {
 	public <T extends RealType<T>, O extends RealType<O>> O sum(
 		final Iterable<T> in)
 	{
-		final O result = (O) ops().run(net.imagej.ops.stats.DefaultSum.class, in);
+		final O result = (O) ops().run(net.imagej.ops.Ops.Stats.Sum.class, in);
 		return result;
 	}
 
@@ -378,7 +378,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSum.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.Sum.class, out, in);
 		return result;
 	}
 
@@ -387,7 +387,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSumOfInverses.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.SumOfInverses.class, in);
 		return result;
 	}
 
@@ -396,7 +396,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final O out, final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSumOfInverses.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.SumOfInverses.class, out, in);
 		return result;
 	}
 
@@ -405,7 +405,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSumOfLogs.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.SumOfLogs.class, in);
 		return result;
 	}
 
@@ -414,7 +414,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final O out, final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSumOfLogs.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.SumOfLogs.class, out, in);
 		return result;
 	}
 
@@ -423,7 +423,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSumOfSquares.class, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.SumOfSquares.class, in);
 		return result;
 	}
 
@@ -432,7 +432,7 @@ public class StatsNamespace extends AbstractNamespace {
 		final O out, final Iterable<T> in)
 	{
 		final O result =
-			(O) ops().run(net.imagej.ops.stats.DefaultSumOfSquares.class, out, in);
+			(O) ops().run(net.imagej.ops.Ops.Stats.SumOfSquares.class, out, in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/thread/ThreadNamespace.java
+++ b/src/main/java/net/imagej/ops/thread/ThreadNamespace.java
@@ -57,7 +57,7 @@ public class ThreadNamespace extends AbstractNamespace {
 	@OpMethod(ops = { net.imagej.ops.thread.chunker.DefaultChunker.class,
 		net.imagej.ops.thread.chunker.ChunkerInterleaved.class })
 	public void chunker(final Chunk chunkable, final long numberOfElements) {
-		ops().run(net.imagej.ops.thread.chunker.DefaultChunker.class, chunkable,
+		ops().run(net.imagej.ops.Ops.Thread.Chunker.class, chunkable,
 			numberOfElements);
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -72,7 +72,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final Iterable<BitType> result =
 			(Iterable<BitType>) ops().run(
-				net.imagej.ops.threshold.apply.ApplyConstantThreshold.class,
+				net.imagej.ops.Ops.Threshold.Apply.class,
 				out, in, threshold);
 		return result;
 	}
@@ -85,7 +85,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.apply.ApplyManualThreshold.class, in,
+				net.imagej.ops.Ops.Threshold.Apply.class, in,
 				threshold);
 		return result;
 	}
@@ -98,7 +98,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.apply.ApplyManualThreshold.class, out,
+				net.imagej.ops.Ops.Threshold.Apply.class, out,
 				in, threshold);
 		return result;
 	}
@@ -110,7 +110,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		final BitType result =
 			(BitType) ops().run(
-				net.imagej.ops.threshold.apply.ApplyThresholdComparable.class,
+				net.imagej.ops.Ops.Threshold.Apply.class,
 				out, in, threshold);
 		return result;
 	}
@@ -122,7 +122,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		final BitType result =
 			(BitType) ops().run(
-				net.imagej.ops.threshold.apply.ApplyThresholdComparator.class,
+				net.imagej.ops.Ops.Threshold.Apply.class,
 				out, in, threshold, comparator);
 		return result;
 	}
@@ -141,7 +141,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.huang.ComputeHuangThreshold.class,
+					net.imagej.ops.Ops.Threshold.Huang.class,
 					in);
 		return result;
 	}
@@ -152,7 +152,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.huang.ComputeHuangThreshold.class,
+				net.imagej.ops.Ops.Threshold.Huang.class,
 				out, in);
 		return result;
 	}
@@ -163,7 +163,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Huang.class, in);
+				net.imagej.ops.Ops.Threshold.Huang.class, in);
 		return result;
 	}
 
@@ -175,7 +175,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Huang.class, out,
+				net.imagej.ops.Ops.Threshold.Huang.class, out,
 				in);
 		return result;
 	}
@@ -191,7 +191,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.ij1.ComputeIJ1Threshold.class, in);
+				net.imagej.ops.Ops.Threshold.IJ1.class, in);
 		return result;
 	}
 
@@ -201,7 +201,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.ij1.ComputeIJ1Threshold.class, out,
+				net.imagej.ops.Ops.Threshold.IJ1.class, out,
 				in);
 		return result;
 	}
@@ -213,7 +213,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.IJ1.class,
+				net.imagej.ops.Ops.Threshold.IJ1.class,
 				in);
 		return result;
 	}
@@ -227,7 +227,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.IJ1.class,
+				net.imagej.ops.Ops.Threshold.IJ1.class,
 				out, in);
 		return result;
 	}
@@ -245,7 +245,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final List<Object> result =
 			(List<Object>) ops()
 				.run(
-					net.imagej.ops.threshold.intermodes.ComputeIntermodesThreshold.class,
+					net.imagej.ops.Ops.Threshold.Intermodes.class,
 					in);
 		return result;
 	}
@@ -260,7 +260,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final List<Object> result =
 			(List<Object>) ops()
 				.run(
-					net.imagej.ops.threshold.intermodes.ComputeIntermodesThreshold.class,
+					net.imagej.ops.Ops.Threshold.Intermodes.class,
 					out, in);
 		return result;
 	}
@@ -272,7 +272,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Intermodes.class,
+				net.imagej.ops.Ops.Threshold.Intermodes.class,
 				in);
 		return result;
 	}
@@ -286,7 +286,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Intermodes.class,
+				net.imagej.ops.Ops.Threshold.Intermodes.class,
 				out, in);
 		return result;
 	}
@@ -303,7 +303,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.IsoData.class,
+					net.imagej.ops.Ops.Threshold.IsoData.class,
 					in);
 		return result;
 	}
@@ -316,7 +316,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.IsoData.class,
+				net.imagej.ops.Ops.Threshold.IsoData.class,
 				out, in);
 		return result;
 	}
@@ -327,7 +327,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final List<Object> result =
 			(List<Object>) ops().run(
-				net.imagej.ops.threshold.isoData.ComputeIsoDataThreshold.class,
+				net.imagej.ops.Ops.Threshold.IsoData.class,
 				in);
 		return result;
 	}
@@ -340,7 +340,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final List<Object> result =
 			(List<Object>) ops().run(
-				net.imagej.ops.threshold.isoData.ComputeIsoDataThreshold.class,
+				net.imagej.ops.Ops.Threshold.IsoData.class,
 				out, in);
 		return result;
 	}
@@ -356,7 +356,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Li.class, in);
+				net.imagej.ops.Ops.Threshold.Li.class, in);
 		return result;
 	}
 
@@ -368,7 +368,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
-				.run(net.imagej.ops.threshold.ApplyThresholdMethod.Li.class,
+				.run(net.imagej.ops.Ops.Threshold.Li.class,
 					out, in);
 		return result;
 	}
@@ -379,7 +379,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.li.ComputeLiThreshold.class, in);
+				net.imagej.ops.Ops.Threshold.Li.class, in);
 		return result;
 	}
 
@@ -389,7 +389,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.li.ComputeLiThreshold.class, out,
+				net.imagej.ops.Ops.Threshold.Li.class, out,
 				in);
 		return result;
 	}
@@ -403,7 +403,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localContrast.LocalContrastThreshold.class,
+			.run(net.imagej.ops.Ops.Threshold.LocalContrastThreshold.class,
 				out, in, shape, outOfBounds);
 		return result;
 	}
@@ -416,7 +416,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localContrast.LocalContrastThreshold.class,
+			.run(net.imagej.ops.Ops.Threshold.LocalContrastThreshold.class,
 				out, in, shape);
 		return result;
 	}
@@ -431,7 +431,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localMean.LocalMeanThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalMeanThreshold.class, out, in, shape,
 				outOfBounds, c);
 		return result;
 	}
@@ -444,7 +444,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localMean.LocalMeanThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalMeanThreshold.class, out, in, shape,
 				c);
 		return result;
 	}
@@ -459,7 +459,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localMedian.LocalMedianThreshold.class, out,
+			.run(net.imagej.ops.Ops.Threshold.LocalMedianThreshold.class, out,
 				in, shape, outOfBounds, c);
 		return result;
 	}
@@ -472,7 +472,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localMedian.LocalMedianThreshold.class, out,
+			.run(net.imagej.ops.Ops.Threshold.LocalMedianThreshold.class, out,
 				in, shape, c);
 		return result;
 	}
@@ -487,7 +487,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localMidGrey.LocalMidGreyThreshold.class, out,
+			.run(net.imagej.ops.Ops.Threshold.LocalMidGreyThreshold.class, out,
 				in, shape, outOfBounds, c);
 		return result;
 	}
@@ -501,7 +501,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localMidGrey.LocalMidGreyThreshold.class, out,
+			.run(net.imagej.ops.Ops.Threshold.LocalMidGreyThreshold.class, out,
 				in, shape, c);
 		return result;
 	}
@@ -516,7 +516,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localNiblack.LocalNiblackThreshold.class, out,
+			.run(net.imagej.ops.Ops.Threshold.LocalNiblackThreshold.class, out,
 				in, shape, outOfBounds, c, k);
 		return result;
 	}
@@ -530,7 +530,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.threshold.localNiblack.LocalNiblackThreshold.class, out,
+			.run(net.imagej.ops.Ops.Threshold.LocalNiblackThreshold.class, out,
 				in, shape, c, k);
 		return result;
 	}
@@ -546,7 +546,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalBernsenThreshold.class, out, in, shape,
 				outOfBounds, contrastThreshold, halfMaxValue);
 		return result;
 	}
@@ -561,7 +561,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalBernsenThreshold.class, out, in, shape,
 				contrastThreshold, halfMaxValue);
 		return result;
 	}
@@ -577,7 +577,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
 			.run(
-				net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class,
+				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
 				out, in, shape, outOfBounds, k, r);
 		return result;
 	}
@@ -593,7 +593,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
 			.run(
-				net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class,
+				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
 				out, in, shape, outOfBounds, k);
 		return result;
 	}
@@ -608,7 +608,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
 			.run(
-				net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class,
+				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
 				out, in, shape, outOfBounds);
 		return result;
 	}
@@ -622,7 +622,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
 			.run(
-				net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class,
+				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
 				out, in, shape);
 		return result;
 	}
@@ -637,7 +637,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape,
 				outOfBounds, k, r);
 		return result;
 	}
@@ -652,7 +652,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape,
 				outOfBounds, k);
 		return result;
 	}
@@ -666,7 +666,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class, out, in, shape,
+				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape,
 				outOfBounds);
 		return result;
 	}
@@ -679,7 +679,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class, out, in, shape);
+				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape);
 		return result;
 	}
 	
@@ -695,7 +695,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.MaxEntropy.class,
+				net.imagej.ops.Ops.Threshold.MaxEntropy.class,
 				in);
 		return result;
 	}
@@ -709,7 +709,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.MaxEntropy.class,
+				net.imagej.ops.Ops.Threshold.MaxEntropy.class,
 				out, in);
 		return result;
 	}
@@ -722,7 +722,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.maxEntropy.ComputeMaxEntropyThreshold.class,
+					net.imagej.ops.Ops.Threshold.MaxEntropy.class,
 					in);
 		return result;
 	}
@@ -735,7 +735,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.maxEntropy.ComputeMaxEntropyThreshold.class,
+					net.imagej.ops.Ops.Threshold.MaxEntropy.class,
 					out, in);
 		return result;
 	}
@@ -753,7 +753,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.MaxLikelihood.class,
+					net.imagej.ops.Ops.Threshold.MaxLikelihood.class,
 					in);
 		return result;
 	}
@@ -768,7 +768,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.MaxLikelihood.class,
+					net.imagej.ops.Ops.Threshold.MaxLikelihood.class,
 					out, in);
 		return result;
 	}
@@ -782,7 +782,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final List<Object> result =
 			(List<Object>) ops()
 				.run(
-					net.imagej.ops.threshold.maxLikelihood.ComputeMaxLikelihoodThreshold.class,
+					net.imagej.ops.Ops.Threshold.MaxLikelihood.class,
 					in);
 		return result;
 	}
@@ -797,7 +797,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final List<Object> result =
 			(List<Object>) ops()
 				.run(
-					net.imagej.ops.threshold.maxLikelihood.ComputeMaxLikelihoodThreshold.class,
+					net.imagej.ops.Ops.Threshold.MaxLikelihood.class,
 					out, in);
 		return result;
 	}
@@ -813,7 +813,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Mean.class, in);
+				net.imagej.ops.Ops.Threshold.Mean.class, in);
 		return result;
 	}
 
@@ -825,7 +825,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Mean.class, out,
+				net.imagej.ops.Ops.Threshold.Mean.class, out,
 				in);
 		return result;
 	}
@@ -836,7 +836,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.mean.ComputeMeanThreshold.class, in);
+				net.imagej.ops.Ops.Threshold.Mean.class, in);
 		return result;
 	}
 
@@ -846,7 +846,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.mean.ComputeMeanThreshold.class,
+				net.imagej.ops.Ops.Threshold.Mean.class,
 				out, in);
 		return result;
 	}
@@ -862,7 +862,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.MinError.class,
+				net.imagej.ops.Ops.Threshold.MinError.class,
 				in);
 		return result;
 	}
@@ -875,7 +875,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.MinError.class,
+				net.imagej.ops.Ops.Threshold.MinError.class,
 				out, in);
 		return result;
 	}
@@ -887,7 +887,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final List<Object> result =
 			(List<Object>) ops().run(
-				net.imagej.ops.threshold.minError.ComputeMinErrorThreshold.class,
+				net.imagej.ops.Ops.Threshold.MinError.class,
 				in);
 		return result;
 	}
@@ -901,7 +901,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final List<Object> result =
 			(List<Object>) ops().run(
-				net.imagej.ops.threshold.minError.ComputeMinErrorThreshold.class,
+				net.imagej.ops.Ops.Threshold.MinError.class,
 				out, in);
 		return result;
 	}
@@ -918,7 +918,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.Minimum.class,
+					net.imagej.ops.Ops.Threshold.Minimum.class,
 					in);
 		return result;
 	}
@@ -931,7 +931,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Minimum.class,
+				net.imagej.ops.Ops.Threshold.Minimum.class,
 				out, in);
 		return result;
 	}
@@ -942,7 +942,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final List<Object> result =
 			(List<Object>) ops().run(
-				net.imagej.ops.threshold.minimum.ComputeMinimumThreshold.class,
+				net.imagej.ops.Ops.Threshold.Minimum.class,
 				in);
 		return result;
 	}
@@ -955,7 +955,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final List<Object> result =
 			(List<Object>) ops().run(
-				net.imagej.ops.threshold.minimum.ComputeMinimumThreshold.class,
+				net.imagej.ops.Ops.Threshold.Minimum.class,
 				out, in);
 		return result;
 	}
@@ -971,7 +971,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.moments.ComputeMomentsThreshold.class,
+				net.imagej.ops.Ops.Threshold.Moments.class,
 				in);
 		return result;
 	}
@@ -984,7 +984,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.moments.ComputeMomentsThreshold.class,
+				net.imagej.ops.Ops.Threshold.Moments.class,
 				out, in);
 		return result;
 	}
@@ -996,7 +996,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.Moments.class,
+					net.imagej.ops.Ops.Threshold.Moments.class,
 					in);
 		return result;
 	}
@@ -1009,7 +1009,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Moments.class,
+				net.imagej.ops.Ops.Threshold.Moments.class,
 				out, in);
 		return result;
 	}
@@ -1025,7 +1025,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.otsu.ComputeOtsuThreshold.class, in);
+				net.imagej.ops.Ops.Threshold.Otsu.class, in);
 		return result;
 	}
 
@@ -1035,7 +1035,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.otsu.ComputeOtsuThreshold.class,
+				net.imagej.ops.Ops.Threshold.Otsu.class,
 				out, in);
 		return result;
 	}
@@ -1046,7 +1046,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Otsu.class, in);
+				net.imagej.ops.Ops.Threshold.Otsu.class, in);
 		return result;
 	}
 
@@ -1058,7 +1058,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Otsu.class, out,
+				net.imagej.ops.Ops.Threshold.Otsu.class, out,
 				in);
 		return result;
 	}
@@ -1075,7 +1075,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Percentile.class,
+				net.imagej.ops.Ops.Threshold.Percentile.class,
 				in);
 		return result;
 	}
@@ -1089,7 +1089,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Percentile.class,
+				net.imagej.ops.Ops.Threshold.Percentile.class,
 				out, in);
 		return result;
 	}
@@ -1102,7 +1102,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.percentile.ComputePercentileThreshold.class,
+					net.imagej.ops.Ops.Threshold.Percentile.class,
 					in);
 		return result;
 	}
@@ -1115,7 +1115,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.percentile.ComputePercentileThreshold.class,
+					net.imagej.ops.Ops.Threshold.Percentile.class,
 					out, in);
 		return result;
 	}
@@ -1133,7 +1133,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.RenyiEntropy.class,
+					net.imagej.ops.Ops.Threshold.RenyiEntropy.class,
 					in);
 		return result;
 	}
@@ -1148,7 +1148,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops()
 				.run(
-					net.imagej.ops.threshold.ApplyThresholdMethod.RenyiEntropy.class,
+					net.imagej.ops.Ops.Threshold.RenyiEntropy.class,
 					out, in);
 		return result;
 	}
@@ -1161,7 +1161,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.renyiEntropy.ComputeRenyiEntropyThreshold.class,
+					net.imagej.ops.Ops.Threshold.RenyiEntropy.class,
 					in);
 		return result;
 	}
@@ -1177,7 +1177,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		final T result =
 			(T) ops()
 				.run(
-					net.imagej.ops.threshold.renyiEntropy.ComputeRenyiEntropyThreshold.class,
+					net.imagej.ops.Ops.Threshold.RenyiEntropy.class,
 					out, in);
 		return result;
 	}
@@ -1193,7 +1193,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Shanbhag.class,
+				net.imagej.ops.Ops.Threshold.Shanbhag.class,
 				in);
 		return result;
 	}
@@ -1206,7 +1206,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Shanbhag.class,
+				net.imagej.ops.Ops.Threshold.Shanbhag.class,
 				out, in);
 		return result;
 	}
@@ -1218,7 +1218,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.shanbhag.ComputeShanbhagThreshold.class,
+				net.imagej.ops.Ops.Threshold.Shanbhag.class,
 				in);
 		return result;
 	}
@@ -1230,7 +1230,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.shanbhag.ComputeShanbhagThreshold.class,
+				net.imagej.ops.Ops.Threshold.Shanbhag.class,
 				out, in);
 		return result;
 	}
@@ -1246,7 +1246,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Triangle.class,
+				net.imagej.ops.Ops.Threshold.Triangle.class,
 				in);
 		return result;
 	}
@@ -1259,7 +1259,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Triangle.class,
+				net.imagej.ops.Ops.Threshold.Triangle.class,
 				out, in);
 		return result;
 	}
@@ -1271,7 +1271,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.triangle.ComputeTriangleThreshold.class,
+				net.imagej.ops.Ops.Threshold.Triangle.class,
 				in);
 		return result;
 	}
@@ -1283,7 +1283,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.triangle.ComputeTriangleThreshold.class,
+				net.imagej.ops.Ops.Threshold.Triangle.class,
 				out, in);
 		return result;
 	}
@@ -1299,7 +1299,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.yen.ComputeYenThreshold.class, in);
+				net.imagej.ops.Ops.Threshold.Yen.class, in);
 		return result;
 	}
 
@@ -1309,7 +1309,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final T result =
 			(T) ops().run(
-				net.imagej.ops.threshold.yen.ComputeYenThreshold.class, out,
+				net.imagej.ops.Ops.Threshold.Yen.class, out,
 				in);
 		return result;
 	}
@@ -1320,7 +1320,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Yen.class, in);
+				net.imagej.ops.Ops.Threshold.Yen.class, in);
 		return result;
 	}
 
@@ -1332,7 +1332,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result =
 			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.threshold.ApplyThresholdMethod.Yen.class, out,
+				net.imagej.ops.Ops.Threshold.Yen.class, out,
 				in);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/threshold/huang/ComputeHuangThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/huang/ComputeHuangThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 //NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Huang.class)
+@Plugin(type = Ops.Threshold.Huang.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeHuangThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Huang {
 

--- a/src/main/java/net/imagej/ops/threshold/ij1/ComputeIJ1Threshold.java
+++ b/src/main/java/net/imagej/ops/threshold/ij1/ComputeIJ1Threshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -48,7 +49,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.IJ1.class)
+@Plugin(type = Ops.Threshold.IJ1.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeIJ1Threshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.IJ1 {
 

--- a/src/main/java/net/imagej/ops/threshold/intermodes/ComputeIntermodesThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/intermodes/ComputeIntermodesThreshold.java
@@ -38,6 +38,7 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -49,7 +50,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Intermodes.class)
+@Plugin(type = Ops.Threshold.Intermodes.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeIntermodesThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Intermodes {
 

--- a/src/main/java/net/imagej/ops/threshold/isoData/ComputeIsoDataThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/isoData/ComputeIsoDataThreshold.java
@@ -37,6 +37,7 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -48,7 +49,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.IsoData.class)
+@Plugin(type = Ops.Threshold.IsoData.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeIsoDataThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.IsoData {
 

--- a/src/main/java/net/imagej/ops/threshold/li/ComputeLiThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/li/ComputeLiThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -47,7 +48,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Li.class)
+@Plugin(type = Ops.Threshold.Li.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeLiThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Li
 {

--- a/src/main/java/net/imagej/ops/threshold/maxEntropy/ComputeMaxEntropyThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/maxEntropy/ComputeMaxEntropyThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.MaxEntropy.class)
+@Plugin(type = Ops.Threshold.MaxEntropy.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeMaxEntropyThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.MaxEntropy {
 

--- a/src/main/java/net/imagej/ops/threshold/maxLikelihood/ComputeMaxLikelihoodThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/maxLikelihood/ComputeMaxLikelihoodThreshold.java
@@ -39,6 +39,7 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // This plugin code ported from the original MatLab code of the max likelihood
@@ -51,7 +52,7 @@ import org.scijava.plugin.Plugin;
  * 
  * @author Barry DeZonia
  */
-@Plugin(type = Ops.Threshold.MaxLikelihood.class)
+@Plugin(type = Ops.Threshold.MaxLikelihood.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeMaxLikelihoodThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.MaxLikelihood
 {

--- a/src/main/java/net/imagej/ops/threshold/mean/ComputeMeanThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/mean/ComputeMeanThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Mean.class)
+@Plugin(type = Ops.Threshold.Mean.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeMeanThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Mean {
 

--- a/src/main/java/net/imagej/ops/threshold/minError/ComputeMinErrorThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/minError/ComputeMinErrorThreshold.java
@@ -39,6 +39,7 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -51,7 +52,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.MinError.class)
+@Plugin(type = Ops.Threshold.MinError.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeMinErrorThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.MinError {
 

--- a/src/main/java/net/imagej/ops/threshold/minimum/ComputeMinimumThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/minimum/ComputeMinimumThreshold.java
@@ -38,6 +38,7 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -49,7 +50,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Minimum.class)
+@Plugin(type = Ops.Threshold.Minimum.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeMinimumThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Minimum {
 

--- a/src/main/java/net/imagej/ops/threshold/moments/ComputeMomentsThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/moments/ComputeMomentsThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Moments.class)
+@Plugin(type = Ops.Threshold.Moments.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeMomentsThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Moments {
 

--- a/src/main/java/net/imagej/ops/threshold/otsu/ComputeOtsuThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/otsu/ComputeOtsuThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Otsu.class)
+@Plugin(type = Ops.Threshold.Otsu.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeOtsuThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Otsu
 {

--- a/src/main/java/net/imagej/ops/threshold/percentile/ComputePercentileThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/percentile/ComputePercentileThreshold.java
@@ -34,6 +34,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -45,7 +46,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Percentile.class)
+@Plugin(type = Ops.Threshold.Percentile.class, priority = Priority.HIGH_PRIORITY)
 public class ComputePercentileThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Percentile {
 

--- a/src/main/java/net/imagej/ops/threshold/renyiEntropy/ComputeRenyiEntropyThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/renyiEntropy/ComputeRenyiEntropyThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.RenyiEntropy.class)
+@Plugin(type = Ops.Threshold.RenyiEntropy.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeRenyiEntropyThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.RenyiEntropy {
 

--- a/src/main/java/net/imagej/ops/threshold/shanbhag/ComputeShanbhagThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/shanbhag/ComputeShanbhagThreshold.java
@@ -35,6 +35,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -46,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Shanbhag.class)
+@Plugin(type = Ops.Threshold.Shanbhag.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeShanbhagThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Shanbhag {
 

--- a/src/main/java/net/imagej/ops/threshold/triangle/ComputeTriangleThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/triangle/ComputeTriangleThreshold.java
@@ -34,6 +34,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -45,7 +46,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Triangle.class)
+@Plugin(type = Ops.Threshold.Triangle.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeTriangleThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Triangle {
 

--- a/src/main/java/net/imagej/ops/threshold/yen/ComputeYenThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/yen/ComputeYenThreshold.java
@@ -34,6 +34,7 @@ import net.imagej.ops.threshold.AbstractComputeThresholdHistogram;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 // NB - this plugin adapted from Gabriel Landini's code of his AutoThreshold
@@ -45,7 +46,7 @@ import org.scijava.plugin.Plugin;
  * @author Barry DeZonia
  * @author Gabriel Landini
  */
-@Plugin(type = Ops.Threshold.Yen.class)
+@Plugin(type = Ops.Threshold.Yen.class, priority = Priority.HIGH_PRIORITY)
 public class ComputeYenThreshold<T extends RealType<T>> extends
 		AbstractComputeThresholdHistogram<T> implements Ops.Threshold.Yen {
 

--- a/src/main/templates/net/imagej/ops/math/NumericTypeBinaryMath.vm
+++ b/src/main/templates/net/imagej/ops/math/NumericTypeBinaryMath.vm
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.math;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.hybrid.AbstractBinaryHybridCFI;
 import net.imglib2.type.numeric.NumericType;
@@ -49,14 +50,29 @@ public final class NumericTypeBinaryMath {
 	private NumericTypeBinaryMath() {
 		// NB: Prevent instantiation of utility class.
 	}
+
+	@SuppressWarnings("rawtypes")
+	private static boolean compatible(NumericType in1, NumericType in2,
+		NumericType out)
+	{
+		if (out == null) {
+			return in1 == null || in2 == null || in1.getClass() == in2.getClass();
+		}
+		return in1.getClass() == in2.getClass() && in1.getClass() == out.getClass();
+	}
 #foreach ($op in $ops)
 #set ($iface = "Ops.Math.$op.name")
 
 	/** Op that $op.verbs two NumericType values. */
 	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
 	public static class $op.name<T extends NumericType<T>> extends
-		AbstractBinaryHybridCFI<T> implements $iface
+		AbstractBinaryHybridCFI<T> implements $iface, Contingent
 	{
+
+		@Override
+		public boolean conforms() {
+			return compatible(in1(), in2(), out());
+		}
 
 		@Override
 		public void compute2(final T input1, final T input2, final T output) {

--- a/src/test/java/net/imagej/ops/math/RealMathTest.java
+++ b/src/test/java/net/imagej/ops/math/RealMathTest.java
@@ -219,7 +219,6 @@ public class RealMathTest extends AbstractOpTest {
 		final DoubleType out = new DoubleType();
 		ops.math().csch(out, in);
 		assertEquals(out.get(), 1 / Math.sinh(1234567890), 0.0);
-		ops.math().add(3, 43.0);
 	}
 
 	@Test


### PR DESCRIPTION
See #176 for the discussion.
Filter and logic namespaces are not included in this refactoring, since that involves more intricate refactoring. They will be done separately.

Since this refactoring reveals some bugs, bug fixes are included in this branch for convenience.