### PR TITLE
Sobel and hessian filter

### DIFF
--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -730,6 +730,16 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	// -- kernelSobel --
+
+	@OpMethod(op = net.imagej.ops.create.kernelSobel.CreateKernelSobel.class)
+	public <T extends ComplexType<T>> RandomAccessibleInterval<T> kernelSobel(final T outType) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops().run(
+			net.imagej.ops.create.kernelSobel.CreateKernelSobel.class, outType);
+		return result;
+	}
+
 	// -- labelingMapping --
 
 	@OpMethod(

--- a/src/main/java/net/imagej/ops/create/kernelSobel/CreateKernelSobel.java
+++ b/src/main/java/net/imagej/ops/create/kernelSobel/CreateKernelSobel.java
@@ -1,0 +1,99 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.create.kernelSobel;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.function.AbstractNullaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.Cursor;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Creates a separated sobel kernel.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ * @param <T>
+ *            type of input
+ */
+
+@Plugin(type = Ops.Create.KernelSobel.class, name = Ops.Create.KernelSobel.NAME)
+public class CreateKernelSobel<T extends ComplexType<T>>
+		extends AbstractNullaryFunctionOp<RandomAccessibleInterval<T>> implements Ops.Create.KernelSobel {
+
+	@Parameter
+	private T type;
+
+	private static final float[] values = { 1.0f, 2.0f, 1.0f, -1.0f, 0.0f, 1.0f };
+	
+	private UnaryFunctionOp<Interval, RandomAccessibleInterval<T>> createOp;
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public void initialize() {
+		createOp = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class, RandomAccessibleInterval.class,
+				Dimensions.class, type);
+	}
+
+	@Override
+	public RandomAccessibleInterval<T> calculate() {
+		long[] dim = new long[4];
+
+		dim[0] = 3;
+		dim[1] = 1;
+
+		for (int k = 2; k < dim.length; k++) {
+			dim[k] = 1;
+		}
+
+		dim[dim.length - 1] = 2;
+
+		RandomAccessibleInterval<T> output = createOp.calculate(new FinalInterval(dim));
+		final Cursor<T> cursor = Views.iterable(output).cursor();
+		int i = 0;
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			cursor.get().setReal(values[i]);
+			i++;
+		}
+
+		return output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -675,6 +675,19 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	// -- hessian --
+
+	@OpMethod(op = net.imagej.ops.filter.hessian.HessianRAI.class)
+	public <T extends RealType<T>> CompositeIntervalView<T, RealComposite<T>> hessian(
+		final RandomAccessibleInterval<T> in)
+	{
+		@SuppressWarnings("unchecked")
+		final CompositeIntervalView<T, RealComposite<T>> result =
+			(CompositeIntervalView<T, RealComposite<T>>) ops().run(
+				net.imagej.ops.filter.hessian.HessianRAI.class, in);
+		return result;
+	}
+
 	// -- ifft --
 
 	/** Executes the "ifft" operation on the given arguments. */

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -980,6 +980,31 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	// -- Sobel
+
+    @OpMethod(op = net.imagej.ops.filter.sobel.SobelRAI.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<T> sobel(
+		final RandomAccessibleInterval<T> in)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(
+				net.imagej.ops.filter.sobel.SobelRAI.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.filter.sobel.SobelRAI.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<T> sobel(
+		final RandomAccessibleInterval<T> out,
+		final RandomAccessibleInterval<T> in)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(
+				net.imagej.ops.filter.sobel.SobelRAI.class, out, in);
+		return result;
+	}
+
 	/** Executes the "variance" filter operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.variance.DefaultVarianceFilter.class)
 	public <T extends RealType<T>> IterableInterval<T> variance(final IterableInterval<T> out,

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -51,6 +51,8 @@ import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.composite.CompositeIntervalView;
+import net.imglib2.view.composite.RealComposite;
 
 import org.scijava.plugin.Plugin;
 
@@ -924,6 +926,35 @@ public class FilterNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
 				.run(Ops.Filter.PadShiftFFTKernel.class, in1, in2, fast);
+		return result;
+	}
+
+	// -- partial derivative --
+
+	/** Executes the "partial derivative" operation on the given arguments */
+	@OpMethod(op = net.imagej.ops.filter.derivative.PartialDerivativeRAI.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<T> partialDerivative(final RandomAccessibleInterval<T> in, final int dimension) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(net.imagej.ops.filter.derivative.PartialDerivativeRAI.class, in, dimension);
+		return result;
+	}
+
+	/** Executes the "partial derivative" operation on the given arguments */
+	@OpMethod(op = net.imagej.ops.filter.derivative.PartialDerivativeRAI.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<T> partialDerivative(final RandomAccessibleInterval<T> out, final RandomAccessibleInterval<T> in, final int dimension) {
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(net.imagej.ops.filter.derivative.PartialDerivativeRAI.class, out, in, dimension);
+		return result;
+	}
+
+	/** Executes the "partial derivative" operation on all dimensions */
+	@OpMethod(op = net.imagej.ops.filter.derivative.PartialDerivativesRAI.class)
+	public <T extends RealType<T>> CompositeIntervalView<T, RealComposite<T>> allPartialDerivatives(final RandomAccessibleInterval<T> in) {
+		@SuppressWarnings("unchecked")
+		final CompositeIntervalView<T, RealComposite<T>> result =
+			(CompositeIntervalView<T, RealComposite<T>>) ops().run(net.imagej.ops.filter.derivative.PartialDerivativesRAI.class, in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/derivative/PartialDerivativeRAI.java
+++ b/src/main/java/net/imagej/ops/filter/derivative/PartialDerivativeRAI.java
@@ -1,0 +1,179 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.derivative;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Calculates the derivative (with sobel kernel) of an image in a given
+ * dimension.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ * @param <T>
+ *            type of input
+ */
+@Plugin(type = Ops.Filter.PartialDerivative.class)
+public class PartialDerivativeRAI<T extends RealType<T>> extends
+		AbstractUnaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> implements Ops.Filter.PartialDerivative {
+
+	@Parameter
+	private int dimension;
+
+	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> createRAI;
+
+	private BinaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> addOp;
+
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> kernelBConvolveOp;
+
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>[] kernelAConvolveOps;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize() {
+		RandomAccessibleInterval<T> kernel = ops().create().kernelSobel(Util.getTypeFromInterval(in()));
+
+		RandomAccessibleInterval<T> kernelA = Views.hyperSlice(Views.hyperSlice(kernel, 3, 0), 2, 0);
+
+		RandomAccessibleInterval<T> kernelB = Views.hyperSlice(Views.hyperSlice(kernel, 3, 0), 2, 1);
+
+		// add dimensions to kernel to rotate properly
+		if (in().numDimensions() > 2) {
+			RandomAccessible<T> expandedKernelA = Views.addDimension(kernelA);
+			RandomAccessible<T> expandedKernelB = Views.addDimension(kernelB);
+			for (int i = 0; i < in().numDimensions() - 3; i++) {
+				expandedKernelA = Views.addDimension(expandedKernelA);
+				expandedKernelB = Views.addDimension(expandedKernelB);
+			}
+			long[] dims = new long[in().numDimensions()];
+			for (int j = 0; j < in().numDimensions(); j++) {
+				dims[j] = 1;
+			}
+			dims[0] = 3;
+			Interval kernelInterval = new FinalInterval(dims);
+			kernelA = Views.interval(expandedKernelA, kernelInterval);
+			kernelB = Views.interval(expandedKernelB, kernelInterval);
+		}
+
+		long[] dims = new long[in().numDimensions()];
+		if (dimension == 0) {
+			// FIXME hack
+			kernelBConvolveOp = RAIs.computer(ops(), Ops.Filter.Convolve.class, in(), new Object[] { kernelB });
+		} else {
+			// rotate kernel B to dimension
+			for (int j = 0; j < in().numDimensions(); j++) {
+				if (j == dimension) {
+					dims[j] = 3;
+				} else {
+					dims[j] = 1;
+				}
+			}
+
+			Img<DoubleType> kernelInterval = ops().create().img(dims);
+
+			RandomAccessibleInterval<T> rotatedKernelB = kernelB;
+			for (int i = 0; i < dimension; i++) {
+				rotatedKernelB = Views.rotate(rotatedKernelB, i, i + 1);
+			}
+
+			rotatedKernelB = Views.interval(rotatedKernelB, kernelInterval);
+			kernelBConvolveOp = RAIs.computer(ops(), Ops.Filter.Convolve.class, in(), new Object[] { rotatedKernelB });
+		}
+
+		dims = null;
+
+		// rotate kernel A to all other dimensions
+		kernelAConvolveOps = new UnaryComputerOp[in().numDimensions()];
+		if (dimension != 0) {
+			kernelAConvolveOps[0] = RAIs.computer(ops(), Ops.Filter.Convolve.class, in(), new Object[] { kernelA });
+		}
+		RandomAccessibleInterval<T> rotatedKernelA = kernelA;
+		for (int i = 1; i < in().numDimensions(); i++) {
+			if (i != dimension) {
+				dims = new long[in().numDimensions()];
+				for (int j = 0; j < in().numDimensions(); j++) {
+					if (i == j) {
+						dims[j] = 3;
+					} else {
+						dims[j] = 1;
+					}
+				}
+				Img<DoubleType> kernelInterval = ops().create().img(dims);
+				for (int j = 0; j < i; j++) {
+					rotatedKernelA = Views.rotate(rotatedKernelA, j, j + 1);
+				}
+
+				kernelAConvolveOps[i] = RAIs.computer(ops(), Ops.Filter.Convolve.class, in(),
+						new Object[] { Views.interval(rotatedKernelA, kernelInterval) });
+				rotatedKernelA = kernelA;
+			}
+		}
+
+		addOp = RAIs.binaryComputer(ops(), Ops.Math.Add.class, in(), in());
+		createRAI = RAIs.function(ops(), Ops.Create.Img.class, in());
+	}
+
+	@Override
+	public void compute(RandomAccessibleInterval<T> input, RandomAccessibleInterval<T> output) {
+		RandomAccessibleInterval<T> in = input;
+		for (int i = input.numDimensions() - 1; i >= 0; i--) {
+			RandomAccessibleInterval<T> derivative = createRAI.calculate(input);
+			if (dimension == i) {
+				kernelBConvolveOp.compute(Views.interval(Views.extendMirrorDouble(in), input), derivative);
+			} else {
+				kernelAConvolveOps[i].compute(Views.interval(Views.extendMirrorDouble(in), input), derivative);
+			}
+			in = derivative;
+		}
+		addOp.compute(output, in, output);
+	}
+
+	@Override
+	public RandomAccessibleInterval<T> createOutput(RandomAccessibleInterval<T> input) {
+		return createRAI.calculate(input);
+	}
+}

--- a/src/main/java/net/imagej/ops/filter/derivative/PartialDerivativesRAI.java
+++ b/src/main/java/net/imagej/ops/filter/derivative/PartialDerivativesRAI.java
@@ -1,0 +1,84 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.derivative;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+import net.imglib2.view.composite.CompositeIntervalView;
+import net.imglib2.view.composite.RealComposite;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Convenience op for partial derivatives. Calculates all partial derivatives
+ * using a separated sobel kernel and returns a {@link CompositeIntervalView}.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ * @param <T>
+ *            type of input
+ */
+
+@Plugin(type = Ops.Filter.AllPartialDerivatives.class)
+public class PartialDerivativesRAI<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<RandomAccessibleInterval<T>, CompositeIntervalView<T, RealComposite<T>>>
+		implements Ops.Filter.AllPartialDerivatives {
+
+	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>[] derivativeFunctions;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize() {
+		derivativeFunctions = new UnaryFunctionOp[in().numDimensions()];
+		for (int i = 0; i < in().numDimensions(); i++) {
+			derivativeFunctions[i] = RAIs.function(ops(), Ops.Filter.PartialDerivative.class, in(), i);
+		}
+	}
+
+	@Override
+	public CompositeIntervalView<T, RealComposite<T>> calculate(RandomAccessibleInterval<T> input) {
+		List<RandomAccessibleInterval<T>> derivatives = new ArrayList<>();
+		for (int i = 0; i < derivativeFunctions.length; i++) {
+			RandomAccessibleInterval<T> derivative = derivativeFunctions[i].calculate(input);
+			derivatives.add(derivative);
+		}
+
+		RandomAccessibleInterval<T> stacked = Views.stack(derivatives);
+		return Views.collapseReal(stacked);
+	}
+}

--- a/src/main/java/net/imagej/ops/filter/hessian/HessianRAI.java
+++ b/src/main/java/net/imagej/ops/filter/hessian/HessianRAI.java
@@ -1,0 +1,93 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.hessian;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+import net.imglib2.view.composite.CompositeIntervalView;
+import net.imglib2.view.composite.RealComposite;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Hessian filter using the sobel filter with separated kernel.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ * @param <T>
+ *            type of input
+ */
+
+@Plugin(type = Ops.Filter.Hessian.class)
+public class HessianRAI<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<RandomAccessibleInterval<T>, CompositeIntervalView<T, RealComposite<T>>>
+		implements Ops.Filter.Hessian {
+
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>[] derivativeComputers;
+
+	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> createRAI;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize() {
+		createRAI = RAIs.function(ops(), Ops.Create.Img.class, in());
+
+		derivativeComputers = new UnaryComputerOp[in().numDimensions()];
+		for (int i = 0; i < in().numDimensions(); i++) {
+			derivativeComputers[i] = RAIs.computer(ops(), Ops.Filter.PartialDerivative.class, in(), i);
+		}
+	}
+
+	@Override
+	public CompositeIntervalView<T, RealComposite<T>> calculate(RandomAccessibleInterval<T> input) {
+		List<RandomAccessibleInterval<T>> derivatives = new ArrayList<>();
+		for (int i = 0; i < derivativeComputers.length; i++) {
+			RandomAccessibleInterval<T> derivative = createRAI.calculate(input);
+			derivativeComputers[i].compute(input, derivative);
+			for (int j = 0; j < derivativeComputers.length; j++) {
+				RandomAccessibleInterval<T> out = createRAI.calculate(input);
+				derivativeComputers[j].compute(derivative, out);
+				derivatives.add(out);
+			}
+		}
+		RandomAccessibleInterval<T> stackedDerivatives = Views.stack(derivatives);
+		return Views.collapseReal(stackedDerivatives);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/filter/sobel/SobelRAI.java
+++ b/src/main/java/net/imagej/ops/filter/sobel/SobelRAI.java
@@ -1,0 +1,102 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.sobel;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Math.Sqr;
+import net.imagej.ops.Ops.Math.Sqrt;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Sobel filter implementation using separated sobel kernel.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ * @param <T>
+ *            type of input
+ */
+
+@Plugin(type = Ops.Filter.Sobel.class)
+public class SobelRAI<T extends RealType<T>>
+		extends AbstractUnaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> implements Ops.Filter.Sobel {
+
+	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> createRAI;
+
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> squareMapOp;
+
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> sqrtMapOp;
+
+	private BinaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> addOp;
+
+	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>[] derivativeComputers;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize() {
+		createRAI = RAIs.function(ops(), Ops.Create.Img.class, in());
+
+		Sqr squareOp = ops().op(Ops.Math.Sqr.class, RealType.class, RealType.class);
+		squareMapOp = RAIs.computer(ops(), Ops.Map.class, in(), squareOp);
+		Sqrt sqrtOp = ops().op(Ops.Math.Sqrt.class, RealType.class, RealType.class);
+		sqrtMapOp = RAIs.computer(ops(), Ops.Map.class, in(), sqrtOp);
+		addOp = RAIs.binaryComputer(ops(), Ops.Math.Add.class, in(), in());
+
+		derivativeComputers = new UnaryComputerOp[in().numDimensions()];
+		for (int i = 0; i < in().numDimensions(); i++) {
+			derivativeComputers[i] = RAIs.computer(ops(), Ops.Filter.PartialDerivative.class, in(), i);
+		}
+
+	}
+
+	@Override
+	public void compute(RandomAccessibleInterval<T> input, RandomAccessibleInterval<T> output) {
+
+		for (int i = 0; i < derivativeComputers.length; i++) {
+			RandomAccessibleInterval<T> derivative = createRAI.calculate(input);
+			derivativeComputers[i].compute(input, derivative);
+			squareMapOp.compute(derivative, derivative);
+			addOp.compute(output, derivative, output);
+		}
+		sqrtMapOp.compute(output, output);
+	}
+
+	@Override
+	public RandomAccessibleInterval<T> createOutput(RandomAccessibleInterval<T> input) {
+		return createRAI.calculate(input);
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -118,6 +118,7 @@ namespaces = ```
 		[name: "paddingIntervalCentered",        iface: "PaddingIntervalCentered"],
 		[name: "paddingIntervalOrigin",          iface: "PaddingIntervalOrigin"],
 		[name: "sigma",                          iface: "Sigma",               aliases: ["sigmaFilter", "filterSigma"]],
+		[name: "sobel",                          iface: "Sobel"],
 		[name: "variance",                       iface: "Variance",            aliases: ["varianceFilter", "filterVariance", "var", "varFilter", "filterVar"]],
 		[name: "frangiVesselness",			 iface: "FrangiVesselness"],
 	]],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -76,6 +76,7 @@ namespaces = ```
 		[name: "kernelBiGauss",                  iface: "KernelBiGauss"],
 		[name: "kernel2ndDerivBiGauss",          iface: "Kernel2ndDerivBiGauss"],
 		[name: "kernelGabor",                    iface: "KernelGabor"],
+		[name: "kernelSobel",                    iface: "KernelSobel"],
 		[name: "labelingMapping",                iface: "LabelingMapping"],
 		[name: "nativeImg",                      iface: "NativeImg"],
 		[name: "nativeType",                     iface: "NativeType"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -100,6 +100,8 @@ namespaces = ```
 		[name: "convolve",                       iface: "Convolve"],
 		[name: "correlate",                      iface: "Correlate"],
 		[name: "createFFTOutput",                iface: "CreateFFTOutput"],
+		[name: "partialDerivative",              iface: "PartialDerivative"],
+		[name: "allPartialDerivatives",          iface: "AllPartialDerivatives"],
 		[name: "dog",                            iface: "DoG",                 aliases: ["differenceOfGaussian"]],
 		[name: "fft",                            iface: "FFT"],
 		[name: "fftSize",                        iface: "FFTSize"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -106,6 +106,7 @@ namespaces = ```
 		[name: "fft",                            iface: "FFT"],
 		[name: "fftSize",                        iface: "FFTSize"],
 		[name: "gauss",                          iface: "Gauss",               aliases: ["smooth"]],
+		[name: "hessian",                        iface: "Hessian"],
 		[name: "ifft",                           iface: "IFFT"],
 		[name: "linearFilter",                   iface: "LinearFilter"],
 		[name: "max",                            iface: "Max",                 aliases: ["maxFilter", "filterMax"]],

--- a/src/test/java/net/imagej/ops/filter/derivative/PartialDerivativeFilterTest.java
+++ b/src/test/java/net/imagej/ops/filter/derivative/PartialDerivativeFilterTest.java
@@ -1,0 +1,295 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.derivative;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Util;
+import net.imglib2.view.composite.CompositeIntervalView;
+import net.imglib2.view.composite.CompositeView;
+import net.imglib2.view.composite.RealComposite;
+
+/**
+ * Test for partial derivative op.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ */
+
+public class PartialDerivativeFilterTest extends AbstractOpTest {
+
+	@Test
+	public void test() {
+		Img<FloatType> img = generateFloatArrayTestImg(false, new long[] { 20, 20 });
+
+		Cursor<FloatType> cursorImg = img.cursor();
+		int counterX = 0;
+		int counterY = 0;
+		while (cursorImg.hasNext()) {
+			if (counterX > 8 && counterX < 12 || counterY > 8 && counterY < 12) {
+				cursorImg.next().setOne();
+			} else {
+				cursorImg.next().setZero();
+			}
+			counterX++;
+			if (counterX % 20 == 0) {
+				counterY++;
+			}
+			if (counterX == 20) {
+				counterX = 0;
+			}
+			if (counterY == 20) {
+				counterY = 0;
+			}
+		}
+
+		RandomAccessibleInterval<FloatType> out = ops.filter().partialDerivative(img, 0);
+
+		FloatType type = Util.getTypeFromInterval(out).createVariable();
+		type.set(4.0f);
+		RandomAccess<FloatType> outRA = out.randomAccess();
+		for (int i = 0; i < 8; i++) {
+			outRA.setPosition(new int[] { 9, i });
+			assertEquals(type, outRA.get());
+
+		}
+		outRA.setPosition(new int[] { 9, 8 });
+		type.set(3.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 9, 10 });
+		type.set(0.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 9, 11 });
+		type.set(1.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 9, 12 });
+		type.set(3.0f);
+		assertEquals(type, outRA.get());
+		type.set(4.0f);
+		for (int i = 13; i < 20; i++) {
+			outRA.setPosition(new int[] { 9, i });
+			assertEquals(type, outRA.get());
+
+		}
+
+		type.set(-4.0f);
+		for (int i = 0; i < 8; i++) {
+			outRA.setPosition(new int[] { 12, i });
+			assertEquals(type, outRA.get());
+
+		}
+		outRA.setPosition(new int[] { 12, 8 });
+		type.set(-3.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 12, 10 });
+		type.set(0.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 12, 11 });
+		type.set(-1.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 12, 12 });
+		type.set(-3.0f);
+		assertEquals(type, outRA.get());
+		type.set(-4.0f);
+		for (int i = 13; i < 20; i++) {
+			outRA.setPosition(new int[] { 12, i });
+			assertEquals(type, outRA.get());
+
+		}
+	}
+
+	@Test
+	public void testAllDerivatives() {
+		Img<FloatType> img = generateFloatArrayTestImg(false, new long[] { 20, 20, 3 });
+
+		Cursor<FloatType> cursorImg = img.cursor();
+		int counterX = 0;
+		int counterY = 0;
+		while (cursorImg.hasNext()) {
+			if (counterX > 8 && counterX < 12 || counterY > 8 && counterY < 12) {
+				cursorImg.next().setOne();
+			} else {
+				cursorImg.next().setZero();
+			}
+			counterX++;
+			if (counterX % 20 == 0) {
+				counterY++;
+			}
+			if (counterX == 20) {
+				counterX = 0;
+			}
+			if (counterY == 20) {
+				counterY = 0;
+			}
+		}
+
+		CompositeIntervalView<FloatType, RealComposite<FloatType>> out = ops.filter().allPartialDerivatives(img);
+
+		CompositeView<FloatType, RealComposite<FloatType>>.CompositeRandomAccess outRA = out.randomAccess();
+
+		FloatType type = Util.getTypeFromInterval(img).createVariable();
+
+		// position 9,8 in all dimensions
+
+		outRA.setPosition(new int[] { 9, 8, 0 });
+		RealComposite<FloatType> outvalue = outRA.get();
+		Float[] correctValues = new Float[] { 12.0f, 4.0f, 0.0f };
+		int i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 8, 1 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 12.0f, 4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 8, 2 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 12.0f, 4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		// position 9,9 in all dimensions
+
+		outRA.setPosition(new int[] { 9, 9, 0 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 4.0f, 4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 9, 1 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 4.0f, 4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 9, 2 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 4.0f, 4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		// position 9,10 in all dimensions
+
+		outRA.setPosition(new int[] { 9, 10, 0 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 0.0f, 0.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 10, 1 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 0.0f, 0.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 10, 2 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 0.0f, 0.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		// position 9,11 in all dimensions
+
+		outRA.setPosition(new int[] { 9, 11, 0 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 4.0f, -4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 11, 1 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 4.0f, -4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+
+		outRA.setPosition(new int[] { 9, 11, 2 });
+		outvalue = outRA.get();
+		correctValues = new Float[] { 4.0f, -4.0f, 0.0f };
+		i = 0;
+		for (FloatType value : outvalue) {
+			type.set(correctValues[i]);
+			assertEquals(type, value);
+			i++;
+		}
+	}
+}

--- a/src/test/java/net/imagej/ops/filter/hessian/HessianFilterTest.java
+++ b/src/test/java/net/imagej/ops/filter/hessian/HessianFilterTest.java
@@ -1,0 +1,123 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.hessian;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import net.imglib2.view.composite.CompositeIntervalView;
+import net.imglib2.view.composite.CompositeView;
+import net.imglib2.view.composite.RealComposite;
+
+import org.junit.Test;
+
+/**
+ * Test for Hessian matrice op.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ */
+
+public class HessianFilterTest extends AbstractOpTest {
+
+	@Test
+	public void test() {
+		Img<FloatType> img = generateFloatArrayTestImg(false, new long[] { 50, 50 });
+
+		Cursor<FloatType> cursorImg = img.cursor();
+		int counterX = 0;
+		int counterY = 0;
+		while (cursorImg.hasNext()) {
+			if (counterX > 20 && counterX < 30 || counterY > 20 && counterY < 30) {
+				cursorImg.next().setOne();
+			} else {
+				cursorImg.next().setZero();
+			}
+			counterX++;
+			if (counterX % 50 == 0) {
+				counterY++;
+			}
+			if (counterX == 50) {
+				counterX = 0;
+			}
+			if (counterY == 50) {
+				counterY = 0;
+			}
+		}
+
+		CompositeIntervalView<FloatType, RealComposite<FloatType>> out = ops.filter().hessian(img);
+		
+		
+		Cursor<RealComposite<FloatType>> outCursor = Views.iterable(out).cursor();
+		
+		while (outCursor.hasNext()) {
+			RealComposite<FloatType> values = outCursor.next();
+			assertEquals(values.get(1), values.get(2));
+		}
+
+		CompositeView<FloatType, RealComposite<FloatType>>.CompositeRandomAccess outRA = out.randomAccess();
+		
+		// two numbers represent a coordinate: 20|0 ; 21|0 ...
+		int[] positions = new int[] { 20, 0, 21, 0, 19, 31, 19, 30 };
+		float[] valuesXX = new float[] { 16.0f, -16.0f, 15.0f, 11.0f };
+		float[] valuesXY = new float[] { 0.0f, 0.0f, 1.0f, 3.0f };
+		float[] valuesYY = new float[] { 0.0f, 0.0f, 15.0f, 15.0f };
+
+		FloatType type = Util.getTypeFromInterval(img).createVariable();
+		int i = 0;
+		int j = 0;
+		while (i < positions.length - 1) {
+			int[] pos = new int[2];
+			pos[0] = positions[i];
+			pos[1] = positions[i + 1];
+
+			outRA.setPosition(pos);
+			type.set(valuesXX[j]);
+			assertEquals(type, outRA.get().get(0));
+
+			outRA.setPosition(pos);
+			type.set(valuesXY[j]);
+			assertEquals(type, outRA.get().get(1));
+
+			outRA.setPosition(pos);
+			type.set(valuesYY[j]);
+			assertEquals(type, outRA.get().get(3));
+
+			i += 2;
+			j++;
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/ops/filter/sobel/SobelFilterTest.java
+++ b/src/test/java/net/imagej/ops/filter/sobel/SobelFilterTest.java
@@ -1,0 +1,100 @@
+/* #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.sobel;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Util;
+
+import org.junit.Test;
+
+/**
+ * Test for sobel op using separated kernel.
+ * 
+ * @author Eike Heinz, University of Konstanz
+ *
+ */
+
+public class SobelFilterTest extends AbstractOpTest {
+
+	@Test
+	public void test() {
+
+		Img<FloatType> img = generateFloatArrayTestImg(false, new long[] { 20, 20 });
+
+		Cursor<FloatType> cursorImg = img.cursor();
+		int counterX = 0;
+		int counterY = 0;
+		while (cursorImg.hasNext()) {
+			if (counterX > 8 && counterX < 12 || counterY > 8 && counterY < 12) {
+				cursorImg.next().setOne();
+			} else {
+				cursorImg.next().setZero();
+			}
+			counterX++;
+			if (counterX % 20 == 0) {
+				counterY++;
+			}
+			if (counterX == 20) {
+				counterX = 0;
+			}
+			if (counterY == 20) {
+				counterY = 0;
+			}
+		}
+		RandomAccessibleInterval<FloatType> out = ops.filter().sobel(img);
+
+		RandomAccess<FloatType> outRA = out.randomAccess();
+		outRA.setPosition(new int[] { 0, 8 });
+		FloatType type = Util.getTypeFromInterval(out).createVariable();
+		type.set(4.0f);
+		assertEquals(type, outRA.get());
+		type.setZero();
+		outRA.setPosition(new int[] { 0, 10 });
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 10, 8 });
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 10, 10 });
+		assertEquals(type, outRA.get());
+
+		outRA.setPosition(new int[] { 10, 12 });
+		type.set(0.0f);
+		assertEquals(type, outRA.get());
+		outRA.setPosition(new int[] { 12, 10 });
+		assertEquals(type, outRA.get());
+	}
+
+}


### PR DESCRIPTION
This adds an implementation of a separated sobel kernel, a sobel filter and a hessian filter. Both filters use a derivative filter that uses the separated sobel kernel. Tests are included.
~~I've tested the sobel filter on several images and compared these to the already filtered versions.
If required I can add some assert statements to the SobelFilterTest case.~~
