### PR TITLE
Distinguish MapUnaryComputers and MapBinaryInplaces

### DIFF
--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
@@ -44,7 +44,7 @@ import org.scijava.plugin.Plugin;
  * @author Leon Yang
  * @param <EA> element type of inputs + outputs
  */
-@Plugin(type = Ops.Map.class, priority = Priority.HIGH_PRIORITY + 1)
+@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
 public class MapIIAndIIInplace<EA> extends
 	AbstractMapBinaryInplace<EA, IterableInterval<EA>> implements Contingent
 {

--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
@@ -47,7 +47,7 @@ import org.scijava.plugin.Plugin;
  * @author Leon Yang
  * @param <EA> element type of inputs + outputs
  */
-@Plugin(type = Ops.Map.class, priority = Priority.HIGH_PRIORITY + 3)
+@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 10)
 public class MapIIAndIIInplaceParallel<EA> extends
 	AbstractMapBinaryInplace<EA, IterableInterval<EA>> implements Contingent,
 	Parallel

--- a/src/main/templates/net/imagej/ops/map/MapUnaryComputers.vm
+++ b/src/main/templates/net/imagej/ops/map/MapUnaryComputers.vm
@@ -37,7 +37,6 @@ import net.imagej.ops.thread.chunker.CursorBasedChunk;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 
-import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -65,7 +64,7 @@ public class MapUnaryComputers {
 	 * @Param <EI> element type of inputs
 	 * @Param <EO> element type of outputs
 	 */
-	@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + $priority)
+	@Plugin(type = Ops.Map.class, priority = $priority)
 	public static class ${inType.alias}To${outType.alias}<EI, EO> extends
 		AbstractMapComputer<EI, EO, ${inType.name}<EI>, ${outType.name}<EO>>
 		implements Contingent
@@ -91,7 +90,7 @@ public class MapUnaryComputers {
 	 * @Param <EI> element type of inputs
 	 * @Param <EO> element type of outputs
 	 */
-	@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + $paraPrio)
+	@Plugin(type = Ops.Map.class, priority = $paraPrio)
 	public static class ${inType.alias}To${outType.alias}Parallel<EI, EO> extends
 		AbstractMapComputer<EI, EO, ${inType.name}<EI>, ${outType.name}<EO>>
 		implements Contingent, Parallel


### PR DESCRIPTION
Both categories of the maps have the same signature as (II/RAI, II/RAI, op). If the providing op is both a unary computer and a binary inplace op (e.g. the NumericTypeBinaryMath ops), the matching for the two
categories of maps will conflict. Now the unary computer maps have higher priority. If want to use binary inplace maps, Inplaces.binary(...) should be called.