### PR TITLE
Fix alternative parameter in MapNeighborhood

### DIFF
--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
@@ -71,7 +71,7 @@ public class MapNeighborhood<I, O> extends
 	public void initialize() {
 		map = (UnaryComputerOp) Computers.unary(ops(), Map.class,
 			IterableInterval.class, in() != null ? shape.neighborhoodsSafe(in())
-				: RandomAccessibleInterval.class, getOp());
+				: IterableInterval.class, getOp());
 	}
 
 	@Override


### PR DESCRIPTION
Alternative input declaration for ops matching was `RandomAccessibleInteval` instead of `IterableInterval` (if the input of `MapNeighborhood` had already been set).

See Gitter:
> @LeonYang5114: In [MapNeighborhood](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java#L74), should the highlighted line use `IterableInterval.class` instead?
> @stelfrich: I think that line is correct, since `MapNeighborhood` is typed on `RandomAccessibleInterval` inputs, while outputs are `IterableInterval`.
> @LeonYang5114: but that line of code is _matching a helper op_ (i.e. the `map` we get in that line is not a `MapNeighborhood`, but just a simple `MapUnaryComputers.IIToII`), and [`shape.neighborhoodsSafe(in())`](https://github.com/imglib/imglib2-algorithm/blob/master/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java#L150) actually returns an `IterableInterval<Neighborhood<T>>`. 
> @stelfrich: you are right, sorry for the confusion!