### PR TITLE
create morphology namespace

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -708,11 +708,11 @@ public interface OpEnvironment extends Contextual {
 	}
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.map.neighborhood.MapNeighborhood.class)
+	@OpMethod(op = net.imagej.ops.map.neighborhood.DefaultMapNeighborhood.class)
 	default <EI, EO> IterableInterval<EO> map(
 		final IterableInterval<EO> out,
-		final RandomAccessibleInterval<EI> in, final UnaryComputerOp<Iterable<EI>, EO> op,
-		final Shape shape)
+		final RandomAccessibleInterval<EI> in, final Shape shape,
+		final UnaryComputerOp<Iterable<EI>, EO> op)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<EO> result =
@@ -726,7 +726,7 @@ public interface OpEnvironment extends Contextual {
 		op = net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class)
 	default <EI, EO> IterableInterval<EO> map(
 		final IterableInterval<EO> out, final RandomAccessibleInterval<EI> in,
-		final CenterAwareComputerOp<EI, EO> func, final Shape shape)
+		final Shape shape, final CenterAwareComputerOp<EI, EO> func)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<EO> result =

--- a/src/main/java/net/imagej/ops/filter/AbstractCenterAwareNeighborhoodBasedFilter.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractCenterAwareNeighborhoodBasedFilter.java
@@ -62,8 +62,7 @@ public abstract class AbstractCenterAwareNeighborhoodBasedFilter<I, O> extends
 	@Override
 	public void initialize() {
 		filterOp = unaryComputer(out().firstElement());
-		map = Computers.unary(ops(), Map.class, out(), in(),
-			filterOp, shape);
+		map = Computers.unary(ops(), Map.class, out(), in(), shape, filterOp);
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/filter/AbstractNeighborhoodBasedFilter.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractNeighborhoodBasedFilter.java
@@ -58,12 +58,10 @@ public abstract class AbstractNeighborhoodBasedFilter<I, O> extends
 
 	private UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>> map;
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
 		filterOp = unaryComputer(out().firstElement());
-		map = (UnaryComputerOp) Computers.unary(ops(), Map.class, out(), in(),
-			filterOp, shape);
+		map = Computers.unary(ops(), Map.class, out(), in(), shape, filterOp);
 	}
 
 	@Override
@@ -84,10 +82,6 @@ public abstract class AbstractNeighborhoodBasedFilter<I, O> extends
 	}
 
 	/**
-	 * @param inClass Class of the type in the input
-	 *          {@link RandomAccessibleInterval}
-	 * @param outClass Class of the type in the output
-	 *          {@link RandomAccessibleInterval}
 	 * @return the Computer to map to all neighborhoods of input to output.
 	 */
 	protected abstract UnaryComputerOp<Iterable<I>, O> unaryComputer(

--- a/src/main/java/net/imagej/ops/filter/sigma/DefaultSigmaFilter.java
+++ b/src/main/java/net/imagej/ops/filter/sigma/DefaultSigmaFilter.java
@@ -72,7 +72,7 @@ public class DefaultSigmaFilter<T extends RealType<T>, V extends RealType<V>>
 				private UnaryComputerOp<Iterable<T>, DoubleType> variance;
 
 				@Override
-				public void compute2(T center, Iterable<T> neighborhood, V output) {
+				public void compute2(final Iterable<T> neighborhood, final T center, final V output) {
 					if (variance == null) {
 						variance = Computers.unary(ops(), Ops.Stats.Variance.class,
 							DoubleType.class, neighborhood);

--- a/src/main/java/net/imagej/ops/map/neighborhood/AbstractCenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/AbstractCenterAwareComputerOp.java
@@ -39,7 +39,7 @@ import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
  * @author Stefan Helfrich (University of Konstanz)
  */
 public abstract class AbstractCenterAwareComputerOp<I, O> extends
-	AbstractBinaryComputerOp<I, Iterable<I>, O> implements
+	AbstractBinaryComputerOp<Iterable<I>, I, O> implements
 	CenterAwareComputerOp<I, O>
 {
 	// NB: Empty.

--- a/src/main/java/net/imagej/ops/map/neighborhood/AbstractMapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/AbstractMapNeighborhood.java
@@ -30,37 +30,37 @@
 
 package net.imagej.ops.map.neighborhood;
 
+import net.imagej.ops.Op;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
+import net.imglib2.algorithm.neighborhood.Shape;
+
 import org.scijava.plugin.Parameter;
 
-import net.imagej.ops.map.MapBinaryComputer;
-import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
-
 /**
- * Abstract implementation of a {@link MapBinaryComputer} for
- * {@link CenterAwareComputerOp}.
+ * Abstract base class for {@link MapNeighborhood} implementations.
  * 
- * @author Jonathan Hale (University of Konstanz)
- * @author Stefan Helfrich (University of Konstanz)
- * @param <A> mapped on {@code <B>}
- * @param <B> mapped from {@code <A>}
- * @param <C> provides {@code <A>}s
- * @param <D> provides {@code <B>}s
+ * @author Leon Yang
+ * @param <EI> element type of inputs
+ * @param <EO> element type of outputs
+ * @param <PI> producer of inputs
+ * @param <PO> producer of outputs
+ * @param <OP> type of {@link Op} which processes each element
  */
-public abstract class AbstractMapCenterAwareComputer<A, B, C, D> 
-	extends AbstractUnaryComputerOp<C, D>
-	implements MapBinaryComputer<A, Iterable<A>, B, CenterAwareComputerOp<A, B>>
+public abstract class AbstractMapNeighborhood<EI, EO, PI, PO, OP extends Op>
+	extends AbstractBinaryComputerOp<PI, Shape, PO> implements
+	MapNeighborhood<EI, EO, PI, PO, OP>
 {
 
 	@Parameter
-	private CenterAwareComputerOp<A, B> op;
+	private OP op;
 
 	@Override
-	public CenterAwareComputerOp<A, B> getOp() {
+	public OP getOp() {
 		return op;
 	}
 
 	@Override
-	public void setOp(final CenterAwareComputerOp<A, B> op) {
+	public void setOp(final OP op) {
 		this.op = op;
 	}
 }

--- a/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/CenterAwareComputerOp.java
@@ -43,7 +43,7 @@ import net.imagej.ops.special.computer.BinaryComputerOp;
  * @param <O> type of output
  */
 public interface CenterAwareComputerOp<I, O> extends
-	BinaryComputerOp<I, Iterable<I>, O>
+	BinaryComputerOp<Iterable<I>, I, O>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/map/neighborhood/DefaultMapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/DefaultMapNeighborhood.java
@@ -30,11 +30,9 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import net.imagej.ops.OpEnvironment;
 import net.imagej.ops.Ops;
-import net.imagej.ops.Ops.Map;
-import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
@@ -44,36 +42,34 @@ import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
 /**
- * Evaluates a {@link CenterAwareComputerOp} for each {@link Neighborhood} on
- * the input {@link RandomAccessibleInterval} and sets the value of the
- * corresponding pixel on the output {@link IterableInterval}. Similar
- * to {@link DefaultMapNeighborhood}, but passes the center pixel to the op as well.
+ * Evaluates a {@link UnaryComputerOp} for each {@link Neighborhood} on the
+ * input {@link RandomAccessibleInterval}.
  * 
- * @author Jonathan Hale (University of Konstanz)
- * @author Stefan Helfrich (University of Konstanz)
- * @see OpEnvironment#map(IterableInterval, RandomAccessibleInterval, Shape,
- *      CenterAwareComputerOp)
- * @see CenterAwareComputerOp
+ * @author Christian Dietz (University of Konstanz)
+ * @author Martin Horn (University of Konstanz)
+ * @param <I> input type
+ * @param <O> output type
  */
-@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 1)
-public class MapNeighborhoodWithCenter<I, O> extends
-	AbstractMapNeighborhood<I, O, RandomAccessibleInterval<I>, IterableInterval<O>, CenterAwareComputerOp<I, O>>
+@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
+public class DefaultMapNeighborhood<I, O> extends
+	AbstractMapNeighborhood<I, O, RandomAccessibleInterval<I>, IterableInterval<O>, UnaryComputerOp<Iterable<I>, O>>
 {
 
-	private BinaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<Neighborhood<I>>, IterableInterval<O>> map;
+	private UnaryComputerOp<IterableInterval<Neighborhood<I>>, IterableInterval<O>> map;
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
-		map = (BinaryComputerOp) Computers.binary(ops(), Map.class, IterableInterval.class,
-			RandomAccessibleInterval.class, IterableInterval.class, getOp());
+		map = (UnaryComputerOp) Computers.unary(ops(), Ops.Map.class,
+			IterableInterval.class, in1() == null ? IterableInterval.class : in2()
+				.neighborhoods(in()), getOp());
 	}
 
 	@Override
 	public void compute2(final RandomAccessibleInterval<I> in1, final Shape in2,
 		final IterableInterval<O> out)
 	{
-		map.compute2(in1, in2.neighborhoodsSafe(in1), out);
+		map.compute1(in2.neighborhoodsSafe(in1), out);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
@@ -30,55 +30,21 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-
-import net.imagej.ops.OpEnvironment;
-import net.imagej.ops.Ops;
-import net.imagej.ops.Ops.Map;
-import net.imagej.ops.map.AbstractMapComputer;
-import net.imagej.ops.special.computer.Computers;
-import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imglib2.IterableInterval;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imagej.ops.Op;
+import net.imagej.ops.map.MapOp;
+import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imglib2.algorithm.neighborhood.Shape;
 
 /**
- * Evaluates a {@link UnaryComputerOp} for each {@link Neighborhood} on the
- * input {@link IterableInterval}.
+ * Typed interface for "map" ops that work with neighborhoods.
  * 
- * @author Christian Dietz (University of Konstanz)
- * @author Martin Horn (University of Konstanz)
- * @param <I> input type
- * @param <O> output type
- * @see OpEnvironment#map(IterableInterval, IterableInterval, UnaryComputerOp)
- * @see UnaryComputerOp
+ * @author Leon Yang
+ * @param <EI> element type of inputs
+ * @param <EO> element type of outputs
+ * @param <OP> type of {@link Op} which processes each neighborhood
  */
-@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
-public class MapNeighborhood<I, O> extends
-	AbstractMapComputer<Iterable<I>, O, RandomAccessibleInterval<I>, IterableInterval<O>>
+public interface MapNeighborhood<EI, EO, PI, PO, OP extends Op> extends
+	BinaryComputerOp<PI, Shape, PO>, MapOp<OP>
 {
-
-	@Parameter
-	private Shape shape;
-
-	private UnaryComputerOp<IterableInterval<Neighborhood<I>>, IterableInterval<O>> map;
-
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	@Override
-	public void initialize() {
-		map = (UnaryComputerOp) Computers.unary(ops(), Map.class,
-			IterableInterval.class, in() != null ? shape.neighborhoodsSafe(in())
-				: IterableInterval.class, getOp());
-	}
-
-	@Override
-	public void compute1(final RandomAccessibleInterval<I> input,
-		final IterableInterval<O> output)
-	{
-		map.compute1(shape.neighborhoodsSafe(input), output);
-	}
-
+	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -60,20 +60,20 @@ public class MapNeighborhoodWithCenter<I, O> extends
 	AbstractMapNeighborhood<I, O, RandomAccessibleInterval<I>, IterableInterval<O>, CenterAwareComputerOp<I, O>>
 {
 
-	private BinaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<Neighborhood<I>>, IterableInterval<O>> map;
+	private BinaryComputerOp<IterableInterval<Neighborhood<I>>, RandomAccessibleInterval<I>, IterableInterval<O>> map;
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
 		map = (BinaryComputerOp) Computers.binary(ops(), Map.class, IterableInterval.class,
-			RandomAccessibleInterval.class, IterableInterval.class, getOp());
+			IterableInterval.class, RandomAccessibleInterval.class, getOp());
 	}
 
 	@Override
 	public void compute2(final RandomAccessibleInterval<I> in1, final Shape in2,
 		final IterableInterval<O> out)
 	{
-		map.compute2(in1, in2.neighborhoodsSafe(in1), out);
+		map.compute2(in2.neighborhoodsSafe(in1), in1, out);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/morphology/Morphologies.java
+++ b/src/main/java/net/imagej/ops/morphology/Morphologies.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology;
+
+import java.util.List;
+
+import net.imglib2.Interval;
+import net.imglib2.algorithm.morphology.MorphologyUtils;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.type.logic.BitType;
+
+/**
+ * Utility class for morphology operations.
+ * 
+ * @author Leon Yang
+ */
+public class Morphologies {
+
+	private Morphologies() {
+		// NB: Prevent instantiation of utility class.
+	}
+
+	/**
+	 * Computes the min coordinate and the size of an {@link Interval} after
+	 * padding with a list of {@link Shape}s in a series morphology operations.
+	 * 
+	 * @param source the interval to be applied with some morphology operation
+	 * @param shapes the list of Shapes for padding
+	 * @return a size-2 array storing the min coordinate and the size of the
+	 *         padded interval
+	 */
+	public static final long[][] computeMinSize(final Interval source,
+		final List<Shape> shapes)
+	{
+
+		final int numDims = source.numDimensions();
+		final long[] min = new long[numDims];
+		final long[] size = new long[numDims];
+
+		for (int i = 0; i < numDims; i++) {
+			min[i] = source.min(i);
+			size[i] = source.dimension(i);
+		}
+
+		for (final Shape shape : shapes) {
+			final Neighborhood<BitType> nh = MorphologyUtils.getNeighborhood(shape,
+				source);
+			for (int i = 0; i < numDims; i++) {
+				min[i] += nh.min(i);
+				size[i] += nh.dimension(i) - 1;
+			}
+		}
+
+		return new long[][] { min, size };
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/MorphologyNamespace.java
+++ b/src/main/java/net/imagej/ops/morphology/MorphologyNamespace.java
@@ -1,0 +1,299 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology;
+
+import java.util.List;
+
+import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.Namespace;
+import net.imagej.ops.OpMethod;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * The morphology namespace contains morphology operations.
+ * 
+ * @author Leon Yang
+ */
+@Plugin(type = Namespace.class)
+public class MorphologyNamespace extends AbstractNamespace {
+
+	// -- Morphology namespace ops --
+
+	@OpMethod(op = net.imagej.ops.morphology.blackTopHat.ListBlackTopHat.class)
+	public <T extends RealType<T>> IterableInterval<T> blackTopHat(
+		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.BlackTopHat.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.blackTopHat.ListBlackTopHat.class)
+	public <T extends RealType<T>> IterableInterval<T> blackTopHat(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.BlackTopHat.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.close.ListClose.class)
+	public <T extends RealType<T>> IterableInterval<T> close(
+		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Close.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.close.ListClose.class)
+	public <T extends RealType<T>> IterableInterval<T> close(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Close.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.DefaultDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final RandomAccessibleInterval<T> in1, final Shape in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.DefaultDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final Shape in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.DefaultDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final Shape in2, final boolean isFull)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, out, in1, in2, isFull);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.DefaultDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final Shape in2, final boolean isFull,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> f)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, out, in1, in2, isFull, f);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.ListDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.ListDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.dilate.ListDilate.class)
+	public <T extends RealType<T>> IterableInterval<T> dilate(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final boolean isFull)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Dilate.class, out, in1, in2, isFull);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.DefaultErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final RandomAccessibleInterval<T> in1, final Shape in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.DefaultErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final Shape in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.DefaultErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final Shape in2, final boolean isFull)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, out, in1, in2, isFull);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.DefaultErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final Shape in2, final boolean isFull,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> f)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, out, in1, in2, isFull, f);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.ListErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.ListErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.erode.ListErode.class)
+	public <T extends RealType<T>> IterableInterval<T> erode(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final boolean isFull)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Erode.class, out, in1, in2, isFull);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.open.ListOpen.class)
+	public <T extends RealType<T>> IterableInterval<T> open(
+		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Open.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.open.ListOpen.class)
+	public <T extends RealType<T>> IterableInterval<T> open(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.Open.class, out, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.topHat.ListTopHat.class)
+	public <T extends RealType<T>> IterableInterval<T> topHat(
+		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.TopHat.class, in1, in2);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.topHat.ListTopHat.class)
+	public <T extends RealType<T>> IterableInterval<T> topHat(
+		final IterableInterval<T> out, final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Morphology.TopHat.class, out, in1, in2);
+		return result;
+	}
+
+	// -- Named methods --
+
+	@Override
+	public String getName() {
+		return "morphology";
+	}
+
+}

--- a/src/main/java/net/imagej/ops/morphology/blackTopHat/ListBlackTopHat.java
+++ b/src/main/java/net/imagej/ops/morphology/blackTopHat/ListBlackTopHat.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.blackTopHat;
+
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.Maps;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.hybrid.BinaryHybridCF;
+import net.imagej.ops.special.hybrid.Hybrids;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the black-top-hat of a {@link RandomAccessibleInterval} using a
+ * {@link List} of {@link Shape}s. It is the caller's responsibility to provide
+ * a {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.BlackTopHat
+ */
+@Plugin(type = Ops.Morphology.BlackTopHat.class)
+public class ListBlackTopHat<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>>
+	implements Ops.Morphology.BlackTopHat, Contingent
+{
+
+	private BinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>> closeComputer;
+	private BinaryInplace1Op<? super IterableInterval<T>, RandomAccessibleInterval<T>, IterableInterval<T>> subtractor;
+
+	@Override
+	public boolean conforms() {
+		return out() == null || Maps.compatible(in1(), out());
+	}
+
+	@Override
+	public void initialize() {
+		closeComputer = Hybrids.binaryCF(ops(), Ops.Morphology.Close.class, out(),
+			in1(), in2());
+
+		if (out() == null) setOutput(createOutput());
+
+		final T type = Util.getTypeFromInterval(in1());
+		subtractor = Inplaces.binary1(ops(), Ops.Map.class, out(), in(), Inplaces
+			.binary1(ops(), Ops.Math.Subtract.class, type, type));
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		return closeComputer.createOutput(in1, in2);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final IterableInterval<T> out)
+	{
+		closeComputer.compute2(in1, in2, out);
+		subtractor.mutate1(out, in1);
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/close/ListClose.java
+++ b/src/main/java/net/imagej/ops/morphology/close/ListClose.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.close;
+
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.Maps;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.hybrid.BinaryHybridCF;
+import net.imagej.ops.special.hybrid.Hybrids;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the closing of a {@link RandomAccessibleInterval} using a
+ * {@link List} of {@link Shape}s. It is the caller's responsibility to provide
+ * a {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.Closing
+ */
+@Plugin(type = Ops.Morphology.Close.class)
+public class ListClose<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>>
+	implements Ops.Morphology.Close, Contingent
+{
+
+	private T maxVal;
+
+	private UnaryFunctionOp<Interval, Img<T>> imgCreator;
+	private BinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>> dilateComputer;
+	private BinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>> erodeComputer;
+
+	@Override
+	public boolean conforms() {
+		return out() == null || Maps.compatible(in1(), out());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		maxVal = Util.getTypeFromInterval(in()).createVariable();
+		maxVal.setReal(maxVal.getMaxValue());
+
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), maxVal.createVariable());
+
+		dilateComputer = Hybrids.binaryCF(ops(), Ops.Morphology.Dilate.class, out(),
+			in1(), in2(), false);
+
+		erodeComputer = Hybrids.binaryCF(ops(), Ops.Morphology.Erode.class, out(),
+			in1(), in2(), false);
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		return erodeComputer.createOutput(in1, in2);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final IterableInterval<T> out)
+	{
+		final Img<T> buffer = imgCreator.compute1(out);
+		dilateComputer.compute2(in1, in2, buffer);
+		erodeComputer.compute2(Views.interval(Views.extendValue(buffer, maxVal),
+			out), in2, out);
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/dilate/DefaultDilate.java
+++ b/src/main/java/net/imagej/ops/morphology/dilate/DefaultDilate.java
@@ -1,0 +1,163 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.dilate;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.Maps;
+import net.imagej.ops.map.neighborhood.MapNeighborhood;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalInterval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.morphology.MorphologyUtils;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the dilation of a {@link RandomAccessibleInterval} using a single
+ * {@link Shape}. It is the caller's responsibility to provide a
+ * {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.Dilation
+ */
+@Plugin(type = Ops.Morphology.Dilate.class)
+public class DefaultDilate<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, Shape, IterableInterval<T>>
+	implements Ops.Morphology.Dilate, Contingent
+{
+
+	@Parameter(required = false)
+	private boolean isFull;
+
+	@Parameter(required = false)
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> f;
+
+	private T minVal;
+	private MapNeighborhood<T, T, RandomAccessibleInterval<T>, IterableInterval<T>, UnaryComputerOp<Iterable<T>, T>> mapper;
+	private UnaryFunctionOp<Dimensions, Img<T>> imgCreator;
+
+	@Override
+	public boolean conforms() {
+		if (out() == null) return true;
+		if (isFull) return createOutput(in()).iterationOrder().equals(out());
+		return Maps.compatible(in(), out());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		minVal = Util.getTypeFromInterval(in()).createVariable();
+		minVal.setReal(minVal.getMinValue());
+
+		if (f == null) {
+			f = new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(
+				minVal);
+		}
+
+		final UnaryComputerOp neighborComputer = minVal instanceof BitType
+			? new DilateBitType() : Computers.unary(ops(), Ops.Stats.Max.class, minVal
+				.createVariable(), Iterable.class);
+
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), minVal.createVariable());
+
+		if (out() == null) setOutput(createOutput(in()));
+
+		mapper = ops().op(MapNeighborhood.class, out(), in1(), in2(),
+			neighborComputer);
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final Shape in2)
+	{
+		if (isFull) {
+			final long[] dims = MorphologyUtils.computeTargetImageDimensionsAndOffset(
+				in1, in2)[0];
+			return imgCreator.compute1(new FinalInterval(dims));
+		}
+		return imgCreator.compute1(in1);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1, final Shape in2,
+		final IterableInterval<T> output)
+	{
+		final RandomAccessibleInterval<T> extended = RAIs.extend(in1, f);
+		final RandomAccessibleInterval<T> shifted;
+		if (isFull) {
+			final long[] offset = MorphologyUtils
+				.computeTargetImageDimensionsAndOffset(in1, in2)[1];
+			shifted = Views.translate(extended, offset);
+		}
+		else {
+			shifted = extended;
+		}
+		mapper.compute2(Views.interval(shifted, output), in2, output);
+	}
+
+	/**
+	 * Helper op for computing the dilation of a {@link BitType} image.
+	 */
+	private static class DilateBitType extends
+		AbstractUnaryComputerOp<Iterable<BitType>, BitType>
+	{
+
+		@Override
+		public void compute1(final Iterable<BitType> input, final BitType output) {
+			for (final BitType e : input)
+				if (e.get()) {
+					output.set(true);
+					return;
+				}
+			output.set(false);
+		}
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/dilate/ListDilate.java
+++ b/src/main/java/net/imagej/ops/morphology/dilate/ListDilate.java
@@ -1,0 +1,140 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.dilate;
+
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.morphology.Morphologies;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the dilation of a {@link RandomAccessibleInterval} using a
+ * {@link List} of {@link Shape}s. It is the caller's responsibility to provide
+ * a {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.Dilation
+ */
+@Plugin(type = Ops.Morphology.Dilate.class, priority = Priority.LOW_PRIORITY)
+public class ListDilate<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>>
+	implements Ops.Morphology.Dilate, Contingent
+{
+
+	@Parameter(required = false)
+	private boolean isFull;
+
+	private T minVal;
+	private UnaryFunctionOp<Interval, Img<T>> imgCreator;
+	private UnaryComputerOp<IterableInterval<T>, IterableInterval<T>> copyImg;
+	private BinaryComputerOp<RandomAccessibleInterval<T>, Shape, IterableInterval<T>> dilateComputer;
+
+	@Override
+	public boolean conforms() {
+		return out() == null || createOutput().iterationOrder().equals(out()
+			.iterationOrder());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		minVal = Util.getTypeFromInterval(in()).createVariable();
+		minVal.setReal(minVal.getMinValue());
+
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), minVal.createVariable());
+
+		copyImg = (UnaryComputerOp) Computers.unary(ops(),
+			Ops.Copy.IterableInterval.class, IterableInterval.class, Views.iterable(
+				in1()));
+
+		dilateComputer = (BinaryComputerOp) Computers.unary(ops(),
+			Ops.Morphology.Dilate.class, IterableInterval.class, in1(), in2().get(0),
+			false);
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		if (isFull) {
+			final long[][] minSize = Morphologies.computeMinSize(in1, in2);
+			return imgCreator.compute1(new FinalInterval(minSize[1]));
+		}
+		return imgCreator.compute1(in1);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final IterableInterval<T> out)
+	{
+		final long[][] minSize = Morphologies.computeMinSize(in1, in2);
+		final Interval interval = new FinalInterval(minSize[1]);
+		Img<T> upstream = imgCreator.compute1(interval);
+		Img<T> downstream = imgCreator.compute1(interval);
+		Img<T> tmp;
+
+		dilateComputer.compute2(in1, in2.get(0), Views.translate(downstream,
+			minSize[0]));
+		for (int i = 1; i < in2.size(); i++) {
+			// Ping-ponging intermediate results between upstream and downstream to
+			// avoid repetitively creating new Imgs.
+			tmp = downstream;
+			downstream = upstream;
+			upstream = tmp;
+			dilateComputer.compute2(upstream, in2.get(i), downstream);
+		}
+		if (isFull) copyImg.compute1(downstream, out);
+		else copyImg.compute1(Views.interval(Views.translate(downstream,
+			minSize[0]), out), out);
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/erode/DefaultErode.java
+++ b/src/main/java/net/imagej/ops/morphology/erode/DefaultErode.java
@@ -1,0 +1,163 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.erode;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.Maps;
+import net.imagej.ops.map.neighborhood.MapNeighborhood;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalInterval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.morphology.MorphologyUtils;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the erosion of a {@link RandomAccessibleInterval} using a single
+ * {@link Shape}. It is the caller's responsibility to provide a
+ * {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.Erosion
+ */
+@Plugin(type = Ops.Morphology.Erode.class)
+public class DefaultErode<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, Shape, IterableInterval<T>>
+	implements Ops.Morphology.Erode, Contingent
+{
+
+	@Parameter(required = false)
+	private boolean isFull;
+
+	@Parameter(required = false)
+	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> f;
+
+	private T maxVal;
+	private MapNeighborhood<T, T, RandomAccessibleInterval<T>, IterableInterval<T>, UnaryComputerOp<Iterable<T>, T>> mapper;
+	private UnaryFunctionOp<Dimensions, Img<T>> imgCreator;
+
+	@Override
+	public boolean conforms() {
+		if (out() == null) return true;
+		if (isFull) return createOutput(in()).iterationOrder().equals(out());
+		return Maps.compatible(in(), out());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		maxVal = Util.getTypeFromInterval(in()).createVariable();
+		maxVal.setReal(maxVal.getMaxValue());
+
+		if (f == null) {
+			f = new OutOfBoundsConstantValueFactory<T, RandomAccessibleInterval<T>>(
+				maxVal);
+		}
+
+		final UnaryComputerOp neighborComputer = maxVal instanceof BitType
+			? new ErodeBitType() : Computers.unary(ops(), Ops.Stats.Min.class, maxVal
+				.createVariable(), Iterable.class);
+
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), maxVal.createVariable());
+
+		if (out() == null) setOutput(createOutput(in()));
+
+		mapper = ops().op(MapNeighborhood.class, out(), in1(), in2(),
+			neighborComputer);
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final Shape in2)
+	{
+		if (isFull) {
+			final long[] dims = MorphologyUtils.computeTargetImageDimensionsAndOffset(
+				in1, in2)[0];
+			return imgCreator.compute1(new FinalInterval(dims));
+		}
+		return imgCreator.compute1(in1);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1, final Shape in2,
+		final IterableInterval<T> output)
+	{
+		final RandomAccessibleInterval<T> extended = RAIs.extend(in1, f);
+		final RandomAccessibleInterval<T> shifted;
+		if (isFull) {
+			final long[] offset = MorphologyUtils
+					.computeTargetImageDimensionsAndOffset(in1, in2)[1];
+				shifted = Views.translate(extended, offset);
+		}
+		else {
+			shifted = extended;
+		}
+		mapper.compute2(Views.interval(shifted, output), in2, output);
+	}
+
+	/**
+	 * Helper op for computing the erosion of a {@link BitType} image.
+	 */
+	private static class ErodeBitType extends
+		AbstractUnaryComputerOp<Iterable<BitType>, BitType>
+	{
+
+		@Override
+		public void compute1(final Iterable<BitType> input, final BitType output) {
+			for (final BitType e : input)
+				if (!e.get()) {
+					output.set(false);
+					return;
+				}
+			output.set(true);
+		}
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/erode/ListErode.java
+++ b/src/main/java/net/imagej/ops/morphology/erode/ListErode.java
@@ -1,0 +1,141 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.erode;
+
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.morphology.Morphologies;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the erosion of a {@link RandomAccessibleInterval} using a
+ * {@link List} of {@link Shape}s. It is the caller's responsibility to provide
+ * a {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.Erosion
+ */
+@Plugin(type = Ops.Morphology.Erode.class, priority = Priority.LOW_PRIORITY)
+public class ListErode<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>>
+	implements Ops.Morphology.Erode, Contingent
+{
+
+	@Parameter(required = false)
+	private boolean isFull;
+
+	private T maxVal;
+	private UnaryFunctionOp<Interval, Img<T>> imgCreator;
+	private UnaryComputerOp<IterableInterval<T>, IterableInterval<T>> copyImg;
+	private BinaryComputerOp<RandomAccessibleInterval<T>, Shape, IterableInterval<T>> erodeComputer;
+
+	@Override
+	public boolean conforms() {
+		return out() == null || createOutput().iterationOrder().equals(out()
+			.iterationOrder());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		maxVal = Util.getTypeFromInterval(in()).createVariable();
+		maxVal.setReal(maxVal.getMaxValue());
+
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), maxVal.createVariable());
+
+		copyImg = (UnaryComputerOp) Computers.unary(ops(),
+			Ops.Copy.IterableInterval.class, IterableInterval.class, Views.iterable(
+				in1()));
+
+		erodeComputer = (BinaryComputerOp) Computers.unary(ops(),
+			Ops.Morphology.Erode.class, IterableInterval.class, in1(), in2().get(0),
+			false);
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		if (isFull) {
+			final long[][] maxSize = Morphologies.computeMinSize(in1, in2);
+			return imgCreator.compute1(new FinalInterval(maxSize[1]));
+		}
+		return imgCreator.compute1(in1);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final IterableInterval<T> out)
+	{
+		final long[][] minSize = Morphologies.computeMinSize(in1, in2);
+		final Interval interval = new FinalInterval(minSize[1]);
+		Img<T> upstream = imgCreator.compute1(interval);
+		Img<T> downstream = imgCreator.compute1(interval);
+		Img<T> tmp;
+
+		erodeComputer.compute2(in1, in2.get(0), Views.translate(downstream,
+			minSize[0]));
+		for (int i = 1; i < in2.size(); i++) {
+			// Ping-ponging intermediate results between upstream and downstream to
+			// avoid repetitively creating new Imgs.
+			tmp = downstream;
+			downstream = upstream;
+			upstream = tmp;
+			erodeComputer.compute2(Views.interval(Views.extendValue(upstream, maxVal),
+				interval), in2.get(i), downstream);
+		}
+		if (isFull) copyImg.compute1(downstream, out);
+		else copyImg.compute1(Views.interval(Views.translate(downstream,
+			minSize[0]), out), out);
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/open/ListOpen.java
+++ b/src/main/java/net/imagej/ops/morphology/open/ListOpen.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.open;
+
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.Maps;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.hybrid.BinaryHybridCF;
+import net.imagej.ops.special.hybrid.Hybrids;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the closing of a {@link RandomAccessibleInterval} using a
+ * {@link List} of {@link Shape}s. It is the caller's responsibility to provide
+ * a {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.Opening
+ */
+@Plugin(type = Ops.Morphology.Open.class)
+public class ListOpen<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>>
+	implements Ops.Morphology.Open, Contingent
+{
+
+	private T minVal;
+
+	private UnaryFunctionOp<Interval, Img<T>> imgCreator;
+	private BinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>> erodeComputer;
+	private BinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>> dilateComputer;
+
+	@Override
+	public boolean conforms() {
+		return out() == null || Maps.compatible(in1(), out());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		minVal = Util.getTypeFromInterval(in()).createVariable();
+		minVal.setReal(minVal.getMinValue());
+
+		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,
+			Img.class, in(), minVal.createVariable());
+
+		erodeComputer = Hybrids.binaryCF(ops(), Ops.Morphology.Erode.class, out(),
+			in1(), in2(), false);
+
+		dilateComputer = Hybrids.binaryCF(ops(), Ops.Morphology.Dilate.class, out(),
+			in1(), in2(), false);
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		return dilateComputer.createOutput(in1, in2);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final IterableInterval<T> out)
+	{
+		final Img<T> buffer = imgCreator.compute1(out);
+		erodeComputer.compute2(in1, in2, buffer);
+		dilateComputer.compute2(Views.interval(Views.extendValue(buffer, minVal),
+			out), in2, out);
+	}
+}

--- a/src/main/java/net/imagej/ops/morphology/topHat/ListTopHat.java
+++ b/src/main/java/net/imagej/ops/morphology/topHat/ListTopHat.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology.topHat;
+
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.Maps;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.hybrid.BinaryHybridCF;
+import net.imagej.ops.special.hybrid.Hybrids;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Computes the top-hat of a {@link RandomAccessibleInterval} using a
+ * {@link List} of {@link Shape}s. It is the caller's responsibility to provide
+ * a {@link RandomAccessibleInterval} with enough padding for the output.
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see net.imglib2.algorithm.morphology.TopHat
+ */
+@Plugin(type = Ops.Morphology.TopHat.class)
+public class ListTopHat<T extends RealType<T>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>>
+	implements Ops.Morphology.TopHat, Contingent
+{
+
+	private BinaryHybridCF<RandomAccessibleInterval<T>, List<Shape>, IterableInterval<T>> openComputer;
+	private BinaryInplaceOp<? super IterableInterval<T>, IterableInterval<T>> subtractor;
+
+	@Override
+	public boolean conforms() {
+		return out() == null || Maps.compatible(in1(), out());
+	}
+
+	@Override
+	public void initialize() {
+		openComputer = Hybrids.binaryCF(ops(), Ops.Morphology.Open.class, out(),
+			in1(), in2());
+
+		if (out() == null) setOutput(createOutput());
+
+		final T type = Util.getTypeFromInterval(in1());
+		subtractor = Inplaces.binary(ops(), Ops.Map.class, out(), Views.iterable(
+			in()), Inplaces.binary(ops(), Ops.Math.Subtract.class, type, type));
+	}
+
+	@Override
+	public IterableInterval<T> createOutput(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2)
+	{
+		return openComputer.createOutput(in1, in2);
+	}
+
+	@Override
+	public void compute2(final RandomAccessibleInterval<T> in1,
+		final List<Shape> in2, final IterableInterval<T> out)
+	{
+		openComputer.compute2(in1, in2, out);
+		subtractor.mutate2(Views.iterable(in1), out);
+	}
+}

--- a/src/main/java/net/imagej/ops/threshold/localBernsen/LocalBernsenThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localBernsen/LocalBernsenThreshold.java
@@ -74,7 +74,7 @@ public class LocalBernsenThreshold<T extends RealType<T>> extends
 
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			@Override
-			public void compute2(final T center, final Iterable<T> neighborhood,
+			public void compute2(final Iterable<T> neighborhood, final T center,
 				final BitType output)
 			{
 

--- a/src/main/java/net/imagej/ops/threshold/localContrast/LocalContrastThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localContrast/LocalContrastThreshold.java
@@ -63,7 +63,7 @@ public class LocalContrastThreshold<T extends RealType<T>> extends
 
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (minMaxFunc == null) {
 					minMaxFunc = (UnaryFunctionOp) Functions.unary(ops(),

--- a/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThreshold.java
@@ -68,7 +68,7 @@ public class LocalMeanThreshold<T extends RealType<T>> extends
 			private UnaryComputerOp<Iterable<T>, DoubleType> meanOp;
 
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (meanOp == null) {
 					meanOp = Computers.unary(ops(),	Ops.Stats.Mean.class, DoubleType.class, neighborhood);

--- a/src/main/java/net/imagej/ops/threshold/localMedian/LocalMedianThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMedian/LocalMedianThreshold.java
@@ -66,7 +66,7 @@ public class LocalMedianThreshold<T extends RealType<T>> extends LocalThreshold<
 			private UnaryComputerOp<Iterable<T>, DoubleType> median;
 
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (median == null) {
 					median = Computers

--- a/src/main/java/net/imagej/ops/threshold/localMidGrey/LocalMidGreyThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMidGrey/LocalMidGreyThreshold.java
@@ -68,7 +68,7 @@ public class LocalMidGreyThreshold<T extends RealType<T>> extends
 
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (minMaxFunc == null) {
 					minMaxFunc = (UnaryFunctionOp) Functions.unary(ops(),

--- a/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThreshold.java
@@ -70,7 +70,7 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends LocalThreshold
 			private UnaryComputerOp<Iterable<T>, DoubleType> stdDeviation;
 
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (mean == null) {
 					mean = Computers.unary(ops(), Ops.Stats.Mean.class, new DoubleType(),

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThreshold.java
@@ -88,7 +88,7 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends LocalThresh
 			private UnaryComputerOp<Iterable<T>, DoubleType> stdDeviation;
 
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (mean == null) {
 					mean = Computers.unary(ops(), Ops.Stats.Mean.class, new DoubleType(),

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThreshold.java
@@ -79,7 +79,7 @@ public class LocalSauvolaThreshold<T extends RealType<T>> extends LocalThreshold
 			private UnaryComputerOp<Iterable<T>, DoubleType> stdDeviation;
 
 			@Override
-			public void compute2(T center, Iterable<T> neighborhood, BitType output) {
+			public void compute2(final Iterable<T> neighborhood, final T center, final BitType output) {
 
 				if (mean == null) {
 					mean = Computers.unary(ops(), Ops.Stats.Mean.class, new DoubleType(),

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -76,11 +76,13 @@ namespaces = ```
 	]],
 
 	[name: "morphology", iface: "Morphology", ops: [
+		[name: "blackTopHat",                 iface: "BlackTopHat"],
 		[name: "close",                       iface: "Close"],
 		[name: "dilate",                      iface: "Dilate"],
 		[name: "erode",                       iface: "Erode"],
 		[name: "open",                        iface: "Open"],
 		[name: "thin",                        iface: "Thin"],
+		[name: "topHat",                      iface: "TopHat"],
 	]],
 
 	[name: "filter", iface: "Filter", ops: [

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -46,7 +46,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * Test for {@link MapNeighborhood} and {@link MapNeighborhoodWithCenter}.
+ * Test for {@link DefaultMapNeighborhood} and {@link MapNeighborhoodWithCenter}.
  *
  * @author Jonathan Hale (University of Konstanz)
  */
@@ -65,13 +65,13 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 	 * Test if every neighborhood pixel of the image was really accessed during
 	 * the map operation.
 	 *
-	 * @see MapNeighborhood
+	 * @see DefaultMapNeighborhood
 	 */
 	@Test
 	public void testMapNeighborhoodsAccess() {
 		final Op mapOp =
-			ops.op(MapNeighborhood.class, out, in, new CountNeighbors(),
-				new RectangleShape(1, false));
+			ops.op(DefaultMapNeighborhood.class, out, in,
+				new RectangleShape(1, false), new CountNeighbors());
 		mapOp.run();
 
 		for (final ByteType t : out) {
@@ -84,8 +84,8 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 	public
 		void testMapNeighoodsWrongArgs() {
 		final Op mapOp =
-			ops.op(MapNeighborhood.class, out, in, new Increment(),
-				new RectangleShape(1, false));
+			ops.op(DefaultMapNeighborhood.class, out, in,
+				new RectangleShape(1, false), new Increment());
 
 		// ClassCastException will be thrown
 		mapOp.run();
@@ -101,7 +101,7 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 	public void testMapNeighborhoodsWithCenterAccess() {
 		final Op mapOp =
 			ops.op(MapNeighborhoodWithCenter.class, out, in,
-				new CountNeighborsWithCenter(), new RectangleShape(1, false));
+				new RectangleShape(1, false), new CountNeighborsWithCenter());
 		mapOp.run();
 
 		for (final ByteType t : out) {

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -144,7 +144,7 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 	{
 
 		@Override
-		public void compute2(final ByteType center, final Iterable<ByteType> neighborhood,
+		public void compute2(final Iterable<ByteType> neighborhood, final ByteType center,
 			final ByteType output)
 		{
 			ByteType a = center;

--- a/src/test/java/net/imagej/ops/morphology/MorphologyNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/morphology/MorphologyNamespaceTest.java
@@ -1,0 +1,53 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.morphology;
+
+import net.imagej.ops.AbstractNamespaceTest;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link MorphologyNamespace}.
+ *
+ * @author Leon Yang
+ */
+public class MorphologyNamespaceTest extends AbstractNamespaceTest {
+
+	/**
+	 * Tests that the ops of the morphology namespace have corresponding type-safe
+	 * Java method signatures declared in the {@link MorphologyNamespace} class.
+	 */
+	@Test
+	public void testCompleteness() {
+		assertComplete("morphology", MorphologyNamespace.class);
+	}
+
+}

--- a/src/test/java/net/imagej/ops/morphology/blackTopHat/BlackTopHatTest.java
+++ b/src/test/java/net/imagej/ops/morphology/blackTopHat/BlackTopHatTest.java
@@ -1,0 +1,66 @@
+
+package net.imagej.ops.morphology.blackTopHat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.algorithm.morphology.BlackTopHat;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link net.imagej.ops.Ops.Morphology.BlackTopHat}
+ * 
+ * @author Leon Yang
+ */
+public class BlackTopHatTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+
+	@Before
+	public void initialize() {
+		in = generateByteArrayTestImg(true, 10, 10);
+	}
+
+	@Test
+	public void testSingleBlackTopHat() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(ListBlackTopHat.class,
+			Img.class, in, shape);
+		final Img<ByteType> out2 = BlackTopHat.blackTopHat(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListBlackTopHat() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListBlackTopHat.class, IterableInterval.class, in, shapes);
+		final Img<ByteType> out2 = BlackTopHat.blackTopHat(in, shapes, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+}

--- a/src/test/java/net/imagej/ops/morphology/close/ClosingTest.java
+++ b/src/test/java/net/imagej/ops/morphology/close/ClosingTest.java
@@ -1,0 +1,66 @@
+
+package net.imagej.ops.morphology.close;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.algorithm.morphology.Closing;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link net.imagej.ops.Ops.Morphology.Close}
+ * 
+ * @author Leon Yang
+ */
+public class ClosingTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+
+	@Before
+	public void initialize() {
+		in = generateByteArrayTestImg(true, 10, 10);
+	}
+
+	@Test
+	public void testSingleClose() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(ListClose.class,
+			Img.class, in, shape);
+		final Img<ByteType> out2 = Closing.close(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListClose() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListClose.class, IterableInterval.class, in, shapes);
+		final Img<ByteType> out2 = Closing.close(in, shapes, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+}

--- a/src/test/java/net/imagej/ops/morphology/dilate/DilationTest.java
+++ b/src/test/java/net/imagej/ops/morphology/dilate/DilationTest.java
@@ -1,0 +1,117 @@
+
+package net.imagej.ops.morphology.dilate;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.algorithm.morphology.Dilation;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link net.imagej.ops.Ops.Morphology.Dilate}
+ * 
+ * @author Leon Yang
+ */
+public class DilationTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+	private Img<BitType> bitIn;
+
+	@Before
+	public void initialize() {
+		in = generateByteArrayTestImg(true, 10, 10);
+		bitIn = ArrayImgs.bits(10, 10);
+		final Random rnd = new Random(0x123456789caffee1L);
+		for (BitType px : bitIn)
+			px.set(rnd.nextBoolean());
+	}
+
+	@Test
+	public void testSingleDilate() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(DefaultDilate.class,
+			Img.class, in, shape, false);
+		final Img<ByteType> out2 = Dilation.dilate(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testSingleDilateBitType() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<BitType> out1 = (Img<BitType>) ops.run(DefaultDilate.class,
+			Img.class, bitIn, shape, false);
+		final Img<BitType> out2 = Dilation.dilate(bitIn, shape, 1);
+		final Cursor<BitType> c1 = out1.cursor();
+		final Cursor<BitType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testSingleDilateFull() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(DefaultDilate.class,
+			Img.class, in, shape, true);
+		final Img<ByteType> out2 = Dilation.dilateFull(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListDilate() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListDilate.class, IterableInterval.class, in, shapes, false);
+		final Img<ByteType> out2 = Dilation.dilate(in, shapes, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListDilateFull() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListDilate.class, IterableInterval.class, in, shapes, true);
+		final Img<ByteType> out2 = Dilation.dilateFull(in, shapes, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+}

--- a/src/test/java/net/imagej/ops/morphology/erode/ErosionTest.java
+++ b/src/test/java/net/imagej/ops/morphology/erode/ErosionTest.java
@@ -1,0 +1,120 @@
+
+package net.imagej.ops.morphology.erode;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.algorithm.morphology.Erosion;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.view.Views;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link net.imagej.ops.Ops.Morphology.Erode}
+ * 
+ * @author Leon Yang
+ */
+public class ErosionTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+	private Img<BitType> bitIn;
+
+	@Before
+	public void initialize() {
+		in = generateByteArrayTestImg(true, 10, 10);
+		bitIn = ArrayImgs.bits(10, 10);
+		final Random rnd = new Random(0x123456789caffee1L);
+		for (BitType px : bitIn)
+			px.set(rnd.nextBoolean());
+	}
+
+	@Test
+	public void testSingleErode() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(DefaultErode.class,
+			Img.class, in, shape, false);
+		final Img<ByteType> out2 = Erosion.erode(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testSingleErodeBitType() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<BitType> out1 = (Img<BitType>) ops.run(DefaultErode.class,
+			Img.class, bitIn, shape, false);
+		final Img<BitType> out2 = Erosion.erode(bitIn, shape, 1);
+		final Cursor<BitType> c1 = out1.cursor();
+		final Cursor<BitType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testSingleErodeFull() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(DefaultErode.class,
+			Img.class, in, shape, true);
+		final Img<ByteType> out2 = Erosion.erodeFull(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+//	@Test
+	public void testListErode() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		final Img<ByteType> out2 = in.copy();
+		Erosion.erode(Views.extendValue(in, new ByteType((byte) -128)), out2,
+			shapes, 1);
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListErode.class, IterableInterval.class, in, shapes, false);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListErodeFull() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		final Img<ByteType> out2 = Erosion.erodeFull(in, shapes, 1);
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListErode.class, IterableInterval.class, in, shapes, true);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+}

--- a/src/test/java/net/imagej/ops/morphology/open/OpeningTest.java
+++ b/src/test/java/net/imagej/ops/morphology/open/OpeningTest.java
@@ -1,0 +1,66 @@
+
+package net.imagej.ops.morphology.open;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.algorithm.morphology.Opening;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link net.imagej.ops.Ops.Morphology.Open}
+ * 
+ * @author Leon Yang
+ */
+public class OpeningTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+
+	@Before
+	public void initialize() {
+		in = generateByteArrayTestImg(true, 10, 10);
+	}
+
+	@Test
+	public void testSingleOpen() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(ListOpen.class,
+			Img.class, in, shape);
+		final Img<ByteType> out2 = Opening.open(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListOpen() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListOpen.class, IterableInterval.class, in, shapes);
+		final Img<ByteType> out2 = Opening.open(in, shapes, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+}

--- a/src/test/java/net/imagej/ops/morphology/topHat/TopHatTest.java
+++ b/src/test/java/net/imagej/ops/morphology/topHat/TopHatTest.java
@@ -1,0 +1,66 @@
+
+package net.imagej.ops.morphology.topHat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.algorithm.morphology.TopHat;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.algorithm.neighborhood.HorizontalLineShape;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link net.imagej.ops.Ops.Morphology.TopHat}
+ * 
+ * @author Leon Yang
+ */
+public class TopHatTest extends AbstractOpTest {
+
+	private Img<ByteType> in;
+
+	@Before
+	public void initialize() {
+		in = generateByteArrayTestImg(true, 10, 10);
+	}
+
+	@Test
+	public void testSingleTopHat() {
+		final Shape shape = new DiamondShape(1);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> out1 = (Img<ByteType>) ops.run(ListTopHat.class,
+			Img.class, in, shape);
+		final Img<ByteType> out2 = TopHat.topHat(in, shape, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+
+	@Test
+	public void testListTopHat() {
+		final List<Shape> shapes = new ArrayList<Shape>();
+		shapes.add(new DiamondShape(1));
+		shapes.add(new DiamondShape(1));
+		shapes.add(new RectangleShape(1, false));
+		shapes.add(new HorizontalLineShape(2, 1, false));
+		@SuppressWarnings("unchecked")
+		final IterableInterval<ByteType> out1 = (IterableInterval<ByteType>) ops
+			.run(ListTopHat.class, IterableInterval.class, in, shapes);
+		final Img<ByteType> out2 = TopHat.topHat(in, shapes, 1);
+		final Cursor<ByteType> c1 = out1.cursor();
+		final Cursor<ByteType> c2 = out2.cursor();
+		while (c1.hasNext())
+			assertEquals(c1.next().get(), c2.next().get());
+	}
+}


### PR DESCRIPTION
@ctrueden 
Here is some rudimentary work on creating the morphology namespace.

A couple questions:
1. Can we come up with better naming for the ops?
2. Do we need the `Inplace` functionalities for each of the morphology operation? (e.g. [`Erosion#erodeInPlace`](https://github.com/imglib/imglib2-algorithm/blob/master/src/main/java/net/imglib2/algorithm/morphology/Erosion.java#L899-L910), which is actually not really "in place," since it creates a new `Img` and copies it back to the given `RAI`)
3. Do we want to combine the `Single` and `Multi` shape versions of each morphology ops?
4. Do we want to use `Map`, `Chunck` etc to re-implement the code in imglib2?

To do:
- [x] Write test cases
- [x] Include the `TopHat` and `BlackTopHat` operations

**==== Update ====**
This branch is now ready for review. It does two things:

1. Refactor the `map.neighborhood` package. This is done because I think the two `MapNeighborhood` should logically share the same interface, and creating that interface makes it possible to reuse a `MapNeighborhood` with different `Shape`s, which is necessary for morphology operations with a `List` of `Shape`s.

2. Create the morphology namespace and implementations. The implementation is adapted from imglib2, but mostly relies on the Op framework (i.e. `MapNeighborhood`, `Ops.Create.Img`). 

Some notes:
All the morphology ops requires extended RAI (or one that is large enough), but they do not have an optional out of bound factory parameter. Not sure if we really want that.
Only the Dilate and Erode have `Default` ops, which operate on a single shape. Other morphology ops do not have that because `SomeType` can be converted to `List<SomeType>` with a single element, and only the Dilate and Erode would have different implementations between the `Default` and `List` versions.

@ctrueden @dietzc any comment?