### PR TITLE
Create fill

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -57,6 +57,7 @@ import net.imagej.ops.math.MathNamespace;
 import net.imagej.ops.special.SpecialOp;
 import net.imagej.ops.special.UnaryOutputFactory;
 import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.NullaryComputerOp;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.inplace.BinaryInplace1Op;
 import net.imagej.ops.special.inplace.BinaryInplaceOp;
@@ -509,6 +510,28 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = Ops.Map.class)
 	default Object map(final Object... args) {
 		return run(Ops.Map.NAME, args);
+	}
+
+	/** Executes the "map" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.map.MapNullaryIterable.class)
+	default <EO> Iterable<EO> map(final Iterable<EO> out,
+		final NullaryComputerOp<EO> op)
+	{
+		@SuppressWarnings("unchecked")
+		final Iterable<EO> result = (Iterable<EO>) run(net.imagej.ops.Ops.Map.class,
+			out, op);
+		return result;
+	}
+
+	/** Executes the "map" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.map.MapNullaryII.class)
+	default <EO> Iterable<EO> map(final IterableInterval<EO> out,
+		final NullaryComputerOp<EO> op)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<EO> result = (IterableInterval<EO>) run(
+			net.imagej.ops.Ops.Map.class, out, op);
+		return result;
 	}
 
 	/** Executes the "map" operation on the given arguments. */

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -185,6 +185,25 @@ public class ImageNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	// -- fill --
+
+	/** Executes the "fill" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.Ops.Image.Fill.class)
+	public Object fill(final Object... args) {
+		return ops().run(Ops.Image.Fill.class, args);
+	}
+
+	/** Executes the "fill" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.image.fill.DefaultFill.class)
+	public <T extends Type<T>> Iterable<T> fill(final Iterable<T> out,
+		final T in)
+	{
+		@SuppressWarnings("unchecked")
+		final Iterable<T> result = (Iterable<T>) ops().run(
+			net.imagej.ops.Ops.Image.Fill.class, out, in);
+		return result;
+	}
+
 	// -- histogram --
 
 	/** Executes the "histogram" operation on the given arguments. */

--- a/src/main/java/net/imagej/ops/image/fill/DefaultFill.java
+++ b/src/main/java/net/imagej/ops/image/fill/DefaultFill.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.fill;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.AbstractNullaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.NullaryComputerOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Fill an {@link IterableInterval} with some constant value.
+ * 
+ * @author Leon Yang
+ */
+@Plugin(type = Ops.Image.Fill.class)
+public class DefaultFill<T extends Type<T>> extends
+	AbstractNullaryComputerOp<Iterable<T>> implements Ops.Image.Fill
+{
+
+	@Parameter
+	private T constant;
+
+	private NullaryComputerOp<T> assigner;
+	private NullaryComputerOp<Iterable<T>> map;
+
+	@Override
+	public void initialize() {
+		assigner = Computers.nullary(ops(), Ops.Math.Assign.class, constant
+			.createVariable(), constant);
+		map = Computers.nullary(ops(), Ops.Map.class, out(), assigner);
+	}
+
+	@Override
+	public void compute0(final Iterable<T> output) {
+		map.compute0(output);
+	}
+}

--- a/src/main/java/net/imagej/ops/map/AbstractMapNullaryComputer.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapNullaryComputer.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.special.computer.AbstractNullaryComputerOp;
+import net.imagej.ops.special.computer.NullaryComputerOp;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract base class for {@link MapNullaryComputer} implementations.
+ * 
+ * @author Leon Yang
+ * @param <EO> element type of outputs
+ * @param <PO> producer of outputs
+ */
+public abstract class AbstractMapNullaryComputer<EO, PO> extends
+	AbstractNullaryComputerOp<PO> implements
+	MapNullaryComputer<EO, NullaryComputerOp<EO>>
+{
+
+	@Parameter
+	private NullaryComputerOp<EO> op;
+
+	// -- MapOp methods --
+
+	@Override
+	public NullaryComputerOp<EO> getOp() {
+		return op;
+	}
+
+	@Override
+	public void setOp(final NullaryComputerOp<EO> op) {
+		this.op = op;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/map/MapNullaryComputer.java
+++ b/src/main/java/net/imagej/ops/map/MapNullaryComputer.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.special.computer.NullaryComputerOp;
+
+/**
+ * Typed interface for "map" {@link NullaryComputerOp}s.
+ * 
+ * @author Leon Yang
+ * @param <EO> element type of outputs
+ * @param <OP> type of {@link NullaryComputerOp} which processes the elements
+ */
+public interface MapNullaryComputer<EO, OP extends NullaryComputerOp<EO>>
+	extends MapOp<OP>
+{
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ops/map/MapNullaryII.java
+++ b/src/main/java/net/imagej/ops/map/MapNullaryII.java
@@ -1,0 +1,37 @@
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.thread.chunker.ChunkerOp;
+import net.imagej.ops.thread.chunker.CursorBasedChunk;
+import net.imglib2.IterableInterval;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A paralleled version of {@link MapNullaryComputer} over an
+ * {@link IterableInterval}.
+ * 
+ * @author Leon Yang
+ * @param <O> element type of outputs
+ */
+@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 1)
+public class MapNullaryII<O> extends
+	AbstractMapNullaryComputer<O, IterableInterval<O>>
+{
+
+	@Override
+	public void compute0(IterableInterval<O> output) {
+		ops().run(ChunkerOp.class, new CursorBasedChunk() {
+
+			@Override
+			public void execute(final int startIndex, final int stepSize,
+				final int numSteps)
+			{
+				Maps.map(output, getOp(), startIndex, stepSize, numSteps);
+			}
+		}, output.size());
+	}
+
+}

--- a/src/main/java/net/imagej/ops/map/MapNullaryIterable.java
+++ b/src/main/java/net/imagej/ops/map/MapNullaryIterable.java
@@ -1,0 +1,23 @@
+
+package net.imagej.ops.map;
+
+import net.imagej.ops.Ops;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A {@link MapNullaryComputer} over an {@link Iterable}.
+ * 
+ * @author Leon Yang
+ * @param <O> element type of outputs
+ */
+@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
+public class MapNullaryIterable<O> extends AbstractMapNullaryComputer<O, Iterable<O>> {
+
+	@Override
+	public void compute0(Iterable<O> output) {
+		Maps.map(output, getOp());
+	}
+
+}

--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -31,6 +31,7 @@
 package net.imagej.ops.map;
 
 import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.NullaryComputerOp;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.inplace.BinaryInplace1Op;
 import net.imagej.ops.special.inplace.BinaryInplaceOp;
@@ -119,6 +120,29 @@ public class Maps {
 		final IterableInterval<O> c)
 	{
 		return Intervals.equalDimensions(a, b) && Intervals.equalDimensions(a, c);
+	}
+
+	// -- Nullary Maps --
+
+	public static <O> void map(final Iterable<O> a,
+		final NullaryComputerOp<O> op)
+	{
+		for (O e : a)
+			op.compute0(e);
+	}
+
+	public static <O> void map(final IterableInterval<O> a,
+		final NullaryComputerOp<O> op, final int startIndex, final int stepSize,
+		final int numSteps)
+	{
+		final Cursor<O> aCursor = a.cursor();
+		aCursor.jumpFwd(startIndex + 1);
+		int ctr = 0;
+		while (ctr < numSteps) {
+			op.compute0(aCursor.get());
+			aCursor.jumpFwd(stepSize);
+			ctr++;
+		}
 	}
 
 	// -- Unary Maps --

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -46,6 +46,7 @@ import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.img.planar.PlanarImg;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.GenericByteType;
@@ -548,6 +549,19 @@ public class MathNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.Ops.Math.Arctanh.class)
 	public Object arctanh(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Math.Arctanh.class, args);
+	}
+
+	@OpMethod(op = net.imagej.ops.math.NumericTypeNullaryMath.Assign.class)
+	public <T extends Type<T>> T assign(final T out, final T constant) {
+		@SuppressWarnings("unchecked")
+		final T result = (T) ops().run(
+			net.imagej.ops.math.NumericTypeNullaryMath.Assign.class, out, constant);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.Ops.Math.Assign.class)
+	public Object assign(final Object... args) {
+		return ops().run(net.imagej.ops.Ops.Math.Assign.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCeil.class)

--- a/src/main/java/net/imagej/ops/math/NumericTypeNullaryMath.java
+++ b/src/main/java/net/imagej/ops/math/NumericTypeNullaryMath.java
@@ -32,8 +32,10 @@ package net.imagej.ops.math;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractNullaryComputerOp;
+import net.imglib2.type.Type;
 import net.imglib2.type.numeric.NumericType;
 
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -46,6 +48,24 @@ public class NumericTypeNullaryMath {
 
 	private NumericTypeNullaryMath() {
 		// NB: Prevent instantiation of utility class.
+	}
+
+	/**
+	 * Sets the output to a constant.
+	 */
+	@Plugin(type = Ops.Math.Assign.class)
+	public static class Assign<T extends Type<T>> extends
+		AbstractNullaryComputerOp<T> implements Ops.Math.Assign
+	{
+		// NB: This class does not require output to be NumericType. Should consider
+		// move to else where.
+		@Parameter
+		private T constant;
+
+		@Override
+		public void compute0(final T output) {
+			output.set(constant);
+		}
 	}
 
 	/**

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -232,6 +232,7 @@ namespaces = ```
 		[name: "arcsinh",                     iface: "Arcsinh"],
 		[name: "arctan",                      iface: "Arctan"],
 		[name: "arctanh",                     iface: "Arctanh"],
+		[name: "assign",                      iface: "Assign"],
 		[name: "ceil",                        iface: "Ceil"],
 		[name: "complement",                  iface: "Complement",          aliases: ["comp", "not"]],
 		[name: "cos",                         iface: "Cos"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -160,6 +160,7 @@ namespaces = ```
 		[name: "cooccurrencematrix",          iface:"CooccurrenceMatrix"],
 		[name: "crop",                        iface: "Crop",                aliases: ["slice"]],
 		[name: "equation",                    iface: "Equation"],
+		[name: "fill",                        iface: "Fill"],
 		[name: "histogram",                   iface: "Histogram"],
 		[name: "invert",                      iface: "Invert"],
 		[name: "normalize",                   iface: "Normalize",           aliases: ["norm"]],

--- a/src/test/java/net/imagej/ops/image/fill/FillTest.java
+++ b/src/test/java/net/imagej/ops/image/fill/FillTest.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use out source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions out binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer out the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.fill;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link net.imagej.ops.Ops.Image.Fill}.
+ * 
+ * @author Leon Yang
+ */
+public class FillTest extends AbstractOpTest {
+
+	private Img<ByteType> out;
+
+	@Override
+	@Before
+	public void setUp() {
+		super.setUp();
+		out = ArrayImgs.bytes(10, 10);
+	}
+
+	@Test
+	public void testDefaultFill() {
+		ops.run(DefaultFill.class, out, new ByteType((byte) 10));
+
+		for (ByteType px : out)
+			assertEquals(px.get(), 10);
+	}
+}

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -60,6 +60,28 @@ public class MapTest extends AbstractOpTest {
 	private Op sub;
 
 	@Test
+	public void testIterable() {
+		final Img<ByteType> in = generateByteArrayTestImg(true, 10, 10);
+
+		Op nullary = Computers.nullary(ops, Ops.Math.Zero.class, ByteType.class);
+		ops.run(MapNullaryIterable.class, in, nullary);
+
+		for (ByteType ps : in)
+			assertEquals(ps.get(), 0);
+	}
+
+	@Test
+	public void testII() {
+		final Img<ByteType> in = generateByteArrayTestImg(true, 10, 10);
+
+		Op nullary = Computers.nullary(ops, Ops.Math.Zero.class, ByteType.class);
+		ops.run(MapNullaryII.class, in, nullary);
+
+		for (ByteType ps : in)
+			assertEquals(ps.get(), 0);
+	}
+
+	@Test
 	public void testIIAndIIInplace() {
 		final Img<ByteType> first = generateByteArrayTestImg(true, 10, 10);
 		final Img<ByteType> firstCopy = first.copy();


### PR DESCRIPTION
As @dietzc commented in #336, we might want to have some fill ops in the image namespace, which is the goal of this branch.

Some infrastructures are implemented for the fill ops to be possible (MapNullaryComputer, Assign).

One problem is the naming of the fill ops: DefaultFillParallel is actually doing parallel filling implicitly, but I cannot figure out a better naming, and not sure FillInterval should be called FillRAI instead.

Any comment is highly appreciated.