### PR TITLE
Create native test

### DIFF
--- a/src/main/java/net/imagej/ops/create/nativeType/CreateNativeTypeFromClass.java
+++ b/src/main/java/net/imagej/ops/create/nativeType/CreateNativeTypeFromClass.java
@@ -54,7 +54,7 @@ public class CreateNativeTypeFromClass<T extends NativeType<T>> extends
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public UnaryFunctionOp<Class<T>, T> createWorker(final Class<T> in) {
 		return (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Object.class,
-			NativeType.class, Class.class);
+			Object.class, NativeType.class);
 	}
 
 }

--- a/src/test/java/net/imagej/ops/create/CreateNativeTypeTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateNativeTypeTest.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.create;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Test;
+
+/**
+ * Tests creating different NativeTypes.
+ *
+ * @author Brian Northan
+ */
+public class CreateNativeTypeTest extends AbstractOpTest {
+
+	@Test
+	public void testCreateNativeType() {
+
+		// default
+		Object type = ops.create().nativeType();
+		assertEquals(type.getClass(), DoubleType.class);
+
+		// FloatType
+		type = ops.create().nativeType(FloatType.class);
+		assertEquals(type.getClass(), FloatType.class);
+
+		// ComplexFloatType
+		type = ops.create().nativeType(ComplexFloatType.class);
+		assertEquals(type.getClass(), ComplexFloatType.class);
+
+		// DoubleType
+		type = ops.create().nativeType(DoubleType.class);
+		assertEquals(type.getClass(), DoubleType.class);
+
+		// ComplexDoubleType
+		type = ops.create().nativeType(ComplexDoubleType.class);
+		assertEquals(type.getClass(), ComplexDoubleType.class);
+
+	}
+
+}


### PR DESCRIPTION
I added tests for creating native types.  At first the tests failed.  In ```CreateNativeTypeFromClass```, ```createWorker``` tried to match a ```Ops.Create.Object``` with an output of ```NativeType.class```, but ```NativeType``` is an interface so it failed.  

At least that was my understanding of what happened.  I tweaked ```CreateNativeTypeFromClass``` and now the test passes.  Let me know if the change I made makes sense, or if there is a better solution.  