### PR TITLE
Create extended rai

### DIFF
--- a/src/main/java/net/imagej/ops/ExtendedRAI.java
+++ b/src/main/java/net/imagej/ops/ExtendedRAI.java
@@ -1,0 +1,166 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops;
+
+import net.imglib2.Interval;
+import net.imglib2.Positionable;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPositionable;
+import net.imglib2.outofbounds.OutOfBounds;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+
+/**
+ * Wrapper of a {@link RandomAccessibleInterval} and a
+ * {@link OutOfBoundsFactory} that keeps the interval information. All the
+ * method except for accessing out of bounds data are handled by the source RAI.
+ * <p>
+ * Creating an instance of this class could be considered a shorthand for:<br/>
+ * <code>Views.interval(Views.extend(source, outOfBoundsFactory), source);</code>
+ * </p>
+ * 
+ * @author Leon Yang
+ * @param <T> element type
+ * @see ExtendedRandomAccessibleInterval
+ */
+public class ExtendedRAI<T, F extends RandomAccessibleInterval<T>> implements
+	RandomAccessibleInterval<T>
+{
+
+	final protected F source;
+
+	final protected OutOfBoundsFactory<T, ? super F> factory;
+
+	public ExtendedRAI(final F source,
+		final OutOfBoundsFactory<T, ? super F> factory)
+	{
+		this.source = source;
+		this.factory = factory;
+	}
+
+	@Override
+	final public OutOfBounds<T> randomAccess() {
+		return factory.create(source);
+	}
+
+	@Override
+	final public RandomAccess<T> randomAccess(final Interval interval) {
+		assert source.numDimensions() == interval.numDimensions();
+
+		if (Intervals.contains(source, interval)) {
+			return source.randomAccess(interval);
+		}
+		return randomAccess();
+	}
+
+	public F getSource() {
+		return source;
+	}
+
+	// -- delegated methods --
+
+	@Override
+	public long min(int d) {
+		return source.min(d);
+	}
+
+	@Override
+	public void min(long[] min) {
+		source.min(min);
+	}
+
+	@Override
+	public void min(Positionable min) {
+		source.min(min);
+	}
+
+	@Override
+	public long max(int d) {
+		return source.max(d);
+	}
+
+	@Override
+	public void max(long[] max) {
+		source.max(max);
+	}
+
+	@Override
+	public void max(Positionable max) {
+		source.max(max);
+	}
+
+	@Override
+	final public int numDimensions() {
+		return source.numDimensions();
+	}
+
+	@Override
+	public double realMin(int d) {
+		return source.realMin(d);
+	}
+
+	@Override
+	public void realMin(double[] min) {
+		source.realMin(min);
+	}
+
+	@Override
+	public void realMin(RealPositionable min) {
+		source.realMin(min);
+	}
+
+	@Override
+	public double realMax(int d) {
+		return source.realMax(d);
+	}
+
+	@Override
+	public void realMax(double[] max) {
+		source.realMax(max);
+	}
+
+	@Override
+	public void realMax(RealPositionable max) {
+		source.realMax(max);
+	}
+
+	@Override
+	public void dimensions(long[] dimensions) {
+		source.dimensions(dimensions);
+	}
+
+	@Override
+	public long dimension(int d) {
+		return source.dimension(d);
+	}
+}

--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -705,7 +705,7 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(op = net.imagej.ops.map.neighborhood.MapNeighborhood.class)
 	default <I, O> IterableInterval<O> map(
 		final IterableInterval<O> out,
-		final RandomAccessibleInterval<I> in, final UnaryComputerOp<Iterable<I>, O> op,
+		final ExtendedRAI<I, RandomAccessibleInterval<I>> in, final UnaryComputerOp<Iterable<I>, O> op,
 		final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
@@ -719,7 +719,7 @@ public interface OpEnvironment extends Contextual {
 	@OpMethod(
 		op = net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class)
 	default <I, O> IterableInterval<O> map(
-		final IterableInterval<O> out, final RandomAccessibleInterval<I> in,
+		final IterableInterval<O> out, final ExtendedRAI<I, RandomAccessibleInterval<I>> in,
 		final CenterAwareComputerOp<I, O> func, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")

--- a/src/main/java/net/imagej/ops/features/tamura2d/DefaultCoarsenessFeature.java
+++ b/src/main/java/net/imagej/ops/features/tamura2d/DefaultCoarsenessFeature.java
@@ -32,6 +32,7 @@ package net.imagej.ops.features.tamura2d;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.filter.mean.MeanFilterOp;
 import net.imglib2.Cursor;
@@ -44,7 +45,6 @@ import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.util.Intervals;
 
@@ -161,10 +161,11 @@ public class DefaultCoarsenessFeature<I extends RealType<I>, O extends RealType<
 		final byte[] array = new byte[(int) Intervals.numElements(new FinalInterval(dims))];
 		Img<I> meanImg = (Img<I>) ArrayImgs.unsignedBytes(array, dims);
 
-		OutOfBoundsMirrorFactory<ByteType, Img<ByteType>> oobFactory = new OutOfBoundsMirrorFactory<>(
-				Boundary.SINGLE);
+		OutOfBoundsMirrorFactory<I, RandomAccessibleInterval<I>> oobFactory =
+			new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
 
-		ops().run(MeanFilterOp.class, meanImg, input, new RectangleShape(i, true), oobFactory);
+		ops().run(MeanFilterOp.class, meanImg, new ExtendedRAI<>(input, oobFactory),
+			new RectangleShape(i, true));
 
 		return meanImg;
 	}

--- a/src/main/java/net/imagej/ops/filter/AbstractCenterAwareNeighborhoodBasedFilter.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractCenterAwareNeighborhoodBasedFilter.java
@@ -30,34 +30,28 @@
 
 package net.imagej.ops.filter;
 
-import org.scijava.plugin.Parameter;
-
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops.Map;
 import net.imagej.ops.map.neighborhood.CenterAwareComputerOp;
-import net.imagej.ops.special.chain.RAIs;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
-import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
-import net.imglib2.outofbounds.OutOfBoundsFactory;
+
+import org.scijava.plugin.Parameter;
 
 public abstract class AbstractCenterAwareNeighborhoodBasedFilter<I, O> extends
-	AbstractUnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
+	AbstractUnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 
 	@Parameter
 	private Shape shape;
 
-	@Parameter(required = false)
-	private OutOfBoundsFactory<I, RandomAccessibleInterval<I>> outOfBoundsFactory =
-		new OutOfBoundsBorderFactory<>();
-
 	private CenterAwareComputerOp<I, O> filterOp;
 
-	private UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>> map;
+	private UnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>> map;
 
 	@Override
 	public void initialize() {
@@ -67,11 +61,10 @@ public abstract class AbstractCenterAwareNeighborhoodBasedFilter<I, O> extends
 	}
 
 	@Override
-	public void compute1(RandomAccessibleInterval<I> input,
-		IterableInterval<O> output)
+	public void compute1(ExtendedRAI<I, RandomAccessibleInterval<I>> input, IterableInterval<O> output)
 	{
 		// map computer to neighborhoods
-		map.compute1(RAIs.extend(input, outOfBoundsFactory), output);
+		map.compute1(input, output);
 	}
 
 	/**

--- a/src/main/java/net/imagej/ops/filter/AbstractNeighborhoodBasedFilter.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractNeighborhoodBasedFilter.java
@@ -30,8 +30,7 @@
 
 package net.imagej.ops.filter;
 
-import org.scijava.plugin.Parameter;
-
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops.Map;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
@@ -39,39 +38,30 @@ import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
-import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
-import net.imglib2.outofbounds.OutOfBoundsFactory;
-import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
 
 public abstract class AbstractNeighborhoodBasedFilter<I, O> extends
-	AbstractUnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
+	AbstractUnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 
 	@Parameter
 	private Shape shape;
 
-	@Parameter(required = false)
-	private OutOfBoundsFactory<I, RandomAccessibleInterval<I>> outOfBoundsFactory =
-		new OutOfBoundsBorderFactory<I, RandomAccessibleInterval<I>>();
-
 	private UnaryComputerOp<Iterable<I>, O> filterOp;
 
-	private UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>> map;
+	private UnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>> map;
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
 		filterOp = unaryComputer(out().firstElement());
-		map = (UnaryComputerOp) Computers.unary(ops(), Map.class, out(), in(),
-			filterOp, shape);
+		map = Computers.unary(ops(), Map.class, out(), in(), filterOp, shape);
 	}
 
 	@Override
-	public void compute1(RandomAccessibleInterval<I> input,
-		IterableInterval<O> output)
+	public void compute1(ExtendedRAI<I, RandomAccessibleInterval<I>> input, IterableInterval<O> output)
 	{
-		map.compute1(Views.interval(Views.extend(input, outOfBoundsFactory), input),
-			output);
+		map.compute1(input, output);
 	}
 
 	/**

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -33,6 +33,7 @@ package net.imagej.ops.filter;
 import java.util.List;
 
 import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
@@ -1031,27 +1032,12 @@ public class FilterNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.filter.mean.DefaultMeanFilter.class)
 	public <T extends RealType<T>> IterableInterval<T> mean(
 		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape)
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
 				net.imagej.ops.filter.mean.DefaultMeanFilter.class, out, in, shape);
-		return result;
-	}
-
-	/** Executes the "mean" filter operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.mean.DefaultMeanFilter.class)
-	public <T extends RealType<T>> IterableInterval<T> mean(
-		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, T> outOfBoundsFactory)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.filter.mean.DefaultMeanFilter.class, out, in, shape,
-				outOfBoundsFactory);
 		return result;
 	}
 
@@ -1061,7 +1047,7 @@ public class FilterNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.filter.max.DefaultMaxFilter.class)
 	public <T extends RealType<T>, V extends RealType<V>> IterableInterval<T> max(
 		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape)
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
@@ -1070,26 +1056,11 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "max" filter operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.max.DefaultMaxFilter.class)
-	public <T extends RealType<T>> IterableInterval<T> max(
-		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, T> outOfBoundsFactory)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.filter.max.DefaultMaxFilter.class, out, in, shape,
-				outOfBoundsFactory);
-		return result;
-	}
-
 	/** Executes the "median" filter operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.median.DefaultMedianFilter.class)
 	public <T extends RealType<T>> IterableInterval<T> median(
 		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape)
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
@@ -1098,26 +1069,11 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "median" filter operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.median.DefaultMedianFilter.class)
-	public <T extends RealType<T>> IterableInterval<T> median(
-		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, T> outOfBoundsFactory)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.filter.median.DefaultMedianFilter.class, out, in, shape,
-				outOfBoundsFactory);
-		return result;
-	}
-
 	/** Executes the "min" filter operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.min.DefaultMinFilter.class)
 	public <T extends RealType<T>> IterableInterval<T> min(
 		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape)
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
@@ -1126,26 +1082,11 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "min" filter operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.min.DefaultMinFilter.class)
-	public <T extends RealType<T>> IterableInterval<T> min(
-		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, T> outOfBoundsFactory)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.filter.min.DefaultMinFilter.class, out, in, shape,
-				outOfBoundsFactory);
-		return result;
-	}
-
 	/** Executes the "sigma" filter operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.sigma.DefaultSigmaFilter.class)
 	public <T extends RealType<T>> IterableInterval<T> sigma(
 		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
 		final Double range, final Double minPixelFraction)
 	{
 		@SuppressWarnings("unchecked")
@@ -1156,48 +1097,17 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "sigma" filter operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.sigma.DefaultSigmaFilter.class)
-	public <T extends RealType<T>> IterableInterval<T> sigma(
-		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, T> outOfBoundsFactory, final Double range,
-		final Double minPixelFraction)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.filter.sigma.DefaultSigmaFilter.class, out, in, shape,
-				outOfBoundsFactory, range, minPixelFraction);
-		return result;
-	}
-
 	/** Executes the "variance" filter operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.variance.DefaultVarianceFilter.class)
 	public <T extends RealType<T>> IterableInterval<T> variance(
 		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape)
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result =
 			(IterableInterval<T>) ops().run(
 				net.imagej.ops.filter.variance.DefaultVarianceFilter.class, out, in,
 				shape);
-		return result;
-	}
-
-	/** Executes the "variance" filter operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.variance.DefaultVarianceFilter.class)
-	public <T extends RealType<T>> IterableInterval<T> variance(
-		final IterableInterval<T> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, T> outOfBoundsFactory)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.filter.variance.DefaultVarianceFilter.class, out, in,
-				shape, outOfBoundsFactory);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/max/MaxFilterOp.java
+++ b/src/main/java/net/imagej/ops/filter/max/MaxFilterOp.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.max;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
@@ -41,7 +42,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Jonathan Hale (University of Konstanz)
  */
 public interface MaxFilterOp<I, O> extends Ops.Filter.Max,
-	UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
+	UnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/filter/mean/MeanFilterOp.java
+++ b/src/main/java/net/imagej/ops/filter/mean/MeanFilterOp.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.mean;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
@@ -41,7 +42,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Jonathan Hale (University of Konstanz)
  */
 public interface MeanFilterOp<I, O> extends Ops.Filter.Mean,
-	UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
+	UnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/filter/median/MedianFilterOp.java
+++ b/src/main/java/net/imagej/ops/filter/median/MedianFilterOp.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.median;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
@@ -41,7 +42,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Jonathan Hale (University of Konstanz)
  */
 public interface MedianFilterOp<I, O> extends Ops.Filter.Median,
-	UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
+	UnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/filter/min/MinFilterOp.java
+++ b/src/main/java/net/imagej/ops/filter/min/MinFilterOp.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.min;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
@@ -41,7 +42,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Jonathan Hale (University of Konstanz)
  */
 public interface MinFilterOp<T, V> extends Ops.Filter.Min,
-	UnaryComputerOp<RandomAccessibleInterval<T>, IterableInterval<V>>
+	UnaryComputerOp<ExtendedRAI<T, RandomAccessibleInterval<T>>, IterableInterval<V>>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/filter/sigma/SigmaFilterOp.java
+++ b/src/main/java/net/imagej/ops/filter/sigma/SigmaFilterOp.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.sigma;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
@@ -41,7 +42,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Jonathan Hale (University of Konstanz)
  */
 public interface SigmaFilterOp<T, V> extends Ops.Filter.Sigma,
-	UnaryComputerOp<RandomAccessibleInterval<T>, IterableInterval<V>>
+	UnaryComputerOp<ExtendedRAI<T, RandomAccessibleInterval<T>>, IterableInterval<V>>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/filter/variance/VarianceFilterOp.java
+++ b/src/main/java/net/imagej/ops/filter/variance/VarianceFilterOp.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.variance;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.IterableInterval;
@@ -41,7 +42,7 @@ import net.imglib2.RandomAccessibleInterval;
  * @author Jonathan Hale (University of Konstanz)
  */
 public interface VarianceFilterOp<I, O> extends Ops.Filter.Variance,
-	UnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
+	UnaryComputerOp<ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhood.java
@@ -30,10 +30,7 @@
 
 package net.imagej.ops.map.neighborhood;
 
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.OpEnvironment;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Ops.Map;
@@ -44,6 +41,10 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.Shape;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
 
 /**
  * Evaluates a {@link UnaryComputerOp} for each {@link Neighborhood} on the
@@ -58,7 +59,7 @@ import net.imglib2.algorithm.neighborhood.Shape;
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
 public class MapNeighborhood<I, O> extends
-	AbstractMapComputer<Iterable<I>, O, RandomAccessibleInterval<I>, IterableInterval<O>>
+	AbstractMapComputer<Iterable<I>, O, ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 
 	@Parameter
@@ -75,7 +76,7 @@ public class MapNeighborhood<I, O> extends
 	}
 
 	@Override
-	public void compute1(final RandomAccessibleInterval<I> input,
+	public void compute1(final ExtendedRAI<I, RandomAccessibleInterval<I>> input,
 		final IterableInterval<O> output)
 	{
 		map.compute1(shape.neighborhoodsSafe(input), output);

--- a/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/src/main/java/net/imagej/ops/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.map.neighborhood;
 
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.OpEnvironment;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Ops.Map;
@@ -58,7 +59,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 1)
 public class MapNeighborhoodWithCenter<I, O> extends
-	AbstractMapCenterAwareComputer<I, O, RandomAccessibleInterval<I>, IterableInterval<O>>
+	AbstractMapCenterAwareComputer<I, O, ExtendedRAI<I, RandomAccessibleInterval<I>>, IterableInterval<O>>
 {
 
 	@Parameter
@@ -74,10 +75,10 @@ public class MapNeighborhoodWithCenter<I, O> extends
 	}
 
 	@Override
-	public void compute1(final RandomAccessibleInterval<I> input,
+	public void compute1(final ExtendedRAI<I, RandomAccessibleInterval<I>> input,
 		final IterableInterval<O> output)
 	{
-		map.compute2(input, shape.neighborhoodsSafe(input), output);
+		map.compute2(input.getSource(), shape.neighborhoodsSafe(input), output);
 	}
 
 }

--- a/src/main/java/net/imagej/ops/special/chain/RAIs.java
+++ b/src/main/java/net/imagej/ops/special/chain/RAIs.java
@@ -44,8 +44,6 @@ import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.outofbounds.OutOfBoundsFactory;
-import net.imglib2.view.Views;
 
 /**
  * Utility class for working with {@link RandomAccessibleInterval}s.
@@ -68,23 +66,6 @@ public final class RAIs {
 	{
 		return (UnaryComputerOp) Computers.unary(ops, opType, RandomAccessibleInterval.class,
 			in == null ? RandomAccessibleInterval.class : in, otherArgs);
-	}
-
-	/**
-	 * Extends an input using an {@link OutOfBoundsFactory}, if available,
-	 * otherwise returns the unchanged input.
-	 *
-	 * @param in {@link RandomAccessibleInterval} that is to be extended
-	 * @param outOfBounds the factory that is used for extending
-	 * @return {@link RandomAccessibleInterval} extended using the
-	 *         {@link OutOfBoundsFactory} with the interval of in
-	 */
-	public static <T> RandomAccessibleInterval<T> extend(
-		final RandomAccessibleInterval<T> in,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
-	{
-		return outOfBounds == null ? in : Views.interval((Views.extend(in,
-			outOfBounds)), in);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
@@ -41,7 +42,6 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.histogram.Histogram1d;
-import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 
@@ -398,171 +398,81 @@ public class ThresholdNamespace extends AbstractNamespace {
 		op = net.imagej.ops.threshold.localContrast.LocalContrastThreshold.class)
 	public <T extends RealType<T>> IterableInterval<BitType>
 		localContrastThreshold(final IterableInterval<BitType> out,
-			final RandomAccessibleInterval<T> in, final Shape shape,
-			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalContrastThreshold.class,
-				out, in, shape, outOfBounds);
+			.run(net.imagej.ops.Ops.Threshold.LocalContrastThreshold.class, out, in,
+				shape);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.threshold.localMean.LocalMeanThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> localMeanThreshold(
+		final IterableInterval<BitType> out,
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+		final double c)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(net.imagej.ops.Ops.Threshold.LocalMeanThreshold.class, out, in,
+				shape, c);
 		return result;
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.threshold.localContrast.LocalContrastThreshold.class)
+		op = net.imagej.ops.threshold.localMedian.LocalMedianThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> localMedianThreshold(
+		final IterableInterval<BitType> out,
+		final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+		final double c)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(net.imagej.ops.Ops.Threshold.LocalMedianThreshold.class, out, in,
+				shape, c);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.localMidGrey.LocalMidGreyThreshold.class)
 	public <T extends RealType<T>> IterableInterval<BitType>
-		localContrastThreshold(final IterableInterval<BitType> out,
-			final RandomAccessibleInterval<T> in, final Shape shape)
+		localMidGreyThreshold(final IterableInterval<BitType> out,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+			final double c)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalContrastThreshold.class,
-				out, in, shape);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.threshold.localMean.LocalMeanThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localMeanThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double c)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalMeanThreshold.class, out, in, shape,
-				outOfBounds, c);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.threshold.localMean.LocalMeanThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localMeanThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape, final double c)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalMeanThreshold.class, out, in, shape,
-				c);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.threshold.localMedian.LocalMedianThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localMedianThreshold(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double c)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalMedianThreshold.class, out,
-				in, shape, outOfBounds, c);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.threshold.localMedian.LocalMedianThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localMedianThreshold(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape, final double c)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalMedianThreshold.class, out,
-				in, shape, c);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.threshold.localMidGrey.LocalMidGreyThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localMidGreyThreshold(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double c)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalMidGreyThreshold.class, out,
-				in, shape, outOfBounds, c);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.threshold.localMidGrey.LocalMidGreyThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localMidGreyThreshold(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final double c)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalMidGreyThreshold.class, out,
-				in, shape, c);
+			.run(net.imagej.ops.Ops.Threshold.LocalMidGreyThreshold.class, out, in,
+				shape, c);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.localNiblack.LocalNiblackThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localNiblackThreshold(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double c, final double k)
+	public <T extends RealType<T>> IterableInterval<BitType>
+		localNiblackThreshold(final IterableInterval<BitType> out,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+			final double c, final double k)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalNiblackThreshold.class, out,
-				in, shape, outOfBounds, c, k);
-		return result;
-	}
-	
-	@OpMethod(
-		op = net.imagej.ops.threshold.localNiblack.LocalNiblackThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localNiblackThreshold(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final double c, final double k)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(net.imagej.ops.Ops.Threshold.LocalNiblackThreshold.class, out,
-				in, shape, c, k);
+			.run(net.imagej.ops.Ops.Threshold.LocalNiblackThreshold.class, out, in,
+				shape, c, k);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localBernsenThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double contrastThreshold,
-		final double halfMaxValue)
+	@OpMethod(
+		op = net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType>
+		localBernsenThreshold(final IterableInterval<BitType> out,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+			final double contrastThreshold, final double halfMaxValue)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalBernsenThreshold.class, out, in, shape,
-				outOfBounds, contrastThreshold, halfMaxValue);
-		return result;
-	}
-	
-	@OpMethod(op = net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localBernsenThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final double contrastThreshold,
-		final double halfMaxValue)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalBernsenThreshold.class, out, in, shape,
-				contrastThreshold, halfMaxValue);
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(net.imagej.ops.Ops.Threshold.LocalBernsenThreshold.class, out, in,
+				shape, contrastThreshold, halfMaxValue);
 		return result;
 	}
 
@@ -570,15 +480,13 @@ public class ThresholdNamespace extends AbstractNamespace {
 		op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class)
 	public <T extends RealType<T>> IterableInterval<BitType>
 		localPhansalkarThreshold(final IterableInterval<BitType> out,
-			final RandomAccessibleInterval<T> in, final Shape shape,
-			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
 			final double k, final double r)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
-				out, in, shape, outOfBounds, k, r);
+			.run(net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class, out, in,
+				shape, k, r);
 		return result;
 	}
 
@@ -586,15 +494,13 @@ public class ThresholdNamespace extends AbstractNamespace {
 		op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class)
 	public <T extends RealType<T>> IterableInterval<BitType>
 		localPhansalkarThreshold(final IterableInterval<BitType> out,
-			final RandomAccessibleInterval<T> in, final Shape shape,
-			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
 			final double k)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
-				out, in, shape, outOfBounds, k);
+			.run(net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class, out, in,
+				shape, k);
 		return result;
 	}
 
@@ -602,87 +508,56 @@ public class ThresholdNamespace extends AbstractNamespace {
 		op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class)
 	public <T extends RealType<T>> IterableInterval<BitType>
 		localPhansalkarThreshold(final IterableInterval<BitType> out,
-			final RandomAccessibleInterval<T> in, final Shape shape,
-			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
-				out, in, shape, outOfBounds);
+			.run(net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class, out, in,
+				shape);
 		return result;
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.threshold.localPhansalkar.LocalPhansalkarThreshold.class)
+		op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
 	public <T extends RealType<T>> IterableInterval<BitType>
-		localPhansalkarThreshold(final IterableInterval<BitType> out,
-			final RandomAccessibleInterval<T> in, final Shape shape)
+		localSauvolaThreshold(final IterableInterval<BitType> out,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+			final double k, final double r)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.Ops.Threshold.LocalPhansalkarThreshold.class,
-				out, in, shape);
+			.run(net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in,
+				shape, k, r);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localSauvolaThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double k, final double r)
+	@OpMethod(
+		op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType>
+		localSauvolaThreshold(final IterableInterval<BitType> out,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape,
+			final double k)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape,
-				outOfBounds, k, r);
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in,
+				shape, k);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localSauvolaThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
-		final double k)
+	@OpMethod(
+		op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType>
+		localSauvolaThreshold(final IterableInterval<BitType> out,
+			final ExtendedRAI<T, RandomAccessibleInterval<T>> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape,
-				outOfBounds, k);
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in,
+				shape);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localSauvolaThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape,
-				outOfBounds);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.threshold.localSauvola.LocalSauvolaThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> localSauvolaThreshold(
-		final IterableInterval<BitType> out,
-		final RandomAccessibleInterval<T> in, final Shape shape)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result =
-			(IterableInterval<BitType>) ops().run(
-				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape);
-		return result;
-	}
-	
 	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxEntropy.class)
 	public Object maxEntropy(final Object... args) {
 		return ops().run(net.imagej.ops.Ops.Threshold.MaxEntropy.class, args);

--- a/src/test/java/net/imagej/ops/filter/NonLinearFiltersTest.java
+++ b/src/test/java/net/imagej/ops/filter/NonLinearFiltersTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.filter.max.DefaultMaxFilter;
 import net.imagej.ops.filter.max.MaxFilterOp;
 import net.imagej.ops.filter.mean.DefaultMeanFilter;
@@ -55,7 +56,6 @@ import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.util.Util;
-import net.imglib2.view.Views;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +69,7 @@ import org.junit.Test;
  */
 public class NonLinearFiltersTest extends AbstractOpTest {
 
-	Img<ByteType> in;
+	ExtendedRAI<ByteType, Img<ByteType>> in;
 	Img<ByteType> out;
 	RectangleShape shape;
 	OutOfBoundsMirrorFactory<ByteType, Img<ByteType>> oobFactory =
@@ -82,7 +82,8 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Before
 	public void before() throws Exception {
-		in = generateByteArrayTestImg(true, new long[] { 10, 10 });
+		in = new ExtendedRAI<>(generateByteArrayTestImg(true, new long[] {
+			10, 10 }), oobFactory);
 		out = generateByteArrayTestImg(false, new long[] { 10, 10 });
 		shape = new RectangleShape(1, false);
 	}
@@ -93,12 +94,12 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMaxFilter() {
-		ops.run(MaxFilterOp.class, out, in, shape, oobFactory);
+		ops.run(MaxFilterOp.class, out, in, shape);
 
 		byte max = Byte.MIN_VALUE;
 
 		NeighborhoodsIterableInterval<ByteType> neighborhoods =
-			shape.neighborhoods(Views.interval(Views.extendMirrorSingle(in), in));
+			shape.neighborhoods(in);
 		for (ByteType t : neighborhoods.firstElement()) {
 			max = (byte) Math.max(t.getInteger(), max);
 		}
@@ -111,12 +112,12 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMeanFilter() {
-		ops.run(MeanFilterOp.class, out, in, shape, oobFactory);
+		ops.run(MeanFilterOp.class, out, in, shape);
 
 		double sum = 0.0;
 
 		NeighborhoodsIterableInterval<ByteType> neighborhoods =
-			shape.neighborhoods(Views.interval(Views.extendMirrorSingle(in), in));
+			shape.neighborhoods(in);
 		for (ByteType t : neighborhoods.firstElement()) {
 			sum += t.getRealDouble();
 		}
@@ -130,11 +131,11 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMedianFilter() {
-		ops.run(MedianFilterOp.class, out, in, shape, oobFactory);
+		ops.run(MedianFilterOp.class, out, in, shape);
 
 		ArrayList<ByteType> items = new ArrayList<>();
 		NeighborhoodsIterableInterval<ByteType> neighborhoods =
-			shape.neighborhoods(Views.interval(Views.extendMirrorSingle(in), in));
+			shape.neighborhoods(in);
 		for (ByteType t : neighborhoods.firstElement()) {
 			items.add(t.copy());
 		}
@@ -150,12 +151,12 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMinFilter() {
-		ops.run(MinFilterOp.class, out, in, shape, oobFactory);
+		ops.run(MinFilterOp.class, out, in, shape);
 
 		byte min = Byte.MAX_VALUE;
 
 		NeighborhoodsIterableInterval<ByteType> neighborhoods =
-			shape.neighborhoods(Views.interval(Views.extendMirrorSingle(in), in));
+			shape.neighborhoods(in);
 		for (ByteType t : neighborhoods.firstElement()) {
 			min = (byte) Math.min(t.getInteger(), min);
 		}
@@ -168,7 +169,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testSigmaFilter() {
-		ops.run(SigmaFilterOp.class, out, in, shape, oobFactory, 1.0, 0.0);
+		ops.run(SigmaFilterOp.class, out, in, shape, 1.0, 0.0);
 	}
 
 	/**
@@ -177,13 +178,13 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testVarianceFilter() {
-		ops.run(VarianceFilterOp.class, out, in, shape, oobFactory);
+		ops.run(VarianceFilterOp.class, out, in, shape);
 
 		double sum = 0.0;
 		double sumSq = 0.0;
 
 		NeighborhoodsIterableInterval<ByteType> neighborhoods =
-			shape.neighborhoods(Views.interval(Views.extendMirrorSingle(in), in));
+			shape.neighborhoods(in);
 		for (ByteType t : neighborhoods.firstElement()) {
 			sum += t.getRealDouble();
 			sumSq += t.getRealDouble()*t.getRealDouble();

--- a/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
+++ b/src/test/java/net/imagej/ops/map/neighborhood/MapNeighborhoodTest.java
@@ -35,10 +35,12 @@ import static org.junit.Assert.assertEquals;
 import java.util.Iterator;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.Op;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
+import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.Before;
@@ -52,12 +54,13 @@ import org.junit.Test;
  */
 public class MapNeighborhoodTest extends AbstractOpTest {
 
-	private Img<ByteType> in;
+	private ExtendedRAI<ByteType, Img<ByteType>> in;
 	private Img<ByteType> out;
 
 	@Before
 	public void initImg() {
-		in = generateByteArrayTestImg(true, 11, 10);
+		in = new ExtendedRAI<>(generateByteArrayTestImg(true, 11, 10),
+			new OutOfBoundsBorderFactory<>());
 		out = generateByteArrayTestImg(false, 11, 10);
 	}
 
@@ -108,7 +111,7 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 			assertEquals(9, t.get());
 		}
 
-		for (final ByteType t : in) {
+		for (final ByteType t : in.getSource()) {
 			assertEquals(9, t.get());
 		}
 	}

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -33,6 +33,7 @@ package net.imagej.ops.threshold.apply;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.ExtendedRAI;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imagej.ops.threshold.ThresholdNamespace;
 import net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold;
@@ -85,55 +86,31 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testOpMethods() {
-		ops.threshold().localMeanThreshold(out, in, new RectangleShape(3, false),
-			0.0);
-		ops.threshold().localMeanThreshold(out, in, new RectangleShape(3, false),
+		ops.threshold().localMeanThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 0.0);
-
-		ops.threshold().localBernsenThreshold(out, in, new RectangleShape(3, false),
-			1.0, Double.MAX_VALUE * 0.5);
-		ops.threshold().localBernsenThreshold(out, in, new RectangleShape(3, false),
+				Boundary.SINGLE)), new RectangleShape(3, false), 0.0);
+		ops.threshold().localBernsenThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 1.0, Double.MAX_VALUE * 0.5);
-
-		ops.threshold().localContrastThreshold(out, in, new RectangleShape(3,
-			false));
-		ops.threshold().localContrastThreshold(out, in, new RectangleShape(3,
-			false),
+				Boundary.SINGLE)), new RectangleShape(3, false), 1.0, Double.MAX_VALUE *
+					0.5);
+		ops.threshold().localContrastThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE));
-
-		ops.threshold().localMedianThreshold(out, in, new RectangleShape(3, false),
-			1.0);
-		ops.threshold().localMedianThreshold(out, in, new RectangleShape(3, false),
+				Boundary.SINGLE)), new RectangleShape(3, false));
+		ops.threshold().localMedianThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 1.0);
-
-		ops.threshold().localMidGreyThreshold(out, in, new RectangleShape(3, false),
-			1.0);
-		ops.threshold().localMidGreyThreshold(out, in, new RectangleShape(3, false),
+				Boundary.SINGLE)), new RectangleShape(3, false), 1.0);
+		ops.threshold().localMidGreyThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 1.0);
-
-		ops.threshold().localNiblackThreshold(out, in, new RectangleShape(3, false),
-			1.0, 2.0);
-		ops.threshold().localNiblackThreshold(out, in, new RectangleShape(3, false),
+				Boundary.SINGLE)), new RectangleShape(3, false), 1.0);
+		ops.threshold().localNiblackThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 1.0, 2.0);
-
-		ops.threshold().localPhansalkarThreshold(out, in, new RectangleShape(3,
-			false),
+				Boundary.SINGLE)), new RectangleShape(3, false), 1.0, 2.0);
+		ops.threshold().localPhansalkarThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 0.25, 0.5);
-		ops.threshold().localPhansalkarThreshold(out, in, new RectangleShape(3,
-			false));
-
-		ops.threshold().localSauvolaThreshold(out, in, new RectangleShape(3, false),
+				Boundary.SINGLE)), new RectangleShape(3, false), 0.25, 0.5);
+		ops.threshold().localSauvolaThreshold(out, new ExtendedRAI<>(in,
 			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
-				Boundary.SINGLE), 0.5, 0.5);
-		ops.threshold().localSauvolaThreshold(out, in, new RectangleShape(3,
-			false));
+				Boundary.SINGLE)), new RectangleShape(3, false), 0.5, 0.5);
 	}
 
 	/**
@@ -141,9 +118,10 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalBernsenThreshold() {
-		ops.run(LocalBernsenThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE), 1.0,
-			Double.MAX_VALUE * 0.5);
+		ops.run(LocalBernsenThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(
+				Boundary.SINGLE)), new RectangleShape(3, false), 1.0, Double.MAX_VALUE *
+					0.5);
 
 		assertEquals(out.firstElement().get(), true);
 	}
@@ -153,8 +131,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalContrastThreshold() {
-		ops.run(LocalContrastThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+		ops.run(LocalContrastThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false));
 
 		assertEquals(out.firstElement().get(), false);
 	}
@@ -164,9 +143,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalThresholdMean() {
-		ops.run(LocalMeanThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
-			0.0);
+		ops.run(LocalMeanThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false), 0.0);
 
 		assertEquals(out.firstElement().get(), true);
 	}
@@ -176,9 +155,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalMedianThreshold() {
-		ops.run(LocalMedianThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
-			0.0);
+		ops.run(LocalMedianThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false), 0.0);
 
 		assertEquals(out.firstElement().get(), true);
 	}
@@ -188,9 +167,10 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalMidGreyThreshold() {
-		ops.run(LocalMidGreyThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE), 0.0);
-		
+		ops.run(LocalMidGreyThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false), 0.0);
+
 		assertEquals(out.firstElement().get(), true);
 	}
 
@@ -199,9 +179,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalNiblackThreshold() {
-		ops.run(LocalNiblackThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
-			0.0, 0.0);
+		ops.run(LocalNiblackThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false), 0.0, 0.0);
 
 		assertEquals(out.firstElement().get(), true);
 	}
@@ -211,9 +191,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalPhansalkar() {
-		ops.run(LocalPhansalkarThreshold.class, out, in, new RectangleShape(3,
-			false), new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(
-				Boundary.SINGLE), 0.0, 0.0);
+		ops.run(LocalPhansalkarThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false), 0.0, 0.0);
 
 		assertEquals(out.firstElement().get(), false);
 	}
@@ -223,9 +203,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalSauvola() {
-		ops.run(LocalSauvolaThreshold.class, out, in, new RectangleShape(3, false),
-			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
-			0.0, 0.0);
+		ops.run(LocalSauvolaThreshold.class, out, new ExtendedRAI<>(in,
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE)),
+			new RectangleShape(3, false), 0.0, 0.0);
 
 		assertEquals(out.firstElement().get(), false);
 	}


### PR DESCRIPTION
Wrapper of a `link RandomAccessibleInterval` and a `OutOfBoundsFactory` that keeps the interval information. All the method except for accessing out of bounds data are handled by the source RAI. Notice that this class is very similar to [`ExtendedRandomAccessibleInterval`](https://github.com/imglib/imglib2/blob/master/src/main/java/net/imglib2/view/ExtendedRandomAccessibleInterval.java), which does not have the interval information.

Creating an instance of this class could be considered a shorthand for: `Views.interval(Views.extend(source, outOfBoundsFactory), source);`

This branch is experimental. Any comment would be appreciated.                              