### PR TITLE
Fix map compatible

### DIFF
--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -63,13 +63,13 @@ public class Maps {
 	public static <I, O> boolean compatible(final IterableInterval<I> a,
 		final RandomAccessibleInterval<O> b)
 	{
-		return Intervals.equalDimensions(a, b);
+		return Intervals.contains(b, a);
 	}
 
 	public static <I, O> boolean compatible(final RandomAccessibleInterval<I> a,
 		final IterableInterval<O> b)
 	{
-		return Intervals.equalDimensions(a, b);
+		return Intervals.contains(a, b);
 	}
 
 	public static <I1, I2, O> boolean compatible(final IterableInterval<I1> a,
@@ -83,14 +83,14 @@ public class Maps {
 		final IterableInterval<I2> b, final RandomAccessibleInterval<O> c)
 	{
 		return a.iterationOrder().equals(b.iterationOrder()) && Intervals
-			.equalDimensions(a, c);
+			.contains(c, a);
 	}
 
 	public static <I1, I2, O> boolean compatible(final IterableInterval<I1> a,
 		final RandomAccessibleInterval<I2> b, final IterableInterval<O> c)
 	{
 		return a.iterationOrder().equals(c.iterationOrder()) && Intervals
-			.equalDimensions(a, b);
+			.contains(b, a);
 	}
 
 	public static <I1, I2, O> boolean compatible(
@@ -98,27 +98,27 @@ public class Maps {
 		final IterableInterval<O> c)
 	{
 		return b.iterationOrder().equals(c.iterationOrder()) && Intervals
-			.equalDimensions(a, b);
+			.contains(a, b);
 	}
 
 	public static <I1, I2, O> boolean compatible(final IterableInterval<I1> a,
 		final RandomAccessibleInterval<I2> b, final RandomAccessibleInterval<O> c)
 	{
-		return Intervals.equalDimensions(a, b) && Intervals.equalDimensions(a, c);
+		return Intervals.contains(b, a) && Intervals.contains(c, a);
 	}
 
 	public static <I1, I2, O> boolean compatible(
 		final RandomAccessibleInterval<I1> a, final IterableInterval<I2> b,
 		final RandomAccessibleInterval<O> c)
 	{
-		return Intervals.equalDimensions(a, b) && Intervals.equalDimensions(a, c);
+		return Intervals.contains(a, b) && Intervals.contains(c, b);
 	}
 
 	public static <I1, I2, O> boolean compatible(
 		final RandomAccessibleInterval<I1> a, final RandomAccessibleInterval<I2> b,
 		final IterableInterval<O> c)
 	{
-		return Intervals.equalDimensions(a, b) && Intervals.equalDimensions(a, c);
+		return Intervals.contains(a, c) && Intervals.contains(b, c);
 	}
 
 	// -- Unary Maps --

--- a/src/test/java/net/imagej/ops/map/MapCompatibleTest.java
+++ b/src/test/java/net/imagej/ops/map/MapCompatibleTest.java
@@ -1,0 +1,194 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for {@link Maps#compatible}.
+ * 
+ * @author Leon Yang
+ */
+public class MapCompatibleTest extends AbstractOpTest {
+
+	private static IterableInterval<ByteType> in1II;
+	private static IterableInterval<ByteType> in2II;
+	private static IterableInterval<ByteType> outII;
+	private static IterableInterval<ByteType> in1LargeII;
+	private static IterableInterval<ByteType> in2LargeII;
+	private static IterableInterval<ByteType> outLargeII;
+	private static RandomAccessibleInterval<ByteType> in1RAI;
+	private static RandomAccessibleInterval<ByteType> in2RAI;
+	private static RandomAccessibleInterval<ByteType> outRAI;
+	private static RandomAccessibleInterval<ByteType> in1LargeRAI;
+	private static RandomAccessibleInterval<ByteType> in2LargeRAI;
+	private static RandomAccessibleInterval<ByteType> outLargeRAI;
+
+	@SuppressWarnings("unchecked")
+	@BeforeClass
+	public static void init() {
+		in1II = ArrayImgs.bytes(2, 2);
+		in2II = ArrayImgs.bytes(2, 2);
+		outII = ArrayImgs.bytes(2, 2);
+		in1LargeII = ArrayImgs.bytes(3, 3);
+		in2LargeII = ArrayImgs.bytes(3, 3);
+		outLargeII = ArrayImgs.bytes(3, 3);
+		in1RAI = (RandomAccessibleInterval<ByteType>) in1II;
+		in2RAI = (RandomAccessibleInterval<ByteType>) in2II;
+		outRAI = (RandomAccessibleInterval<ByteType>) outII;
+		in1LargeRAI = (RandomAccessibleInterval<ByteType>) in1LargeII;
+		in2LargeRAI = (RandomAccessibleInterval<ByteType>) in2LargeII;
+		outLargeRAI = (RandomAccessibleInterval<ByteType>) outLargeII;
+	}
+
+	@Test
+	public void testIInII() {
+		assertTrue(Maps.compatible(in1II, outII));
+		assertFalse(Maps.compatible(in1II, outLargeII));
+	}
+
+	@Test
+	public void testIInRAI() {
+		assertTrue(Maps.compatible(in1II, outRAI));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1II, outLargeRAI));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1LargeII, outRAI));
+	}
+
+	@Test
+	public void testRAInII() {
+		assertTrue(Maps.compatible(in1RAI, outII));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1LargeRAI, outII));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1RAI, outLargeII));
+	}
+
+	@Test
+	public void testIInIInII() {
+		assertTrue(Maps.compatible(in1II, in2II, outII));
+
+		// IterationOrders do not match
+		assertFalse(Maps.compatible(in1LargeII, in2II, outII));
+		assertFalse(Maps.compatible(in1II, in2LargeII, outII));
+		assertFalse(Maps.compatible(in1II, in2II, outLargeII));
+	}
+
+	@Test
+	public void testIInIInRAI() {
+		assertTrue(Maps.compatible(in1II, in2II, outRAI));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1II, in2II, outLargeRAI));
+
+		// IterationOrders do not match
+		assertFalse(Maps.compatible(in1LargeII, in2II, outLargeRAI));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1II, in2LargeII, outRAI));
+	}
+
+	@Test
+	public void testIInRAInII() {
+		assertTrue(Maps.compatible(in1II, in2RAI, outII));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1II, in2LargeRAI, outII));
+
+		// IterationOrders do not match
+		assertFalse(Maps.compatible(in1LargeII, in2LargeRAI, outII));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1II, in2RAI, outLargeII));
+	}
+
+	@Test
+	public void testRAInIInII() {
+		assertTrue(Maps.compatible(in1RAI, in2II, outII));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1LargeRAI, in2II, outII));
+
+		// IterationOrders do not match
+		assertFalse(Maps.compatible(in1LargeRAI, in2LargeII, outII));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1RAI, in2II, outLargeII));
+	}
+
+	@Test
+	public void testIInRAInRAI() {
+		assertTrue(Maps.compatible(in1II, in2RAI, outRAI));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1II, in2LargeRAI, outLargeRAI));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1LargeII, in2LargeRAI, outRAI));
+	}
+
+	@Test
+	public void testRAInIInRAI() {
+		assertTrue(Maps.compatible(in1RAI, in2II, outRAI));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1LargeRAI, in2II, outLargeRAI));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1LargeRAI, in2LargeII, outRAI));
+	}
+
+	@Test
+	public void testRAInRAInII() {
+		assertTrue(Maps.compatible(in1RAI, in2RAI, outII));
+
+		// RAI contains II
+		assertTrue(Maps.compatible(in1LargeRAI, in2LargeRAI, outII));
+
+		// RAI does not contain II
+		assertFalse(Maps.compatible(in1LargeRAI, in2RAI, outLargeII));
+	}
+}

--- a/src/test/templates/net/imagej/ops/map/MapBinaryComputersTest.vm
+++ b/src/test/templates/net/imagej/ops/map/MapBinaryComputersTest.vm
@@ -55,9 +55,7 @@ import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests for {@link MapBinaryComputers}.
@@ -69,11 +67,7 @@ public class MapBinaryComputersTest extends AbstractOpTest {
 	private Img<ByteType> in1;
 	private Img<ByteType> in2;
 	private Img<ByteType> out;
-	private Img<ByteType> outDiffDims;
 	private Op add;
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Before
 	public void initImg() {
@@ -82,7 +76,6 @@ public class MapBinaryComputersTest extends AbstractOpTest {
 		for (ByteType px : in2)
 			px.set((byte) 1);
 		out = generateByteArrayTestImg(false, 10, 10);
-		outDiffDims = generateByteArrayTestImg(false, 10, 10, 2);
 		add = Computers.binary(ops, Ops.Math.Add.class, ByteType.class,
 			ByteType.class, ByteType.class);
 	}
@@ -99,10 +92,6 @@ public class MapBinaryComputersTest extends AbstractOpTest {
 	public void test${className}() {
 		ops.run(${className}.class, out, in1, in2, add);
 		assertImgAddEquals(in1, in2, out);
-
-		// Expect exception when output has different dimensions
-		thrown.expect(IllegalArgumentException.class);
-		ops.op(${className}.class, outDiffDims, in1, in2, add);
 	}
 
 #end

--- a/src/test/templates/net/imagej/ops/map/MapBinaryInplace1sTest.vm
+++ b/src/test/templates/net/imagej/ops/map/MapBinaryInplace1sTest.vm
@@ -46,9 +46,7 @@ import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests for {@link MapBinaryInplace1}s.
@@ -59,17 +57,12 @@ public class MapBinaryInplace1sTest extends AbstractOpTest {
 
 	private Img<ByteType> in1;
 	private Img<ByteType> in2;
-	private Img<ByteType> in2DiffDims;
 	private Op add;
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Before
 	public void initImg() {
 		in1 = generateByteArrayTestImg(true, 10, 10);
 		in2 = generateByteArrayTestImg(false, 10, 10);
-		in2DiffDims = generateByteArrayTestImg(false, 10, 10, 2);
 		for (ByteType px : in2)
 			px.set((byte) 1);
 		add = Computers.binary(ops, Ops.Math.Add.class, ByteType.class,
@@ -88,10 +81,6 @@ public class MapBinaryInplace1sTest extends AbstractOpTest {
 		final Img<ByteType> in1Copy = in1.copy();
 		ops.run(${className}.class, in1Copy, in2, add);
 		assertImgAddEquals(in1, in2, in1Copy);
-
-		// Expect exception when in2 has different dimensions
-		thrown.expect(IllegalArgumentException.class);
-		ops.op(${className}.class, in1, in2DiffDims, add);
 	}
 
 #end

--- a/src/test/templates/net/imagej/ops/map/MapUnaryComputersTest.vm
+++ b/src/test/templates/net/imagej/ops/map/MapUnaryComputersTest.vm
@@ -47,9 +47,7 @@ import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests for {@link MapUnaryComputers}.
@@ -61,17 +59,12 @@ public class MapUnaryComputersTest extends AbstractOpTest {
 
 	private Img<ByteType> in;
 	private Img<ByteType> out;
-	private Img<ByteType> outDiffDims;
 	private Op add;
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Before
 	public void initImg() {
 		in = generateByteArrayTestImg(true, 10, 10);
 		out = generateByteArrayTestImg(false, 10, 10);
-		outDiffDims = generateByteArrayTestImg(false, 10, 10, 2);
 		add = Computers.unary(ops, Ops.Math.Add.class, ByteType.class, ByteType.class,
 			new ByteType((byte) 1));
 	}
@@ -87,10 +80,6 @@ public class MapUnaryComputersTest extends AbstractOpTest {
 	public void test${className}() {
 		ops.run(${className}.class, out, in, add);
 		assertImgAddOneEquals(in, out);
-
-		// Expect exception when output has different dimensions
-		thrown.expect(IllegalArgumentException.class);
-		ops.op(${className}.class, outDiffDims, in, add);
 	}
 
 #end


### PR DESCRIPTION
When RAI and II are involved, they do not necessarily have the same dimensions. Instead, as long as the II is contained by the RAI, mapping could proceed.