### PR TITLE
Fix double min max

### DIFF
--- a/src/main/java/net/imagej/ops/features/tamura2d/DefaultCoarsenessFeature.java
+++ b/src/main/java/net/imagej/ops/features/tamura2d/DefaultCoarsenessFeature.java
@@ -112,7 +112,8 @@ public class DefaultCoarsenessFeature<I extends RealType<I>, O extends RealType<
 
 			cursor.next();
 
-			double max = Double.MIN_VALUE;
+			// NB: the smallest possible value for maxDiff is 0
+			double maxDiff = 0;
 
 			for (int i = 1; i <= 5; i++) {
 
@@ -133,12 +134,12 @@ public class DefaultCoarsenessFeature<I extends RealType<I>, O extends RealType<
 						double val2 = ra2.get().getRealDouble();
 
 						double diff = Math.abs(val2 - val1);
-						max = diff >= max ? diff : max;
+						maxDiff = diff >= maxDiff ? diff : maxDiff;
 					}
 				}
 			}
 
-			maxDifferences.add(max);
+			maxDifferences.add(maxDiff);
 		}
 		return maxDifferences;
 	}

--- a/src/main/java/net/imagej/ops/stats/DefaultMinMax.java
+++ b/src/main/java/net/imagej/ops/stats/DefaultMinMax.java
@@ -53,8 +53,8 @@ public class DefaultMinMax<I extends RealType<I>> extends
 
 	@Override
 	public Pair<I, I> compute1(final Iterable<I> input) {
-		double tmpMin = Double.MAX_VALUE;
-		double tmpMax = Double.MIN_VALUE;
+		double tmpMin = Double.POSITIVE_INFINITY;
+		double tmpMax = Double.NEGATIVE_INFINITY;
 
 		for (final I in : input) {
 			final double n = in.getRealDouble();

--- a/src/main/java/net/imagej/ops/stats/IterableMax.java
+++ b/src/main/java/net/imagej/ops/stats/IterableMax.java
@@ -53,7 +53,7 @@ public class IterableMax<I extends RealType<I>, O extends RealType<O>> extends
 
 	@Override
 	public void compute1(final Iterable<I> input, final O output) {
-		double max = Double.MIN_VALUE;
+		double max = Double.NEGATIVE_INFINITY;
 		for (final I in : input) {
 			final double n = in.getRealDouble();
 			if (max < n) {

--- a/src/main/java/net/imagej/ops/stats/IterableMin.java
+++ b/src/main/java/net/imagej/ops/stats/IterableMin.java
@@ -53,7 +53,7 @@ public class IterableMin<I extends RealType<I>, O extends RealType<O>> extends
 
 	@Override
 	public void compute1(final Iterable<I> input, final O output) {
-		double min = Double.MAX_VALUE;
+		double min = Double.POSITIVE_INFINITY;
 		for (final I in : input) {
 			final double n = in.getRealDouble();
 			if (min > n) {

--- a/src/main/java/net/imagej/ops/threshold/huang/ComputeHuangThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/huang/ComputeHuangThreshold.java
@@ -92,7 +92,7 @@ public class ComputeHuangThreshold<T extends RealType<T>> extends
 
 		// calculate the threshold
 		int bestThreshold = 0;
-		double bestEntropy = Double.MAX_VALUE;
+		double bestEntropy = Double.POSITIVE_INFINITY;
 		for (int threshold = first; threshold <= last; threshold++) {
 			double entropy = 0;
 			int mu = (int) Math.round(W[threshold] / S[threshold]);

--- a/src/main/java/net/imagej/ops/threshold/maxEntropy/ComputeMaxEntropyThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/maxEntropy/ComputeMaxEntropyThreshold.java
@@ -114,7 +114,7 @@ public class ComputeMaxEntropyThreshold<T extends RealType<T>> extends
 
 		// Calculate the total entropy each gray-level
 		// and find the threshold that maximizes it
-		max_ent = Double.MIN_VALUE;
+		max_ent = Double.NEGATIVE_INFINITY;
 
 		for (it = first_bin; it <= last_bin; it++) {
 			/* Entropy of the background pixels */

--- a/src/main/java/net/imagej/ops/threshold/shanbhag/ComputeShanbhagThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/shanbhag/ComputeShanbhagThreshold.java
@@ -114,7 +114,7 @@ public class ComputeShanbhagThreshold<T extends RealType<T>> extends
 		// Calculate the total entropy each gray-level
 		// and find the threshold that maximizes it
 		threshold = -1;
-		min_ent = Double.MAX_VALUE;
+		min_ent = Double.POSITIVE_INFINITY;
 
 		for (it = first_bin; it <= last_bin; it++) {
 			/* Entropy of the background pixels */

--- a/src/main/java/net/imagej/ops/threshold/yen/ComputeYenThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/yen/ComputeYenThreshold.java
@@ -102,7 +102,7 @@ public class ComputeYenThreshold<T extends RealType<T>> extends
 
 		/* Find the threshold that maximizes the criterion */
 		threshold = -1;
-		max_crit = Double.MIN_VALUE;
+		max_crit = Double.NEGATIVE_INFINITY;
 		for (it = 0; it < histogram.length; it++) {
 			crit = -1.0
 					* ((P1_sq[it] * P2_sq[it]) > 0.0 ? Math.log(P1_sq[it]

--- a/src/test/java/net/imagej/ops/features/tamura2d/Tamura2dFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/tamura2d/Tamura2dFeatureTest.java
@@ -33,6 +33,9 @@ import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.features.AbstractFeatureTest;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.Test;
 
@@ -61,6 +64,12 @@ public class Tamura2dFeatureTest extends AbstractFeatureTest {
 	public void testCoarsenessFeature() {
 		assertEquals(Ops.Tamura.Coarseness.NAME, 43.614, ops.tamura().coarseness(
 			random).getRealDouble(), 1e-3);
+
+		// NB: according to the implementation, this 2x2 image should have exactly 0
+		// coarseness.
+		byte[] arr = new byte[] {0, -1, 0, 0};
+		Img<ByteType> in = ArrayImgs.bytes(arr, 2, 2);
+		assertEquals(Ops.Tamura.Coarseness.NAME, 0.0, ops.tamura().coarseness(in).getRealDouble(), 0.0);
 	}
 
 }

--- a/src/test/java/net/imagej/ops/stats/StatisticsTest.java
+++ b/src/test/java/net/imagej/ops/stats/StatisticsTest.java
@@ -33,6 +33,7 @@ package net.imagej.ops.stats;
 import net.imagej.ops.AbstractOpTest;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -150,6 +151,10 @@ public class StatisticsTest extends AbstractOpTest {
 	public void testMax() {
 		Assert.assertEquals("Max", 254d, ops.stats().max(randomlyFilledImg)
 			.getRealDouble(), 0.00001d);
+
+		// NB: should work with negative numbers
+		Assert.assertEquals("Max", -1.0, ops.stats().max(ArrayImgs.bytes(new byte[] {
+			-1, -2, -4, -3 }, 2, 2)).getRealDouble(), 0.0);
 	}
 
 	@Test


### PR DESCRIPTION
`Double.MIN_VALUE`, which equals to the minimum absolute double value, is used as initial values for finding the maximum values. The correct way is to use `Double.NEGATIVE_INFINITY`. The usage of `Double.MAX_VALUE` is changed to `Double.POSITIVE_INFINITY` for consistency.

Notice that the [`DefaultCoarsenessFeature`](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/features/tamura2d/DefaultCoarsenessFeature.java#L115) has a kind of strange behavior, since an `ArrayImg` with data `{0, -1, 0, 0}` has 0 coarseness.