### PR TITLE
Thresholding Fixes

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdImg.java
+++ b/src/main/java/net/imagej/ops/threshold/AbstractApplyThresholdImg.java
@@ -31,6 +31,7 @@
 package net.imagej.ops.threshold;
 
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
@@ -57,8 +58,8 @@ public abstract class AbstractApplyThresholdImg<T> extends
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void initialize() {
-		applyThresholdComp = Computers.binary(ops(), Ops.Threshold.Apply.class,
-			out(), in(), in().firstElement());
+		applyThresholdComp = (BinaryComputerOp) Computers.binary(ops(), Ops.Threshold.Apply.class,
+			out() == null ? IterableInterval.class : out(), in(), in().firstElement());
 		histCreator = (UnaryFunctionOp) Functions.unary(ops(),
 			Ops.Image.Histogram.class, Histogram1d.class, in());
 		imgCreator = (UnaryFunctionOp) Functions.unary(ops(), Ops.Create.Img.class,

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThreshold.java
@@ -57,11 +57,13 @@ public class ApplyConstantThreshold<T extends RealType<T>> extends
 	private BinaryComputerOp<T, T, BitType> applyThreshold;
 	private UnaryComputerOp<Iterable<T>, Iterable<BitType>> mapper;
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void initialize() {
 		applyThreshold = Computers.binary(ops(), ApplyThresholdComparable.class,
 			BitType.class, in2(), in2());
-		mapper = Computers.unary(ops(), Ops.Map.class, out(), in(), applyThreshold);
+		mapper = (UnaryComputerOp) Computers.unary(ops(), Ops.Map.class, out() == null
+			? Iterable.class : out(), in1(), applyThreshold);
 	}
 
 	@Override

--- a/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethod.vm
+++ b/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethod.vm
@@ -31,8 +31,8 @@
 package net.imagej.ops.threshold;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.function.Functions;
-import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
@@ -60,13 +60,13 @@ public final class ApplyThresholdMethod {
 		implements ${iface}
 	{
 
-		private UnaryFunctionOp<Histogram1d<T>, T> thresholdFunc;
+		private UnaryComputerOp<Histogram1d<T>, T> thresholdComp;
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Override
 		public void initialize() {
 			super.initialize();
-			thresholdFunc = (UnaryFunctionOp) Functions.unary(ops(),
+			thresholdComp = (UnaryComputerOp) Computers.unary(ops(),
 				Ops.Threshold.${method.iface}.class, in().firstElement().getClass(),
 				Histogram1d.class);
 		}
@@ -74,7 +74,9 @@ public final class ApplyThresholdMethod {
 		@Override
 		public T getThreshold(final IterableInterval<T> input) {
 			final Histogram1d<T> hist = histCreator.compute1(input);
-			return thresholdFunc.compute1(hist);
+			final T type = input.firstElement().createVariable();
+			thresholdComp.compute1(hist, type);
+			return type;
 		}
 	}
 #end


### PR DESCRIPTION
This PR fixes https://github.com/imagej/imagej-ops/issues/372.

However, this is just a workaround, as there seem to be deeper problems with the `OpMatching` which I couldn't figure out. However, as a next step I will try to create a test which lets the `OpMatcher` fail and makes the problem more accessible. Basically, now I only changed the `Function.unary(..)` calls to `Computers.unary(...)` calls. I think the `canCast` in https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/DefaultOpMatchingService.java#L267 is correct for `Computers` but not for `Functions`.  But I'm not sure yet. I have to investigate further. However, the most important thing is now, that `otsu` etc can be executed again.

Best,

Christian