### PR TITLE
Improve type flexibility of inplace ops

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -444,12 +444,11 @@ public interface OpEnvironment extends Contextual {
 
 	/** Executes the "join" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.join.DefaultJoin2Inplaces.class)
-	default <A> A join(final A arg, final UnaryInplaceOp<A> first,
-		final UnaryInplaceOp<A> second)
+	default <A, B extends A, C extends B> C join(final C arg,
+		final UnaryInplaceOp<A, B> first, final UnaryInplaceOp<B, C> second)
 	{
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.Ops.Join.class,
-			arg, first, second);
+		final C result = (C) run(net.imagej.ops.Ops.Join.class, arg, first, second);
 		return result;
 	}
 
@@ -467,33 +466,32 @@ public interface OpEnvironment extends Contextual {
 
 	/** Executes the "join" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.join.DefaultJoinNInplaces.class)
-	default <A> A join(final A arg, final List<? extends UnaryInplaceOp<A>> ops) {
+	default <I, O extends I> O join(final O arg,
+		final List<? extends UnaryInplaceOp<I, O>> ops)
+	{
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.Ops.Join.class,
-			arg, ops);
+		final O result = (O) run(net.imagej.ops.Ops.Join.class, arg, ops);
 		return result;
 	}
 
 	/** Executes the "join" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.join.DefaultJoinInplaceAndComputer.class)
-	default <A, B> B join(final B out, final A in, final UnaryInplaceOp<A> first,
-		final UnaryComputerOp<A, B> second)
+	default <AI, AO extends AI, B> B join(final B out, final AO in,
+		final UnaryInplaceOp<AI, AO> first, final UnaryComputerOp<AO, B> second)
 	{
 		@SuppressWarnings("unchecked")
-		final B result = (B) run(
-			net.imagej.ops.Ops.Join.class, out, in, first,
+		final B result = (B) run(net.imagej.ops.Ops.Join.class, out, in, first,
 			second);
 		return result;
 	}
 
 	/** Executes the "join" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.join.DefaultJoinComputerAndInplace.class)
-	default <A, B> B join(final B out, final A in,
-		final UnaryComputerOp<A, B> first, final UnaryInplaceOp<B> second)
+	default <A, BI, BO extends BI> BO join(final BO out, final A in,
+		final UnaryComputerOp<A, BO> first, final UnaryInplaceOp<BI, BO> second)
 	{
 		@SuppressWarnings("unchecked")
-		final B result = (B) run(
-			net.imagej.ops.Ops.Join.class, out, in, first,
+		final BO result = (BO) run(net.imagej.ops.Ops.Join.class, out, in, first,
 			second);
 		return result;
 	}
@@ -506,10 +504,11 @@ public interface OpEnvironment extends Contextual {
 
 	/** Executes the "loop" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.loop.DefaultLoopInplace.class)
-	default <A> A loop(final A arg, final UnaryInplaceOp<A> op, final int n) {
+	default <I, O extends I> O loop(final O arg, final UnaryInplaceOp<I, O> op,
+		final int n)
+	{
 		@SuppressWarnings("unchecked")
-		final A result = (A) run(net.imagej.ops.Ops.Loop.class, arg,
-			op, n);
+		final O result = (O) run(net.imagej.ops.Ops.Loop.class, arg, op, n);
 		return result;
 	}
 
@@ -724,34 +723,36 @@ public interface OpEnvironment extends Contextual {
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.map.MapIIInplaceParallel.class)
-	default <A> IterableInterval<A> map(final IterableInterval<A> arg,
-		final UnaryInplaceOp<A> op)
+	default <EI, EO extends EI> IterableInterval<EO> map(
+		final IterableInterval<EO> arg, final UnaryInplaceOp<EI, EO> op)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<A> result = (IterableInterval<A>) run(
+		final IterableInterval<EO> result = (IterableInterval<EO>) run(
 			net.imagej.ops.Ops.Map.class, arg, op);
 		return result;
 	}
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.map.MapIterableInplace.class)
-	default <A> Iterable<A> map(final Iterable<A> arg, final UnaryInplaceOp<A> op) {
+	default <EI, EO extends EI> Iterable<EO> map(final Iterable<EO> arg,
+		final UnaryInplaceOp<EI, EO> op)
+	{
 		@SuppressWarnings("unchecked")
-		final Iterable<A> result = (Iterable<A>) run(
-			net.imagej.ops.Ops.Map.class, arg, op);
+		final Iterable<EO> result = (Iterable<EO>) run(net.imagej.ops.Ops.Map.class,
+			arg, op);
 		return result;
 	}
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.map.neighborhood.MapNeighborhood.class)
-	default <I, O> IterableInterval<O> map(
-		final IterableInterval<O> out,
-		final RandomAccessibleInterval<I> in, final UnaryComputerOp<Iterable<I>, O> op,
+	default <EI, EO> IterableInterval<EO> map(
+		final IterableInterval<EO> out,
+		final RandomAccessibleInterval<EI> in, final UnaryComputerOp<Iterable<EI>, EO> op,
 		final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result =
-			(IterableInterval<O>) run(
+		final IterableInterval<EO> result =
+			(IterableInterval<EO>) run(
 				net.imagej.ops.Ops.Map.class, out, in, op, shape);
 		return result;
 	}
@@ -759,13 +760,13 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(
 		op = net.imagej.ops.map.neighborhood.MapNeighborhoodWithCenter.class)
-	default <I, O> IterableInterval<O> map(
-		final IterableInterval<O> out, final RandomAccessibleInterval<I> in,
-		final CenterAwareComputerOp<I, O> func, final Shape shape)
+	default <EI, EO> IterableInterval<EO> map(
+		final IterableInterval<EO> out, final RandomAccessibleInterval<EI> in,
+		final CenterAwareComputerOp<EI, EO> func, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result =
-			(IterableInterval<O>) run(
+		final IterableInterval<EO> result =
+			(IterableInterval<EO>) run(
 				net.imagej.ops.Ops.Map.class, out, in, func, shape);
 		return result;
 	}
@@ -776,19 +777,20 @@ public interface OpEnvironment extends Contextual {
 		final Iterable<EI> in, final UnaryComputerOp<EI, EO> op)
 	{
 		@SuppressWarnings("unchecked")
-		final Iterable<EO> result = (Iterable<EO>) run(
-			net.imagej.ops.Ops.Map.class, out, in, op);
+		final Iterable<EO> result = (Iterable<EO>) run(net.imagej.ops.Ops.Map.class,
+			out, in, op);
 		return result;
 	}
 
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.map.MapIIAndIIInplaceParallel.class,
 		net.imagej.ops.map.MapIIAndIIInplace.class })
-	default <EA> IterableInterval<EA> map(final IterableInterval<EA> arg,
-		final IterableInterval<EA> in, final BinaryInplaceOp<EA> op)
+	default <EI, EO extends EI> IterableInterval<EO> map(
+		final IterableInterval<EO> arg, final IterableInterval<EO> in,
+		final BinaryInplaceOp<EI, EO> op)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<EA> result = (IterableInterval<EA>) run(
+		final IterableInterval<EO> result = (IterableInterval<EO>) run(
 			net.imagej.ops.Ops.Map.class, arg, in, op);
 		return result;
 	}
@@ -796,36 +798,41 @@ public interface OpEnvironment extends Contextual {
 	/** Executes the "map" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.map.MapBinaryInplace1s.IIAndIIParallel.class,
 		net.imagej.ops.map.MapBinaryInplace1s.IIAndII.class })
-	default <EA, EI> IterableInterval<EA> map(final IterableInterval<EA> arg,
-		final IterableInterval<EI> in, final BinaryInplace1Op<EA, EI> op)
+	default <EI1, EI2, EO extends EI1> IterableInterval<EO> map(
+		final IterableInterval<EO> arg, final IterableInterval<EI2> in,
+		final BinaryInplace1Op<EI1, EI2, EO> op)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<EA> result = (IterableInterval<EA>) run(
+		final IterableInterval<EO> result = (IterableInterval<EO>) run(
 			Ops.Map.class, arg, in, op);
 		return result;
 	}
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.map.MapBinaryInplace1s.IIAndRAIParallel.class,
+	@OpMethod(ops = {
+		net.imagej.ops.map.MapBinaryInplace1s.IIAndRAIParallel.class,
 		net.imagej.ops.map.MapBinaryInplace1s.IIAndRAI.class })
-	default <EA, EI> IterableInterval<EA> map(final IterableInterval<EA> arg,
-		final RandomAccessibleInterval<EI> in, final BinaryInplace1Op<EA, EI> op)
+	default <EI1, EI2, EO extends EI1> IterableInterval<EO> map(
+		final IterableInterval<EO> arg, final RandomAccessibleInterval<EI2> in,
+		final BinaryInplace1Op<EI1, EI2, EO> op)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<EA> result = (IterableInterval<EA>) run(
+		final IterableInterval<EO> result = (IterableInterval<EO>) run(
 			Ops.Map.class, arg, in, op);
 		return result;
 	}
 
 	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.map.MapBinaryInplace1s.RAIAndIIParallel.class,
+	@OpMethod(ops = {
+		net.imagej.ops.map.MapBinaryInplace1s.RAIAndIIParallel.class,
 		net.imagej.ops.map.MapBinaryInplace1s.RAIAndII.class })
-	default <EA, EI> RandomAccessibleInterval<EA> map(final RandomAccessibleInterval<EA> arg,
-		final IterableInterval<EI> in, final BinaryInplace1Op<EA, EI> op)
+	default <EI1, EI2, EO extends EI1> RandomAccessibleInterval<EO> map(
+		final RandomAccessibleInterval<EO> arg, final IterableInterval<EI2> in,
+		final BinaryInplace1Op<EI1, EI2, EO> op)
 	{
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<EA> result = (RandomAccessibleInterval<EA>) run(
-			Ops.Map.class, arg, in, op);
+		final RandomAccessibleInterval<EO> result =
+			(RandomAccessibleInterval<EO>) run(Ops.Map.class, arg, in, op);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/addNoise/AddNoiseRealTypeCFI.java
+++ b/src/main/java/net/imagej/ops/filter/addNoise/AddNoiseRealTypeCFI.java
@@ -50,7 +50,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Filter.AddNoise.class, priority = Priority.HIGH_PRIORITY)
 public class AddNoiseRealTypeCFI<T extends RealType<T>> extends
-	AbstractUnaryHybridCFI<T> implements Ops.Filter.AddNoise
+	AbstractUnaryHybridCFI<T, T> implements Ops.Filter.AddNoise
 {
 
 	@Parameter

--- a/src/main/java/net/imagej/ops/identity/IdentityOp.java
+++ b/src/main/java/net/imagej/ops/identity/IdentityOp.java
@@ -31,13 +31,13 @@
 package net.imagej.ops.identity;
 
 import net.imagej.ops.Ops;
-import net.imagej.ops.special.inplace.UnaryInplaceOp;
+import net.imagej.ops.special.inplace.UnaryInplaceOnlyOp;
 
 /**
  * A typed "identity" function.
  * 
  * @author Curtis Rueden
  */
-public interface IdentityOp<A> extends Ops.Identity, UnaryInplaceOp<A> {
+public interface IdentityOp<A> extends Ops.Identity, UnaryInplaceOnlyOp<A> {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/image/integral/AbstractIntegralImg.java
+++ b/src/main/java/net/imagej/ops/image/integral/AbstractIntegralImg.java
@@ -57,7 +57,7 @@ public abstract class AbstractIntegralImg<I extends RealType<I>> extends
 	implements Contingent
 {
 
-	private AbstractUnaryHybridCI<IterableInterval<RealType<?>>> integralAdd;
+	private AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>> integralAdd;
 	private UnaryComputerOp[] slicewiseOps;
 	
 	@Override
@@ -125,6 +125,6 @@ public abstract class AbstractIntegralImg<I extends RealType<I>> extends
 	 * Implements the row-wise addition required for computations of integral
 	 * images.
 	 */
-	public abstract AbstractUnaryHybridCI<IterableInterval<RealType<?>>> getComputer();
+	public abstract AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>> getComputer();
 
 }

--- a/src/main/java/net/imagej/ops/image/integral/DefaultIntegralImg.java
+++ b/src/main/java/net/imagej/ops/image/integral/DefaultIntegralImg.java
@@ -55,7 +55,7 @@ public class DefaultIntegralImg<I extends RealType<I>> extends
 {
 	
 	@Override
-	public AbstractUnaryHybridCI<IterableInterval<RealType<?>>> getComputer() {
+	public AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>> getComputer() {
 		return new IntegralAddComputer();
 	}
 
@@ -66,7 +66,7 @@ public class DefaultIntegralImg<I extends RealType<I>> extends
 	 * @author Stefan Helfrich (University of Konstanz)
 	 */
 	private class IntegralAddComputer extends
-		AbstractUnaryHybridCI<IterableInterval<RealType<?>>>
+		AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>>
 	{
 
 		@Override

--- a/src/main/java/net/imagej/ops/image/integral/SquareIntegralImg.java
+++ b/src/main/java/net/imagej/ops/image/integral/SquareIntegralImg.java
@@ -56,7 +56,7 @@ public class SquareIntegralImg<I extends RealType<I>> extends
 {
 	
 	@Override
-	public AbstractUnaryHybridCI<IterableInterval<RealType<?>>> getComputer() {
+	public AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>> getComputer() {
 		return new IntegralAddComputer();
 	}
 
@@ -67,7 +67,7 @@ public class SquareIntegralImg<I extends RealType<I>> extends
 	 * @author Stefan Helfrich (University of Konstanz)
 	 */
 	private class IntegralAddComputer extends
-		AbstractUnaryHybridCI<IterableInterval<RealType<?>>>
+		AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>>
 	{
 
 		@Override

--- a/src/main/java/net/imagej/ops/join/DefaultJoin2Inplaces.java
+++ b/src/main/java/net/imagej/ops/join/DefaultJoin2Inplaces.java
@@ -43,35 +43,35 @@ import org.scijava.plugin.Plugin;
  * @author Christian Dietz (University of Konstanz)
  */
 @Plugin(type = Ops.Join.class)
-public class DefaultJoin2Inplaces<A> extends AbstractUnaryInplaceOp<A> implements
-	Join2Inplaces<A>
+public class DefaultJoin2Inplaces<A> extends
+	AbstractUnaryInplaceOp<A> implements Join2Inplaces<A, A, A>
 {
 
 	@Parameter
-	private UnaryInplaceOp<A> first;
+	private UnaryInplaceOp<A, A> first;
 
 	@Parameter
-	private UnaryInplaceOp<A> second;
+	private UnaryInplaceOp<A, A> second;
 
 	// -- Join2Ops methods --
 
 	@Override
-	public UnaryInplaceOp<A> getFirst() {
+	public UnaryInplaceOp<A, A> getFirst() {
 		return first;
 	}
 
 	@Override
-	public void setFirst(final UnaryInplaceOp<A> first) {
+	public void setFirst(final UnaryInplaceOp<A, A> first) {
 		this.first = first;
 	}
 
 	@Override
-	public UnaryInplaceOp<A> getSecond() {
+	public UnaryInplaceOp<A, A> getSecond() {
 		return second;
 	}
 
 	@Override
-	public void setSecond(final UnaryInplaceOp<A> second) {
+	public void setSecond(final UnaryInplaceOp<A, A> second) {
 		this.second = second;
 	}
 
@@ -82,8 +82,8 @@ public class DefaultJoin2Inplaces<A> extends AbstractUnaryInplaceOp<A> implement
 		final DefaultJoin2Inplaces<A> joiner =
 			new DefaultJoin2Inplaces<>();
 
-		joiner.setFirst(getFirst());
-		joiner.setSecond(getSecond());
+		joiner.setFirst(getFirst().getIndependentInstance());
+		joiner.setSecond(getSecond().getIndependentInstance());
 
 		return joiner;
 	}

--- a/src/main/java/net/imagej/ops/join/DefaultJoinComputerAndInplace.java
+++ b/src/main/java/net/imagej/ops/join/DefaultJoinComputerAndInplace.java
@@ -45,14 +45,14 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Join.class)
 public class DefaultJoinComputerAndInplace<A, B> extends
-	AbstractUnaryComputerOp<A, B> implements JoinComputerAndInplace<A, B>
+	AbstractUnaryComputerOp<A, B> implements JoinComputerAndInplace<A, B, B>
 {
 
 	@Parameter
 	private UnaryComputerOp<A, B> first;
 
 	@Parameter
-	private UnaryInplaceOp<B> second;
+	private UnaryInplaceOp<B, B> second;
 
 	// -- Join2Ops methods --
 
@@ -67,12 +67,12 @@ public class DefaultJoinComputerAndInplace<A, B> extends
 	}
 
 	@Override
-	public UnaryInplaceOp<B> getSecond() {
+	public UnaryInplaceOp<B, B> getSecond() {
 		return second;
 	}
 
 	@Override
-	public void setSecond(final UnaryInplaceOp<B> second) {
+	public void setSecond(final UnaryInplaceOp<B, B> second) {
 		this.second = second;
 	}
 

--- a/src/main/java/net/imagej/ops/join/DefaultJoinInplaceAndComputer.java
+++ b/src/main/java/net/imagej/ops/join/DefaultJoinInplaceAndComputer.java
@@ -45,11 +45,11 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Join.class)
 public class DefaultJoinInplaceAndComputer<A, B> extends
-	AbstractUnaryComputerOp<A, B> implements JoinInplaceAndComputer<A, B>
+	AbstractUnaryComputerOp<A, B> implements JoinInplaceAndComputer<A, A, B>
 {
 
 	@Parameter
-	private UnaryInplaceOp<A> first;
+	private UnaryInplaceOp<A, A> first;
 
 	@Parameter
 	private UnaryComputerOp<A, B> second;
@@ -57,12 +57,12 @@ public class DefaultJoinInplaceAndComputer<A, B> extends
 	// -- Join2Ops methods --
 
 	@Override
-	public UnaryInplaceOp<A> getFirst() {
+	public UnaryInplaceOp<A, A> getFirst() {
 		return first;
 	}
 
 	@Override
-	public void setFirst(final UnaryInplaceOp<A> first) {
+	public void setFirst(final UnaryInplaceOp<A, A> first) {
 		this.first = first;
 	}
 

--- a/src/main/java/net/imagej/ops/join/DefaultJoinNInplaces.java
+++ b/src/main/java/net/imagej/ops/join/DefaultJoinNInplaces.java
@@ -48,17 +48,17 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Join.class)
 public class DefaultJoinNInplaces<A> extends AbstractUnaryInplaceOp<A> implements
-	JoinNInplaces<A>
+	JoinNInplaces<A, A>
 {
 
 	@Parameter
-	private List<? extends UnaryInplaceOp<A>> ops;
+	private List<? extends UnaryInplaceOp<A, A>> ops;
 
 	// -- UnaryInplaceOp methods --
 
 	@Override
 	public void mutate(final A input) {
-		for (final UnaryInplaceOp<A> inplace : getOps()) {
+		for (final UnaryInplaceOp<A, A> inplace : getOps()) {
 			inplace.mutate(input);
 		}
 	}
@@ -66,12 +66,12 @@ public class DefaultJoinNInplaces<A> extends AbstractUnaryInplaceOp<A> implement
 	// -- JoinNOps methods --
 
 	@Override
-	public void setOps(final List<? extends UnaryInplaceOp<A>> ops) {
+	public void setOps(final List<? extends UnaryInplaceOp<A, A>> ops) {
 		this.ops = ops;
 	}
 
 	@Override
-	public List<? extends UnaryInplaceOp<A>> getOps() {
+	public List<? extends UnaryInplaceOp<A, A>> getOps() {
 		return ops;
 	}
 
@@ -81,8 +81,8 @@ public class DefaultJoinNInplaces<A> extends AbstractUnaryInplaceOp<A> implement
 	public DefaultJoinNInplaces<A> getIndependentInstance() {
 		final DefaultJoinNInplaces<A> joiner = new DefaultJoinNInplaces<>();
 
-		final ArrayList<UnaryInplaceOp<A>> opsCopy = new ArrayList<>();
-		for (final UnaryInplaceOp<A> func : getOps()) {
+		final ArrayList<UnaryInplaceOp<A, A>> opsCopy = new ArrayList<>();
+		for (final UnaryInplaceOp<A, A> func : getOps()) {
 			opsCopy.add(func.getIndependentInstance());
 		}
 

--- a/src/main/java/net/imagej/ops/join/Join2Inplaces.java
+++ b/src/main/java/net/imagej/ops/join/Join2Inplaces.java
@@ -34,17 +34,17 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
 
 /**
  * A join operation which joins two {@link UnaryInplaceOp}s. The joined
- * {@link UnaryInplaceOp} mutates each argument using the first {@link UnaryInplaceOp}
- * followed by the second {@link UnaryInplaceOp}.
+ * {@link UnaryInplaceOp} mutates each argument using the first
+ * {@link UnaryInplaceOp} followed by the second {@link UnaryInplaceOp}.
  * 
  * @author Christian Dietz (University of Konstanz)
  */
-public interface Join2Inplaces<A> extends UnaryInplaceOp<A>,
-	Join2Ops<UnaryInplaceOp<A>, UnaryInplaceOp<A>>
+public interface Join2Inplaces<A, B extends A, C extends B> extends
+	UnaryInplaceOp<A, C>, Join2Ops<UnaryInplaceOp<A, B>, UnaryInplaceOp<B, C>>
 {
 
 	@Override
-	default void mutate(final A arg) {
+	default void mutate(final C arg) {
 		getFirst().mutate(arg);
 		getSecond().mutate(arg);
 	}

--- a/src/main/java/net/imagej/ops/join/JoinComputerAndInplace.java
+++ b/src/main/java/net/imagej/ops/join/JoinComputerAndInplace.java
@@ -38,14 +38,14 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * 
  * @author Curtis Rueden
  */
-public interface JoinComputerAndInplace<A, B> extends
-	UnaryComputerOp<A, B>, Join2Ops<UnaryComputerOp<A, B>, UnaryInplaceOp<B>>
+public interface JoinComputerAndInplace<A, BI, BO extends BI> extends
+	UnaryComputerOp<A, BO>, Join2Ops<UnaryComputerOp<A, BO>, UnaryInplaceOp<BI, BO>>
 {
 
 	// -- UnaryComputerOp methods --
 
 	@Override
-	default void compute1(final A input, final B output) {
+	default void compute1(final A input, final BO output) {
 		getFirst().compute1(input, output);
 		getSecond().mutate(output);
 	}

--- a/src/main/java/net/imagej/ops/join/JoinInplaceAndComputer.java
+++ b/src/main/java/net/imagej/ops/join/JoinInplaceAndComputer.java
@@ -38,14 +38,14 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * 
  * @author Curtis Rueden
  */
-public interface JoinInplaceAndComputer<A, B> extends
-	UnaryComputerOp<A, B>, Join2Ops<UnaryInplaceOp<A>, UnaryComputerOp<A, B>>
+public interface JoinInplaceAndComputer<AI, AO extends AI, B> extends
+	UnaryComputerOp<AO, B>, Join2Ops<UnaryInplaceOp<AI, AO>, UnaryComputerOp<AO, B>>
 {
 
 	// -- UnaryComputerOp methods --
 
 	@Override
-	default void compute1(final A input, final B output) {
+	default void compute1(final AO input, final B output) {
 		getFirst().mutate(input);
 		getSecond().compute1(input, output);
 	}

--- a/src/main/java/net/imagej/ops/join/JoinNInplaces.java
+++ b/src/main/java/net/imagej/ops/join/JoinNInplaces.java
@@ -38,6 +38,6 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * @author Christian Dietz (University of Konstanz)
  * @author Curtis Rueden
  */
-public interface JoinNInplaces<A> extends UnaryInplaceOp<A>, JoinNOps<UnaryInplaceOp<A>> {
+public interface JoinNInplaces<I, O extends I> extends UnaryInplaceOp<I, O>, JoinNOps<UnaryInplaceOp<I, O>> {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/loop/DefaultLoopInplace.java
+++ b/src/main/java/net/imagej/ops/loop/DefaultLoopInplace.java
@@ -45,11 +45,11 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Loop.class)
 public class DefaultLoopInplace<A> extends AbstractUnaryInplaceOp<A> implements
-	LoopInplace<A>
+	LoopInplace<A, A>
 {
 
 	@Parameter
-	private UnaryInplaceOp<A> op;
+	private UnaryInplaceOp<A, A> op;
 
 	@Parameter
 	private int n;
@@ -57,12 +57,12 @@ public class DefaultLoopInplace<A> extends AbstractUnaryInplaceOp<A> implements
 	// -- LoopOp methods --
 
 	@Override
-	public UnaryInplaceOp<A> getOp() {
+	public UnaryInplaceOp<A, A> getOp() {
 		return op;
 	}
 
 	@Override
-	public void setOp(final UnaryInplaceOp<A> op) {
+	public void setOp(final UnaryInplaceOp<A, A> op) {
 		this.op = op;
 	}
 

--- a/src/main/java/net/imagej/ops/loop/LoopInplace.java
+++ b/src/main/java/net/imagej/ops/loop/LoopInplace.java
@@ -38,14 +38,14 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * 
  * @author Christian Dietz (University of Konstanz)
  */
-public interface LoopInplace<A> extends UnaryInplaceOp<A>, LoopOp<UnaryInplaceOp<A>> {
+public interface LoopInplace<I, O extends I> extends UnaryInplaceOp<I, O>, LoopOp<UnaryInplaceOp<I, O>> {
 
 	// -- UnaryInplaceOp methods --
 
 	@Override
-	default void mutate(final A arg) {
+	default void mutate(final O arg) {
 		final int n = getLoopCount();
-		final UnaryInplaceOp<A> op = getOp();
+		final UnaryInplaceOp<I, O> op = getOp();
 		for (int i = 0; i < n; i++) {
 			op.mutate(arg);
 		}

--- a/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace.java
@@ -39,24 +39,25 @@ import org.scijava.plugin.Parameter;
  * Abstract base class for {@link MapBinaryInplace} implementations.
  * 
  * @author Leon Yang
- * @param <EA> element type of first, second inputs, and the outputs
+ * @param <EI> element type of first, second inputs
+ * @param <EO> element type of output
  * @param <PA> producer of first, second inputs, and the outputs
  */
-public abstract class AbstractMapBinaryInplace<EA, PA> extends
+public abstract class AbstractMapBinaryInplace<EI, EO extends EI, PA> extends
 	AbstractBinaryInplaceOp<PA> implements
-	MapBinaryInplace<EA, BinaryInplaceOp<EA>>
+	MapBinaryInplace<EI, EO, BinaryInplaceOp<EI, EO>>
 {
 
 	@Parameter
-	private BinaryInplaceOp<EA> op;
+	private BinaryInplaceOp<EI, EO> op;
 
 	@Override
-	public BinaryInplaceOp<EA> getOp() {
+	public BinaryInplaceOp<EI, EO> getOp() {
 		return op;
 	}
 
 	@Override
-	public void setOp(final BinaryInplaceOp<EA> op) {
+	public void setOp(final BinaryInplaceOp<EI, EO> op) {
 		this.op = op;
 	}
 }

--- a/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace1.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapBinaryInplace1.java
@@ -39,26 +39,27 @@ import org.scijava.plugin.Parameter;
  * Abstract base class for {@link MapBinaryInplace1} implementations.
  * 
  * @author Leon Yang
- * @param <EA> element type of first inputs + outputs
- * @param <EI> element type of second inputs
+ * @param <EI1> element type of first inputs
+ * @param <EI2> element type of second inputs
+ * @param <EO> element type of outputs
  * @param <PA> producer of first inputs + outputs
  * @param <PI> producer of second inputs
  */
-public abstract class AbstractMapBinaryInplace1<EA, EI, PA, PI> extends
-	AbstractBinaryInplace1Op<PA, PI> implements
-	MapBinaryInplace1<EA, EI, BinaryInplace1Op<EA, EI>>
+public abstract class AbstractMapBinaryInplace1<EI1, EI2, EO extends EI1, PA, PI>
+	extends AbstractBinaryInplace1Op<PA, PI> implements
+	MapBinaryInplace1<EI1, EI2, EO, BinaryInplace1Op<EI1, EI2, EO>>
 {
 
 	@Parameter
-	private BinaryInplace1Op<EA, EI> op;
+	private BinaryInplace1Op<EI1, EI2, EO> op;
 
 	@Override
-	public BinaryInplace1Op<EA, EI> getOp() {
+	public BinaryInplace1Op<EI1, EI2, EO> getOp() {
 		return op;
 	}
 
 	@Override
-	public void setOp(final BinaryInplace1Op<EA, EI> op) {
+	public void setOp(final BinaryInplace1Op<EI1, EI2, EO> op) {
 		this.op = op;
 	}
 }

--- a/src/main/java/net/imagej/ops/map/AbstractMapInplace.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapInplace.java
@@ -39,25 +39,27 @@ import org.scijava.plugin.Parameter;
  * Abstract base class for {@link MapInplace} implementations.
  * 
  * @author Curtis Rueden
- * @param <EA> element type of inplace arguments
+ * @param <EI> element input type
+ * @param <EO> element output type
  * @param <PA> producer of arguments
  */
-public abstract class AbstractMapInplace<EA, PA> extends AbstractUnaryInplaceOp<PA>
-	implements MapInplace<EA, UnaryInplaceOp<EA>>
+public abstract class AbstractMapInplace<EI, EO extends EI, PA> extends
+	AbstractUnaryInplaceOp<PA> implements
+	MapInplace<EI, EO, UnaryInplaceOp<EI, EO>>
 {
 
 	@Parameter
-	private UnaryInplaceOp<EA> op;
+	private UnaryInplaceOp<EI, EO> op;
 
 	// -- MapOp methods --
 
 	@Override
-	public UnaryInplaceOp<EA> getOp() {
+	public UnaryInplaceOp<EI, EO> getOp() {
 		return op;
 	}
 
 	@Override
-	public void setOp(final UnaryInplaceOp<EA> op) {
+	public void setOp(final UnaryInplaceOp<EI, EO> op) {
 		this.op = op;
 	}
 

--- a/src/main/java/net/imagej/ops/map/AbstractMapIterableInplace.java
+++ b/src/main/java/net/imagej/ops/map/AbstractMapIterableInplace.java
@@ -35,11 +35,12 @@ package net.imagej.ops.map;
  * {@link Iterable}s.
  * 
  * @author Christian Dietz (University of Konstanz)
- * @param <EA> element type of inplace arguments
+ * @param <EI> element input type
+ * @param <EO> element output type
  * @param <PA> producer of arguments
  */
-public abstract class AbstractMapIterableInplace<EA, PA extends Iterable<EA>>
-	extends AbstractMapInplace<EA, PA>
+public abstract class AbstractMapIterableInplace<EI, EO extends EI, PA extends Iterable<EI>>
+	extends AbstractMapInplace<EI, EO, PA>
 {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/map/MapBinaryInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapBinaryInplace.java
@@ -36,11 +36,12 @@ import net.imagej.ops.special.inplace.BinaryInplaceOp;
  * Typed interface for "map" {@link BinaryInplaceOp}s.
  * 
  * @author Leon Yang
- * @param <EA> element type of inputs + outputs
+ * @param <EI> element type of inputs
+ * @param <EO> element type of outputs
  * @param <OP> type of {@link BinaryInplaceOp} which processes each element
  */
-public interface MapBinaryInplace<EA, OP extends BinaryInplaceOp<EA>> extends
-	MapOp<OP>
+public interface MapBinaryInplace<EI, EO extends EI, OP extends BinaryInplaceOp<EI, EO>>
+	extends MapOp<OP>
 {
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/map/MapBinaryInplace1.java
+++ b/src/main/java/net/imagej/ops/map/MapBinaryInplace1.java
@@ -36,11 +36,12 @@ import net.imagej.ops.special.inplace.BinaryInplace1Op;
  * Typed interface for "map" {@link BinaryInplace1Op}s.
  * 
  * @author Leon Yang
- * @param <EA> element type of first inputs + outputs
- * @param <EI> element type of second inputs
+ * @param <EI1> element type of first inputs
+ * @param <EI2> element type of second inputs
+ * @param <EO> element type of outputs
  * @param <OP> type of {@link BinaryInplace1Op} which processes each element
  */
-public interface MapBinaryInplace1<EA, EI, OP extends BinaryInplace1Op<EA, EI>>
+public interface MapBinaryInplace1<EI1, EI2, EO extends EI1, OP extends BinaryInplace1Op<EI1, EI2, EO>>
 	extends MapOp<OP>
 {
 	// NB: Marker interface.

--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
@@ -46,7 +46,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
 public class MapIIAndIIInplace<EA> extends
-	AbstractMapBinaryInplace<EA, IterableInterval<EA>> implements Contingent
+	AbstractMapBinaryInplace<EA, EA, IterableInterval<EA>> implements Contingent
 {
 
 	@Override
@@ -58,7 +58,7 @@ public class MapIIAndIIInplace<EA> extends
 	public void mutate1(final IterableInterval<EA> arg,
 		final IterableInterval<EA> in)
 	{
-		Maps.inplace(arg, in, (BinaryInplace1Op<EA, EA>) getOp());
+		Maps.inplace(arg, in, (BinaryInplace1Op<EA, EA, EA>) getOp());
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
@@ -49,7 +49,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 10)
 public class MapIIAndIIInplaceParallel<EA> extends
-	AbstractMapBinaryInplace<EA, IterableInterval<EA>> implements Contingent,
+	AbstractMapBinaryInplace<EA, EA, IterableInterval<EA>> implements Contingent,
 	Parallel
 {
 
@@ -68,7 +68,7 @@ public class MapIIAndIIInplaceParallel<EA> extends
 			public void execute(final int startIndex, final int stepSize,
 				final int numSteps)
 			{
-				Maps.inplace(arg, in, (BinaryInplace1Op<EA, EA>) getOp(),
+				Maps.inplace(arg, in, (BinaryInplace1Op<EA, EA, EA>) getOp(),
 					startIndex, stepSize, numSteps);
 			}
 		}, arg.size());

--- a/src/main/java/net/imagej/ops/map/MapIIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIIInplaceParallel.java
@@ -47,7 +47,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + 5)
 public class MapIIInplaceParallel<A> extends
-	AbstractMapIterableInplace<A, IterableInterval<A>> implements Parallel
+	AbstractMapIterableInplace<A, A, IterableInterval<A>> implements Parallel
 {
 
 	@Override

--- a/src/main/java/net/imagej/ops/map/MapInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapInplace.java
@@ -36,9 +36,12 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * Typed interface for "map" {@link UnaryInplaceOp}s.
  * 
  * @author Curtis Rueden
- * @param <EA> element type of inplace arguments
+ * @param <EI> element input type
+ * @param <EO> element output type
  * @param <OP> type of {@link UnaryInplaceOp} which processes each element
  */
-public interface MapInplace<EA, OP extends UnaryInplaceOp<EA>> extends MapOp<OP> {
+public interface MapInplace<EI, EO extends EI, OP extends UnaryInplaceOp<EI, EO>>
+	extends MapOp<OP>
+{
 	// NB: Marker interface.
 }

--- a/src/main/java/net/imagej/ops/map/MapIterableInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIterableInplace.java
@@ -44,7 +44,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY)
 public class MapIterableInplace<A> extends
-	AbstractMapIterableInplace<A, Iterable<A>>
+	AbstractMapIterableInplace<A, A, Iterable<A>>
 {
 
 	@Override

--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -475,18 +475,18 @@ public class Maps {
 
 	// -- Unary Inplace Maps --
 
-	public static <A> void inplace(final Iterable<A> arg,
-		final UnaryInplaceOp<A> op)
+	public static <I, O extends I> void inplace(final Iterable<O> arg,
+		final UnaryInplaceOp<I, O> op)
 	{
-		for (A e : arg)
+		for (final O e : arg)
 			op.mutate(e);
 	}
 
-	public static <A> void inplace(final IterableInterval<A> arg,
-		final UnaryInplaceOp<A> op, final int startIndex, final int stepSize,
+	public static <I, O extends I> void inplace(final IterableInterval<O> arg,
+		final UnaryInplaceOp<I, O> op, final int startIndex, final int stepSize,
 		final int numSteps)
 	{
-		final Cursor<A> argCursor = arg.cursor();
+		final Cursor<O> argCursor = arg.cursor();
 		argCursor.jumpFwd(startIndex + 1);
 		int ctr = 0;
 		while (ctr < numSteps) {
@@ -498,21 +498,23 @@ public class Maps {
 
 	// -- Binary Inplace Maps --
 
-	public static <A, I> void inplace(final IterableInterval<A> arg,
-		final IterableInterval<I> in, final BinaryInplace1Op<A, I> op)
+	public static <I1, I2, O extends I1> void inplace(
+		final IterableInterval<O> arg, final IterableInterval<I2> in,
+		final BinaryInplace1Op<I1, I2, O> op)
 	{
-		final Cursor<A> argCursor = arg.cursor();
-		final Cursor<I> inCursor = in.cursor();
+		final Cursor<O> argCursor = arg.cursor();
+		final Cursor<I2> inCursor = in.cursor();
 		while (argCursor.hasNext()) {
 			op.mutate1(argCursor.next(), inCursor.next());
 		}
 	}
 
-	public static <A, I> void inplace(final IterableInterval<A> arg,
-		final RandomAccessibleInterval<I> in, final BinaryInplace1Op<A, I> op)
+	public static <I1, I2, O extends I1> void inplace(
+		final IterableInterval<O> arg, final RandomAccessibleInterval<I2> in,
+		final BinaryInplace1Op<I1, I2, O> op)
 	{
-		final Cursor<A> argCursor = arg.localizingCursor();
-		final RandomAccess<I> inAccess = in.randomAccess();
+		final Cursor<O> argCursor = arg.localizingCursor();
+		final RandomAccess<I2> inAccess = in.randomAccess();
 		while (argCursor.hasNext()) {
 			argCursor.fwd();
 			inAccess.setPosition(argCursor);
@@ -521,7 +523,7 @@ public class Maps {
 	}
 
 	public static <A, I> void inplace(final RandomAccessibleInterval<A> arg,
-		final IterableInterval<I> in, final BinaryInplace1Op<A, I> op)
+		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op)
 	{
 		final RandomAccess<A> argAccess = arg.randomAccess();
 		final Cursor<I> inCursor = in.localizingCursor();
@@ -533,7 +535,7 @@ public class Maps {
 	}
 
 	public static <A, I> void inplace(final IterableInterval<A> arg,
-		final IterableInterval<I> in, final BinaryInplace1Op<A, I> op,
+		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
 		final Cursor<A> argCursor = arg.cursor();
@@ -550,7 +552,7 @@ public class Maps {
 	}
 
 	public static <A, I> void inplace(final IterableInterval<A> arg,
-		final RandomAccessibleInterval<I> in, final BinaryInplace1Op<A, I> op,
+		final RandomAccessibleInterval<I> in, final BinaryInplace1Op<A, I, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
 		final Cursor<A> argCursor = arg.localizingCursor();
@@ -566,7 +568,7 @@ public class Maps {
 	}
 
 	public static <A, I> void inplace(final RandomAccessibleInterval<A> arg,
-		final IterableInterval<I> in, final BinaryInplace1Op<A, I> op,
+		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
 		final RandomAccess<A> argAccess = arg.randomAccess();
@@ -582,7 +584,7 @@ public class Maps {
 	}
 
 	public static <A> void inplace(final IterableInterval<A> arg,
-		final IterableInterval<A> in, final BinaryInplaceOp<A> op)
+		final IterableInterval<A> in, final BinaryInplaceOp<A, A> op)
 	{
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<A> inCursor = in.cursor();
@@ -592,7 +594,7 @@ public class Maps {
 	}
 
 	public static <A> void inplace(final IterableInterval<A> arg,
-		final IterableInterval<A> in, final BinaryInplaceOp<A> op,
+		final IterableInterval<A> in, final BinaryInplaceOp<A, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
 		final Cursor<A> argCursor = arg.cursor();

--- a/src/main/java/net/imagej/ops/special/chain/IIs.java
+++ b/src/main/java/net/imagej/ops/special/chain/IIs.java
@@ -88,9 +88,9 @@ public final class IIs {
 			in == null ? IterableInterval.class : in, otherArgs);
 	}
 
-	public static <T> UnaryInplaceOp<IterableInterval<T>> inplace(
-		final OpEnvironment ops, final Class<? extends Op> opType,
-		final IterableInterval<T> arg, final Object... otherArgs)
+	public static <T> UnaryInplaceOp<? super IterableInterval<T>, IterableInterval<T>>
+		inplace(final OpEnvironment ops, final Class<? extends Op> opType,
+			final IterableInterval<T> arg, final Object... otherArgs)
 	{
 		return Inplaces.unary(ops, opType, arg, otherArgs);
 	}

--- a/src/main/java/net/imagej/ops/special/chain/InplaceViaInplace.java
+++ b/src/main/java/net/imagej/ops/special/chain/InplaceViaInplace.java
@@ -39,11 +39,13 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * 
  * @author Curtis Rueden
  */
-public abstract class InplaceViaInplace<A> extends AbstractUnaryInplaceOp<A> {
+public abstract class InplaceViaInplace<I, O extends I> extends
+	AbstractUnaryInplaceOp<O>
+{
 
-	private UnaryInplaceOp<A> worker;
+	private UnaryInplaceOp<I, O> worker;
 
-	public abstract UnaryInplaceOp<A> createWorker(A t);
+	public abstract UnaryInplaceOp<I, O> createWorker(I t);
 
 	@Override
 	public void initialize() {
@@ -51,7 +53,7 @@ public abstract class InplaceViaInplace<A> extends AbstractUnaryInplaceOp<A> {
 	}
 
 	@Override
-	public void mutate(final A arg) {
+	public void mutate(final O arg) {
 		worker.mutate(arg);
 	}
 

--- a/src/main/java/net/imagej/ops/special/chain/RAIs.java
+++ b/src/main/java/net/imagej/ops/special/chain/RAIs.java
@@ -116,7 +116,7 @@ public final class RAIs {
 				in == null ? RandomAccessibleInterval.class : in, otherArgs);
 	}
 
-	public static <T> UnaryInplaceOp<RandomAccessibleInterval<T>> inplace(final OpEnvironment ops,
+	public static <T> UnaryInplaceOp<? super RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> inplace(final OpEnvironment ops,
 			final Class<? extends Op> opType, final RandomAccessibleInterval<T> arg, final Object... otherArgs) {
 		return Inplaces.unary(ops, opType, arg, otherArgs);
 	}

--- a/src/main/java/net/imagej/ops/special/chain/RTs.java
+++ b/src/main/java/net/imagej/ops/special/chain/RTs.java
@@ -82,7 +82,7 @@ public final class RTs {
 		return (UnaryHybridCF) Hybrids.unaryCF(ops, opType, RealType.class, in, otherArgs);
 	}
 
-	public static <A extends RealType<A>> UnaryInplaceOp<A> inplace(
+	public static <A extends RealType<A>> UnaryInplaceOp<? super A, A> inplace(
 		final OpEnvironment ops, final Class<? extends Op> opType, final A arg,
 		final Object... otherArgs)
 	{

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridC.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridC.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.hybrid;
+
+import net.imagej.ops.special.AbstractBinaryOp;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+
+/**
+ * Abstract superclass for {@link BinaryHybridCF} and {@link BinaryHybridCI1}
+ * implementations.
+ * 
+ * @author Curtis Rueden
+ */
+public abstract class AbstractBinaryHybridC<I1, I2, O> extends
+	AbstractBinaryOp<I1, I2, O> implements BinaryComputerOp<I1, I2, O>
+{
+
+	// -- Parameters --
+
+	@Parameter(type = ItemIO.BOTH, required = false)
+	private O out;
+
+	@Parameter
+	private I1 in1;
+
+	@Parameter
+	private I2 in2;
+
+	// -- BinaryInput methods --
+
+	@Override
+	public I1 in1() {
+		return in1;
+	}
+
+	@Override
+	public I2 in2() {
+		return in2;
+	}
+
+	@Override
+	public void setInput1(final I1 input1) {
+		in1 = input1;
+	}
+
+	@Override
+	public void setInput2(final I2 input2) {
+		in2 = input2;
+	}
+
+	// -- Output methods --
+
+	@Override
+	public O out() {
+		return out;
+	}
+
+	// -- OutputMutable methods --
+
+	@Override
+	public void setOutput(final O output) {
+		out = output;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCF.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCF.java
@@ -30,65 +30,13 @@
 
 package net.imagej.ops.special.hybrid;
 
-import net.imagej.ops.special.AbstractBinaryOp;
-
-import org.scijava.ItemIO;
-import org.scijava.plugin.Parameter;
-
 /**
  * Abstract superclass for {@link BinaryHybridCF} implementations.
  * 
  * @author Curtis Rueden
  */
 public abstract class AbstractBinaryHybridCF<I1, I2, O> extends
-	AbstractBinaryOp<I1, I2, O> implements BinaryHybridCF<I1, I2, O>
+	AbstractBinaryHybridC<I1, I2, O> implements BinaryHybridCF<I1, I2, O>
 {
-
-	// -- Parameters --
-
-	@Parameter(type = ItemIO.BOTH, required = false)
-	private O out;
-
-	@Parameter
-	private I1 in1;
-
-	@Parameter
-	private I2 in2;
-
-	// -- BinaryInput methods --
-
-	@Override
-	public I1 in1() {
-		return in1;
-	}
-
-	@Override
-	public I2 in2() {
-		return in2;
-	}
-
-	@Override
-	public void setInput1(final I1 input1) {
-		in1 = input1;
-	}
-
-	@Override
-	public void setInput2(final I2 input2) {
-		in2 = input2;
-	}
-
-	// -- Output methods --
-
-	@Override
-	public O out() {
-		return out;
-	}
-
-	// -- OutputMutable methods --
-
-	@Override
-	public void setOutput(final O output) {
-		out = output;
-	}
-
+	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCFI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCFI.java
@@ -35,8 +35,8 @@ package net.imagej.ops.special.hybrid;
  * 
  * @author Curtis Rueden
  */
-public abstract class AbstractBinaryHybridCFI<A> extends
-	AbstractBinaryHybridCFI1<A, A> implements BinaryHybridCFI<A>
+public abstract class AbstractBinaryHybridCFI<I, O extends I> extends
+	AbstractBinaryHybridCFI1<I, I, O> implements BinaryHybridCFI<I, O>
 {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCFI1.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCFI1.java
@@ -35,8 +35,8 @@ package net.imagej.ops.special.hybrid;
  * 
  * @author Curtis Rueden
  */
-public abstract class AbstractBinaryHybridCFI1<A, I> extends
-	AbstractBinaryHybridCF<A, I, A> implements BinaryHybridCFI1<A, I>
+public abstract class AbstractBinaryHybridCFI1<I1, I2, O extends I1> extends
+	AbstractBinaryHybridCF<I1, I2, O> implements BinaryHybridCFI1<I1, I2, O>
 {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCI.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.hybrid;
+
+/**
+ * Abstract superclass for {@link BinaryHybridCI} implementations.
+ * 
+ * @author Leon Yang
+ */
+public abstract class AbstractBinaryHybridCI<I, O extends I> extends
+	AbstractBinaryHybridCI1<I, I, O> implements BinaryHybridCI<I, O>
+{
+	// NB: No implementation needed.
+}

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCI1.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractBinaryHybridCI1.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.hybrid;
+
+/**
+ * Abstract superclass for {@link BinaryHybridCI1} implementations.
+ * 
+ * @author Leon Yang
+ */
+public abstract class AbstractBinaryHybridCI1<I1, I2, O extends I1> extends
+	AbstractBinaryHybridC<I1, I2, O> implements BinaryHybridCI1<I1, I2, O>
+{
+	// NB: No implementation needed.
+}

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractUnaryHybridC.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractUnaryHybridC.java
@@ -31,7 +31,7 @@
 package net.imagej.ops.special.hybrid;
 
 import net.imagej.ops.special.AbstractUnaryOp;
-import net.imagej.ops.special.OutputMutable;
+import net.imagej.ops.special.computer.UnaryComputerOp;
 
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
@@ -44,7 +44,7 @@ import org.scijava.plugin.Parameter;
  * @author Curtis Rueden
  */
 public abstract class AbstractUnaryHybridC<I, O> extends AbstractUnaryOp<I, O>
-	implements OutputMutable<O>
+	implements UnaryComputerOp<I, O>
 {
 
 	// -- Parameters --

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractUnaryHybridCFI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractUnaryHybridCFI.java
@@ -35,8 +35,8 @@ package net.imagej.ops.special.hybrid;
  * 
  * @author Curtis Rueden
  */
-public abstract class AbstractUnaryHybridCFI<IO> extends
-	AbstractUnaryHybridCF<IO, IO> implements UnaryHybridCFI<IO>
+public abstract class AbstractUnaryHybridCFI<I, O extends I> extends
+	AbstractUnaryHybridCF<I, O> implements UnaryHybridCFI<I, O>
 {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/special/hybrid/AbstractUnaryHybridCI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/AbstractUnaryHybridCI.java
@@ -36,8 +36,8 @@ package net.imagej.ops.special.hybrid;
  * @author Christian Dietz (University of Konstanz)
  * @author Curtis Rueden
  */
-public abstract class AbstractUnaryHybridCI<I> extends
-	AbstractUnaryHybridC<I, I> implements UnaryHybridCI<I>
+public abstract class AbstractUnaryHybridCI<I, O extends I> extends
+	AbstractUnaryHybridC<I, O> implements UnaryHybridCI<I, O>
 {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCFI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCFI.java
@@ -48,21 +48,22 @@ import net.imagej.ops.special.inplace.BinaryInplaceOp;
  * </p>
  * 
  * @author Curtis Rueden
- * @param <A> type of inputs + output
+ * @param <I> type of inputs
+ * @param <O> type of output
  * @see BinaryHybridCF
  * @see BinaryHybridCFI1
  */
-public interface BinaryHybridCFI<A> extends BinaryHybridCFI1<A, A>,
-	BinaryInplaceOp<A>
+public interface BinaryHybridCFI<I, O extends I> extends
+	BinaryHybridCFI1<I, I, O>, BinaryHybridCI<I, O>
 {
 
 	// -- BinaryOp methods --
 
 	@Override
-	default A run(final A input1, final A input2, final A output) {
+	default O run(final I input1, final I input2, final O output) {
 		if (input2 == output) {
 			// run as an inplace
-			return BinaryInplaceOp.super.run(input1, input2, output);
+			return BinaryHybridCI.super.run(input1, input2, output);
 		}
 		// run as a hybrid CFI1
 		return BinaryHybridCFI1.super.run(input1, input2, output);
@@ -78,7 +79,7 @@ public interface BinaryHybridCFI<A> extends BinaryHybridCFI1<A, A>,
 	// -- Threadable methods --
 
 	@Override
-	default BinaryHybridCFI<A> getIndependentInstance() {
+	default BinaryHybridCFI<I, O> getIndependentInstance() {
 		// NB: We assume the op instance is thread-safe by default.
 		// Individual implementations can override this assumption if they
 		// have state (such as buffers) that cannot be shared across threads.

--- a/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCFI1.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCFI1.java
@@ -46,22 +46,24 @@ import net.imagej.ops.special.inplace.BinaryInplace1Op;
  * </p>
  * 
  * @author Curtis Rueden
- * @param <A> type of first input + output
- * @param <I> type of second input
+ * @param <I1> type of first input
+ * @param <I2> type of second input
+ * @param <O> type of output
  * @see BinaryHybridCF
  * @see BinaryHybridCFI
  */
-public interface BinaryHybridCFI1<A, I> extends BinaryHybridCF<A, I, A>,
-	BinaryInplace1Op<A, I>, UnaryHybridCFI<A>
+public interface BinaryHybridCFI1<I1, I2, O extends I1> extends
+	BinaryHybridCF<I1, I2, O>, BinaryHybridCI1<I1, I2, O>,
+	UnaryHybridCFI<I1, O>
 {
 
 	// -- BinaryOp methods --
 
 	@Override
-	default A run(final A input1, final I input2, final A output) {
+	default O run(final I1 input1, final I2 input2, final O output) {
 		if (input1 == output) {
 			// run as an inplace (1st input)
-			return BinaryInplace1Op.super.run(input1, input2, output);
+			return BinaryHybridCI1.super.run(input1, input2, output);
 		}
 		// run as a hybrid CF
 		return BinaryHybridCF.super.run(input1, input2, output);
@@ -70,8 +72,8 @@ public interface BinaryHybridCFI1<A, I> extends BinaryHybridCF<A, I, A>,
 	// -- UnaryInplaceOp methods --
 
 	@Override
-	default void mutate(final A arg) {
-		BinaryInplace1Op.super.mutate(arg);
+	default void mutate(final O arg) {
+		BinaryHybridCI1.super.mutate(arg);
 	}
 
 	// -- Runnable methods --
@@ -84,7 +86,7 @@ public interface BinaryHybridCFI1<A, I> extends BinaryHybridCF<A, I, A>,
 	// -- Threadable methods --
 
 	@Override
-	default BinaryHybridCFI1<A, I> getIndependentInstance() {
+	default BinaryHybridCFI1<I1, I2, O> getIndependentInstance() {
 		// NB: We assume the op instance is thread-safe by default.
 		// Individual implementations can override this assumption if they
 		// have state (such as buffers) that cannot be shared across threads.

--- a/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCI.java
@@ -1,0 +1,81 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.hybrid;
+
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
+
+/**
+ * A hybrid binary operation which can be used as a {@link BinaryComputerOp} or
+ * {@link BinaryInplaceOp}.
+ * <p>
+ * To populate a preallocated output object, call
+ * {@link BinaryComputerOp#compute1}; to compute inplace, call
+ * {@link BinaryInplaceOp#mutate1} or {@link BinaryInplaceOp#mutate2}. To do any
+ * of these things as appropriate, call {@link #run(Object, Object, Object)}.
+ * </p>
+ * 
+ * @author Leon Yang
+ * @param <I> type of first + second input
+ * @param <O> type of output
+ * @see BinaryHybridCI1
+ */
+public interface BinaryHybridCI<I, O extends I> extends
+	BinaryHybridCI1<I, I, O>, BinaryInplaceOp<I, O>
+{
+
+	// -- UnaryOp methods --
+
+	@Override
+	default O run(final I input1, final I input2, final O output) {
+		if (output == input1)
+			// mutate first input
+			mutate1(output, input2);
+		else if (output == input2)
+			// mutate second input
+			mutate2(input1, output);
+		else
+			// run as computer
+			compute2(input1, input2, output);
+		return output;
+	}
+
+	// -- Threadable methods --
+
+	@Override
+	default BinaryHybridCI<I, O> getIndependentInstance() {
+		// NB: We assume the op instance is thread-safe by default.
+		// Individual implementations can override this assumption if they
+		// have state (such as buffers) that cannot be shared across threads.
+		return this;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCI1.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/BinaryHybridCI1.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.hybrid;
+
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+
+/**
+ * A hybrid binary operation which can be used as a {@link BinaryComputerOp}, or
+ * {@link BinaryInplace1Op}.
+ * <p>
+ * To populate a preallocated output object, call
+ * {@link BinaryComputerOp#compute2}; to mutate the first input inplace, call
+ * {@link BinaryInplace1Op#mutate1}. To do any of these things as appropriate,
+ * call {@link #run(Object, Object, Object)}.
+ * </p>
+ * 
+ * @author Leon Yang
+ * @param <I1> type of first input
+ * @param <I2> type of second input
+ * @param <O> type of output
+ * @see BinaryHybridCF
+ * @see BinaryHybridCFI
+ */
+public interface BinaryHybridCI1<I1, I2, O extends I1> extends
+	BinaryComputerOp<I1, I2, O>, BinaryInplace1Op<I1, I2, O>,
+	UnaryHybridCI<I1, O>
+{
+
+	// -- UnaryInplaceOp methods --
+
+	@Override
+	default void mutate(final O arg) {
+		compute2(arg, in2(), arg);
+	}
+
+	// -- UnaryOp methods --
+
+	@Override
+	default O run(final I1 input1, final I2 input2, final O output) {
+		if (output == input1) {
+			// run inplace
+			mutate(output);
+			return output;
+		}
+
+		// run as a computer
+		compute2(input1, input2, output);
+		return output;
+	}
+	// -- Runnable methods --
+
+	@Override
+	default void run() {
+		setOutput(run(in1(), in2(), out()));
+	}
+
+	// -- Threadable methods --
+
+	@Override
+	default BinaryHybridCI1<I1, I2, O> getIndependentInstance() {
+		// NB: We assume the op instance is thread-safe by default.
+		// Individual implementations can override this assumption if they
+		// have state (such as buffers) that cannot be shared across threads.
+		return this;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/special/hybrid/Hybrids.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/Hybrids.java
@@ -191,25 +191,26 @@ public final class Hybrids {
 	 *          interface which multiple {@link UnaryHybridCI}s implement), then
 	 *          the best {@link UnaryHybridCI} implementation to use will be
 	 *          selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link UnaryHybridCI} typed
-	 *          arguments.
+	 * @param outType The {@link Class} of the {@link UnaryHybridCI} typed
+	 *          output.
+	 * @param inType The {@link Class} of the {@link UnaryHybridCI} typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed input and
 	 *          output values.
 	 * @return A {@link UnaryHybridCI} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryHybridCI<A> unaryCI(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final Object... otherArgs)
+	public static <I, O extends I, OP extends Op> UnaryHybridCI<I, O> unaryCI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final Class<I> inType, final Object... otherArgs)
 	{
 		@SuppressWarnings("unchecked")
-		final UnaryHybridCI<A> op = SpecialOp.op(ops, opType, UnaryHybridCI.class,
-			null, OpUtils.args(otherArgs, argType, argType));
+		final UnaryHybridCI<I, O> op = SpecialOp.op(ops, opType,
+			UnaryHybridCI.class, null, OpUtils.args(otherArgs, outType, inType));
 		return op;
 	}
 
 	/**
-	 * Gets the best {@link UnaryHybridCI} implementation for the given types and
-	 * arguments, populating its inputs.
+	 * Gets the best {@link UnaryHybridCI} implementation for the given types
+	 * and arguments, populating its inputs.
 	 *
 	 * @param ops The {@link OpEnvironment} to search for a matching op.
 	 * @param opType The {@link Class} of the operation. If multiple
@@ -217,26 +218,26 @@ public final class Hybrids {
 	 *          interface which multiple {@link UnaryHybridCI}s implement), then
 	 *          the best {@link UnaryHybridCI} implementation to use will be
 	 *          selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link UnaryHybridCI} typed
-	 *          arguments.
+	 * @param outType The {@link Class} of the {@link UnaryHybridCI} typed
+	 *          output.
 	 * @param in The typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed input and
 	 *          output values.
 	 * @return A {@link UnaryHybridCI} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryHybridCI<A> unaryCI(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final A in, final Object... otherArgs)
+	public static <I, O extends I, OP extends Op> UnaryHybridCI<I, O> unaryCI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final I in, final Object... otherArgs)
 	{
 		@SuppressWarnings("unchecked")
-		final UnaryHybridCI<A> op = SpecialOp.op(ops, opType, UnaryHybridCI.class,
-			null, OpUtils.args(otherArgs, argType, in));
+		final UnaryHybridCI<I, O> op = SpecialOp.op(ops, opType,
+			UnaryHybridCI.class, null, OpUtils.args(otherArgs, outType, in));
 		return op;
 	}
 
 	/**
-	 * Gets the best {@link UnaryHybridCI} implementation for the given types and
-	 * arguments, populating its inputs.
+	 * Gets the best {@link UnaryHybridCI} implementation for the given types
+	 * and arguments, populating its inputs.
 	 *
 	 * @param ops The {@link OpEnvironment} to search for a matching op.
 	 * @param opType The {@link Class} of the operation. If multiple
@@ -250,13 +251,13 @@ public final class Hybrids {
 	 *          output values.
 	 * @return A {@link UnaryHybridCI} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryHybridCI<A> unaryCI(
-		final OpEnvironment ops, final Class<OP> opType, final A out, final A in,
+	public static <I, O extends I, OP extends Op> UnaryHybridCI<I, O> unaryCI(
+		final OpEnvironment ops, final Class<OP> opType, final O out, final I in,
 		final Object... otherArgs)
 	{
 		@SuppressWarnings("unchecked")
-		final UnaryHybridCI<A> op = SpecialOp.op(ops, opType, UnaryHybridCI.class,
-			null, OpUtils.args(otherArgs, out, in));
+		final UnaryHybridCI<I, O> op = SpecialOp.op(ops, opType,
+			UnaryHybridCI.class, null, OpUtils.args(otherArgs, out, in));
 		return op;
 	}
 
@@ -270,25 +271,26 @@ public final class Hybrids {
 	 *          interface which multiple {@link UnaryHybridCFI}s implement), then
 	 *          the best {@link UnaryHybridCFI} implementation to use will be
 	 *          selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link UnaryHybridCFI} typed
-	 *          arguments.
+	 * @param outType The {@link Class} of the {@link UnaryHybridCFI} typed
+	 *          output.
+	 * @param inType The {@link Class} of the {@link UnaryHybridCFI} typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed input and
 	 *          output values.
 	 * @return A {@link UnaryHybridCFI} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryHybridCFI<A> unaryCFI(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final Object... otherArgs)
+	public static <I, O extends I, OP extends Op> UnaryHybridCFI<I, O> unaryCFI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final Class<I> inType, final Object... otherArgs)
 	{
 		@SuppressWarnings("unchecked")
-		final UnaryHybridCFI<A> op = SpecialOp.op(ops, opType, UnaryHybridCFI.class,
-			null, OpUtils.args(otherArgs, argType, argType));
+		final UnaryHybridCFI<I, O> op = SpecialOp.op(ops, opType,
+			UnaryHybridCFI.class, null, OpUtils.args(otherArgs, outType, inType));
 		return op;
 	}
 
 	/**
-	 * Gets the best {@link UnaryHybridCFI} implementation for the given types and
-	 * arguments, populating its inputs.
+	 * Gets the best {@link UnaryHybridCFI} implementation for the given types
+	 * and arguments, populating its inputs.
 	 *
 	 * @param ops The {@link OpEnvironment} to search for a matching op.
 	 * @param opType The {@link Class} of the operation. If multiple
@@ -296,26 +298,26 @@ public final class Hybrids {
 	 *          interface which multiple {@link UnaryHybridCFI}s implement), then
 	 *          the best {@link UnaryHybridCFI} implementation to use will be
 	 *          selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link UnaryHybridCFI} typed
-	 *          arguments.
+	 * @param outType The {@link Class} of the {@link UnaryHybridCFI} typed
+	 *          output.
 	 * @param in The typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed input and
 	 *          output values.
 	 * @return A {@link UnaryHybridCFI} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryHybridCFI<A> unaryCFI(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final A in, final Object... otherArgs)
+	public static <I, O extends I, OP extends Op> UnaryHybridCFI<I, O> unaryCFI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final I in, final Object... otherArgs)
 	{
 		@SuppressWarnings("unchecked")
-		final UnaryHybridCFI<A> op = SpecialOp.op(ops, opType, UnaryHybridCFI.class,
-			null, OpUtils.args(otherArgs, argType, in));
+		final UnaryHybridCFI<I, O> op = SpecialOp.op(ops, opType,
+			UnaryHybridCFI.class, null, OpUtils.args(otherArgs, outType, in));
 		return op;
 	}
 
 	/**
-	 * Gets the best {@link UnaryHybridCFI} implementation for the given types and
-	 * arguments, populating its inputs.
+	 * Gets the best {@link UnaryHybridCFI} implementation for the given types
+	 * and arguments, populating its inputs.
 	 *
 	 * @param ops The {@link OpEnvironment} to search for a matching op.
 	 * @param opType The {@link Class} of the operation. If multiple
@@ -329,13 +331,13 @@ public final class Hybrids {
 	 *          output values.
 	 * @return A {@link UnaryHybridCFI} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryHybridCFI<A> unaryCFI(
-		final OpEnvironment ops, final Class<OP> opType, final A out, final A in,
+	public static <I, O extends I, OP extends Op> UnaryHybridCFI<I, O> unaryCFI(
+		final OpEnvironment ops, final Class<OP> opType, final O out, final I in,
 		final Object... otherArgs)
 	{
 		@SuppressWarnings("unchecked")
-		final UnaryHybridCFI<A> op = SpecialOp.op(ops, opType, UnaryHybridCFI.class,
-			null, OpUtils.args(otherArgs, out, in));
+		final UnaryHybridCFI<I, O> op = SpecialOp.op(ops, opType,
+			UnaryHybridCFI.class, null, OpUtils.args(otherArgs, out, in));
 		return op;
 	}
 
@@ -429,6 +431,97 @@ public final class Hybrids {
 	}
 
 	/**
+	 * Gets the best {@link BinaryHybridCI1} implementation for the given types
+	 * and arguments, populating its inputs.
+	 *
+	 * @param ops The {@link OpEnvironment} to search for a matching op.
+	 * @param opType The {@link Class} of the operation. If multiple
+	 *          {@link BinaryHybridCI1}s share this type (e.g., the type is an
+	 *          interface which multiple {@link BinaryHybridCI1}s implement),
+	 *          then the best {@link BinaryHybridCI1} implementation to use will
+	 *          be selected automatically from the type and arguments.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCI1} typed
+	 *          output.
+	 * @param in1Type The {@link Class} of the {@link BinaryHybridCI1} first
+	 *          typed input.
+	 * @param in2Type The {@link Class} of the {@link BinaryHybridCI1} second
+	 *          typed input.
+	 * @param otherArgs The operation's arguments, excluding the typed inputs and
+	 *          output values.
+	 * @return A {@link BinaryHybridCI1} with populated inputs, ready to use.
+	 */
+	public static <I1, I2, O extends I1, OP extends Op>
+		BinaryHybridCI1<I1, I2, O> binaryCI1(final OpEnvironment ops,
+			final Class<OP> opType, final Class<O> outType, final Class<I1> in1Type,
+			final Class<I2> in2Type, final Object... otherArgs)
+	{
+		final Object[] args = OpUtils.args(otherArgs, outType, in1Type, in2Type);
+		@SuppressWarnings("unchecked")
+		final BinaryHybridCI1<I1, I2, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCI1.class, null, args);
+		return op;
+	}
+
+	/**
+	 * Gets the best {@link BinaryHybridCI1} implementation for the given types
+	 * and arguments, populating its inputs.
+	 *
+	 * @param ops The {@link OpEnvironment} to search for a matching op.
+	 * @param opType The {@link Class} of the operation. If multiple
+	 *          {@link BinaryHybridCI1}s share this type (e.g., the type is an
+	 *          interface which multiple {@link BinaryHybridCI1}s implement),
+	 *          then the best {@link BinaryHybridCI1} implementation to use will
+	 *          be selected automatically from the type and arguments.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCI1} typed
+	 *          output.
+	 * @param in1 The first typed input.
+	 * @param in2 The second typed input.
+	 * @param otherArgs The operation's arguments, excluding the typed inputs and
+	 *          output values.
+	 * @return A {@link BinaryHybridCI1} with populated inputs, ready to use.
+	 */
+	public static <I1, I2, O extends I1, OP extends Op>
+		BinaryHybridCI1<I1, I2, O> binaryCI1(final OpEnvironment ops,
+			final Class<OP> opType, final Class<O> outType, final I1 in1,
+			final I2 in2, final Object... otherArgs)
+	{
+		final Object[] args = OpUtils.args(otherArgs, outType, in1, in2);
+		@SuppressWarnings("unchecked")
+		final BinaryHybridCI1<I1, I2, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCI1.class, null, args);
+		return op;
+	}
+
+	/**
+	 * Gets the best {@link BinaryHybridCI1} implementation for the given types
+	 * and arguments, populating its inputs.
+	 *
+	 * @param ops The {@link OpEnvironment} to search for a matching op.
+	 * @param opType The {@link Class} of the operation. If multiple
+	 *          {@link BinaryHybridCI1}s share this type (e.g., the type is an
+	 *          interface which multiple {@link BinaryHybridCI1}s implement),
+	 *          then the best {@link BinaryHybridCI1} implementation to use will
+	 *          be selected automatically from the type and arguments.
+	 * @param out The typed output.
+	 * @param in1 The first typed input.
+	 * @param in2 The second typed input.
+	 * @param otherArgs The operation's arguments, excluding the typed inputs and
+	 *          output values.
+	 * @return A {@link BinaryHybridCI1} with populated inputs, ready to use.
+	 */
+	public static <I1, I2, O extends I1, OP extends Op>
+		BinaryHybridCI1<I1, I2, O> binaryCI1(final OpEnvironment ops,
+			final Class<OP> opType, final O out, final I1 in1, final I2 in2,
+			final Object... otherArgs)
+	{
+		final Object[] args = OpUtils.args(otherArgs, out, in1, in2);
+		@SuppressWarnings("unchecked")
+		final BinaryHybridCI1<I1, I2, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCI1.class, null, args);
+		return op;
+	}
+
+	/**
 	 * Gets the best {@link BinaryHybridCFI1} implementation for the given types
 	 * and arguments, populating its inputs.
 	 *
@@ -438,21 +531,24 @@ public final class Hybrids {
 	 *          interface which multiple {@link BinaryHybridCFI1}s implement),
 	 *          then the best {@link BinaryHybridCFI1} implementation to use will
 	 *          be selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link BinaryHybridCFI1} typed
-	 *          output and first input.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCFI1} typed
+	 *          output.
+	 * @param in1Type The {@link Class} of the {@link BinaryHybridCFI1} first
+	 *          typed input.
 	 * @param in2Type The {@link Class} of the {@link BinaryHybridCFI1} second
 	 *          typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed inputs and
 	 *          output values.
 	 * @return A {@link BinaryHybridCFI1} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryHybridCFI1<A, I> binaryCFI1(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final Class<I> in2Type, final Object... otherArgs)
+	public static <I1, I2, O extends I1, OP extends Op>
+		BinaryHybridCFI1<I1, I2, O> binaryCFI1(final OpEnvironment ops,
+			final Class<OP> opType, final Class<O> outType, final Class<I1> in1Type,
+			final Class<I2> in2Type, final Object... otherArgs)
 	{
-		final Object[] args = OpUtils.args(otherArgs, argType, argType, in2Type);
+		final Object[] args = OpUtils.args(otherArgs, outType, in1Type, in2Type);
 		@SuppressWarnings("unchecked")
-		final BinaryHybridCFI1<A, I> op = SpecialOp.op(ops, opType,
+		final BinaryHybridCFI1<I1, I2, O> op = SpecialOp.op(ops, opType,
 			BinaryHybridCFI1.class, null, args);
 		return op;
 	}
@@ -467,21 +563,22 @@ public final class Hybrids {
 	 *          interface which multiple {@link BinaryHybridCFI1}s implement),
 	 *          then the best {@link BinaryHybridCFI1} implementation to use will
 	 *          be selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link BinaryHybridCFI1} typed
-	 *          output and first input.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCFI1} typed
+	 *          output.
 	 * @param in1 The first typed input.
 	 * @param in2 The second typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed inputs and
 	 *          output values.
 	 * @return A {@link BinaryHybridCFI1} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryHybridCFI1<A, I> binaryCFI1(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final A in1, final I in2, final Object... otherArgs)
+	public static <I1, I2, O extends I1, OP extends Op>
+		BinaryHybridCFI1<I1, I2, O> binaryCFI1(final OpEnvironment ops,
+			final Class<OP> opType, final Class<O> outType, final I1 in1,
+			final I2 in2, final Object... otherArgs)
 	{
-		final Object[] args = OpUtils.args(otherArgs, argType, in1, in2);
+		final Object[] args = OpUtils.args(otherArgs, outType, in1, in2);
 		@SuppressWarnings("unchecked")
-		final BinaryHybridCFI1<A, I> op = SpecialOp.op(ops, opType,
+		final BinaryHybridCFI1<I1, I2, O> op = SpecialOp.op(ops, opType,
 			BinaryHybridCFI1.class, null, args);
 		return op;
 	}
@@ -503,14 +600,101 @@ public final class Hybrids {
 	 *          output values.
 	 * @return A {@link BinaryHybridCFI1} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryHybridCFI1<A, I> binaryCFI1(
-		final OpEnvironment ops, final Class<OP> opType, final A out, final A in1,
+	public static <I1, I2, O extends I1, OP extends Op>
+		BinaryHybridCFI1<I1, I2, O> binaryCFI1(final OpEnvironment ops,
+			final Class<OP> opType, final O out, final I1 in1, final I2 in2,
+			final Object... otherArgs)
+	{
+		final Object[] args = OpUtils.args(otherArgs, out, in1, in2);
+		@SuppressWarnings("unchecked")
+		final BinaryHybridCFI1<I1, I2, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCFI1.class, null, args);
+		return op;
+	}
+
+	/**
+	 * Gets the best {@link BinaryHybridCI} implementation for the given types
+	 * and arguments, populating its inputs.
+	 *
+	 * @param ops The {@link OpEnvironment} to search for a matching op.
+	 * @param opType The {@link Class} of the operation. If multiple
+	 *          {@link BinaryHybridCI}s share this type (e.g., the type is an
+	 *          interface which multiple {@link BinaryHybridCI}s implement), then
+	 *          the best {@link BinaryHybridCI} implementation to use will be
+	 *          selected automatically from the type and arguments.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCI} typed
+	 *          output.
+	 * @param inType The {@link Class} of the {@link BinaryHybridCI} typed
+	 *          inputs.
+	 * @param otherArgs The operation's arguments, excluding the typed inputs and
+	 *          output values.
+	 * @return A {@link BinaryHybridCI} with populated inputs, ready to use.
+	 */
+	public static <I, O extends I, OP extends Op> BinaryHybridCI<I, O> binaryCI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final Class<I> inType, final Object... otherArgs)
+	{
+		final Object[] args = OpUtils.args(otherArgs, outType, inType, inType);
+		@SuppressWarnings("unchecked")
+		final BinaryHybridCI<I, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCI.class, null, args);
+		return op;
+	}
+
+	/**
+	 * Gets the best {@link BinaryHybridCI} implementation for the given types
+	 * and arguments, populating its inputs.
+	 *
+	 * @param ops The {@link OpEnvironment} to search for a matching op.
+	 * @param opType The {@link Class} of the operation. If multiple
+	 *          {@link BinaryHybridCI}s share this type (e.g., the type is an
+	 *          interface which multiple {@link BinaryHybridCI}s implement), then
+	 *          the best {@link BinaryHybridCI} implementation to use will be
+	 *          selected automatically from the type and arguments.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCI} typed
+	 *          output.
+	 * @param in1 The first typed input.
+	 * @param in2 The second typed input.
+	 * @param otherArgs The operation's arguments, excluding the typed inputs and
+	 *          output values.
+	 * @return A {@link BinaryHybridCI} with populated inputs, ready to use.
+	 */
+	public static <I, O extends I, OP extends Op> BinaryHybridCI<I, O> binaryCI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final I in1, final I in2, final Object... otherArgs)
+	{
+		final Object[] args = OpUtils.args(otherArgs, outType, in1, in2);
+		@SuppressWarnings("unchecked")
+		final BinaryHybridCI<I, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCI.class, null, args);
+		return op;
+	}
+
+	/**
+	 * Gets the best {@link BinaryHybridCI} implementation for the given types
+	 * and arguments, populating its inputs.
+	 *
+	 * @param ops The {@link OpEnvironment} to search for a matching op.
+	 * @param opType The {@link Class} of the operation. If multiple
+	 *          {@link BinaryHybridCI}s share this type (e.g., the type is an
+	 *          interface which multiple {@link BinaryHybridCI}s implement), then
+	 *          the best {@link BinaryHybridCI} implementation to use will be
+	 *          selected automatically from the type and arguments.
+	 * @param out The typed output.
+	 * @param in1 The first typed input.
+	 * @param in2 The second typed input.
+	 * @param otherArgs The operation's arguments, excluding the typed inputs and
+	 *          output values.
+	 * @return A {@link BinaryHybridCI} with populated inputs, ready to use.
+	 */
+	public static <I, O extends I, OP extends Op> BinaryHybridCI<I, O> binaryCI(
+		final OpEnvironment ops, final Class<OP> opType, final O out, final I in1,
 		final I in2, final Object... otherArgs)
 	{
 		final Object[] args = OpUtils.args(otherArgs, out, in1, in2);
 		@SuppressWarnings("unchecked")
-		final BinaryHybridCFI1<A, I> op = SpecialOp.op(ops, opType,
-			BinaryHybridCFI1.class, null, args);
+		final BinaryHybridCI<I, O> op = SpecialOp.op(ops, opType,
+			BinaryHybridCI.class, null, args);
 		return op;
 	}
 
@@ -524,19 +708,21 @@ public final class Hybrids {
 	 *          interface which multiple {@link BinaryHybridCFI}s implement), then
 	 *          the best {@link BinaryHybridCFI} implementation to use will be
 	 *          selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link BinaryHybridCFI} typed
-	 *          arguments.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCFI} typed
+	 *          output.
+	 * @param inType The {@link Class} of the {@link BinaryHybridCFI} typed
+	 *          inputs.
 	 * @param otherArgs The operation's arguments, excluding the typed inputs and
 	 *          output values.
 	 * @return A {@link BinaryHybridCFI} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryHybridCFI<A> binaryCFI(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final Object... otherArgs)
+	public static <I, O extends I, OP extends Op> BinaryHybridCFI<I, O> binaryCFI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final Class<I> inType, final Object... otherArgs)
 	{
-		final Object[] args = OpUtils.args(otherArgs, argType, argType, argType);
+		final Object[] args = OpUtils.args(otherArgs, outType, inType, inType);
 		@SuppressWarnings("unchecked")
-		final BinaryHybridCFI<A> op = SpecialOp.op(ops, opType,
+		final BinaryHybridCFI<I, O> op = SpecialOp.op(ops, opType,
 			BinaryHybridCFI.class, null, args);
 		return op;
 	}
@@ -551,21 +737,21 @@ public final class Hybrids {
 	 *          interface which multiple {@link BinaryHybridCFI}s implement), then
 	 *          the best {@link BinaryHybridCFI} implementation to use will be
 	 *          selected automatically from the type and arguments.
-	 * @param argType The {@link Class} of the {@link BinaryHybridCFI} typed
-	 *          arguments.
+	 * @param outType The {@link Class} of the {@link BinaryHybridCFI} typed
+	 *          output.
 	 * @param in1 The first typed input.
 	 * @param in2 The second typed input.
 	 * @param otherArgs The operation's arguments, excluding the typed inputs and
 	 *          output values.
 	 * @return A {@link BinaryHybridCFI} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryHybridCFI<A> binaryCFI(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final A in1, final I in2, final Object... otherArgs)
+	public static <I, O extends I, OP extends Op> BinaryHybridCFI<I, O> binaryCFI(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> outType,
+		final I in1, final I in2, final Object... otherArgs)
 	{
-		final Object[] args = OpUtils.args(otherArgs, argType, in1, in2);
+		final Object[] args = OpUtils.args(otherArgs, outType, in1, in2);
 		@SuppressWarnings("unchecked")
-		final BinaryHybridCFI<A> op = SpecialOp.op(ops, opType,
+		final BinaryHybridCFI<I, O> op = SpecialOp.op(ops, opType,
 			BinaryHybridCFI.class, null, args);
 		return op;
 	}
@@ -587,13 +773,13 @@ public final class Hybrids {
 	 *          output values.
 	 * @return A {@link BinaryHybridCFI} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryHybridCFI<A> binaryCFI(
-		final OpEnvironment ops, final Class<OP> opType, final A out, final A in1,
+	public static <I, O extends I, OP extends Op> BinaryHybridCFI<I, O> binaryCFI(
+		final OpEnvironment ops, final Class<OP> opType, final O out, final I in1,
 		final I in2, final Object... otherArgs)
 	{
 		final Object[] args = OpUtils.args(otherArgs, out, in1, in2);
 		@SuppressWarnings("unchecked")
-		final BinaryHybridCFI<A> op = SpecialOp.op(ops, opType,
+		final BinaryHybridCFI<I, O> op = SpecialOp.op(ops, opType,
 			BinaryHybridCFI.class, null, args);
 		return op;
 	}

--- a/src/main/java/net/imagej/ops/special/hybrid/UnaryHybridCFI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/UnaryHybridCFI.java
@@ -46,18 +46,19 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * </p>
  * 
  * @author Curtis Rueden
- * @param <A> type of input + output
+ * @param <I> type of input
+ * @param <O> type of output
  * @see UnaryHybridCF
  * @see UnaryHybridCI
  */
-public interface UnaryHybridCFI<A> extends UnaryHybridCF<A, A>,
-	UnaryHybridCI<A>
+public interface UnaryHybridCFI<I, O extends I> extends UnaryHybridCF<I, O>,
+	UnaryHybridCI<I, O>
 {
 
 	// -- UnaryOp methods --
 
 	@Override
-	default A run(final A input, final A output) {
+	default O run(final I input, final O output) {
 		if (input == output) {
 			// run as an inplace
 			return UnaryHybridCI.super.run(input, output);
@@ -69,7 +70,7 @@ public interface UnaryHybridCFI<A> extends UnaryHybridCF<A, A>,
 	// -- NullaryOp methods --
 
 	@Override
-	default A run(final A output) {
+	default O run(final O output) {
 		return UnaryHybridCF.super.run(output);
 	}
 
@@ -83,7 +84,7 @@ public interface UnaryHybridCFI<A> extends UnaryHybridCF<A, A>,
 	// -- Threadable methods --
 
 	@Override
-	default UnaryHybridCFI<A> getIndependentInstance() {
+	default UnaryHybridCFI<I, O> getIndependentInstance() {
 		// NB: We assume the op instance is thread-safe by default.
 		// Individual implementations can override this assumption if they
 		// have state (such as buffers) that cannot be shared across threads.

--- a/src/main/java/net/imagej/ops/special/hybrid/UnaryHybridCI.java
+++ b/src/main/java/net/imagej/ops/special/hybrid/UnaryHybridCI.java
@@ -46,37 +46,40 @@ import net.imagej.ops.special.inplace.UnaryInplaceOp;
  * @author Curtis Rueden
  * @author Christian Dietz (University of Konstanz)
  * @param <I> type of input
+ * @param <O> type of output
  * @see UnaryHybridCI
  */
-public interface UnaryHybridCI<I> extends UnaryComputerOp<I, I>,
-	UnaryInplaceOp<I>
+public interface UnaryHybridCI<I, O extends I> extends UnaryComputerOp<I, O>,
+	UnaryInplaceOp<I, O>
 {
 
 	// -- UnaryInplaceOp methods --
 
 	@Override
-	default void mutate(final I input) {
-		compute1(input, input);
-	}
-
-	@Override
-	default I run(final I output) {
-		return UnaryInplaceOp.super.run(output);
+	default void mutate(final O arg) {
+		compute1(arg, arg);
 	}
 
 	// -- UnaryOp methods --
 
 	@Override
-	default I run(final I input, final I output) {
+	default O run(final I input, final O output) {
 		if (output == input) {
 			// run inplace
-			mutate(input);
-			return input;
+			mutate(output);
+			return output;
 		}
 
 		// run as a computer
 		compute1(input, output);
 		return output;
+	}
+
+	// -- NullaryOp methods --
+
+	@Override
+	default O run(final O output) {
+		return UnaryInplaceOp.super.run(output);
 	}
 
 	// -- Runnable methods --
@@ -89,7 +92,7 @@ public interface UnaryHybridCI<I> extends UnaryComputerOp<I, I>,
 	// -- Threadable methods --
 
 	@Override
-	default UnaryHybridCI<I> getIndependentInstance() {
+	default UnaryHybridCI<I, O> getIndependentInstance() {
 		// NB: We assume the op instance is thread-safe by default.
 		// Individual implementations can override this assumption if they
 		// have state (such as buffers) that cannot be shared across threads.

--- a/src/main/java/net/imagej/ops/special/inplace/AbstractBinaryInplace1Op.java
+++ b/src/main/java/net/imagej/ops/special/inplace/AbstractBinaryInplace1Op.java
@@ -36,12 +36,12 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 
 /**
- * Abstract superclass for {@link BinaryInplace1Op} implementations.
+ * Abstract superclass for {@link BinaryInplace1OnlyOp} implementations.
  * 
  * @author Curtis Rueden
  */
 public abstract class AbstractBinaryInplace1Op<A, I> extends
-	AbstractBinaryOp<A, I, A> implements BinaryInplace1Op<A, I>
+	AbstractBinaryOp<A, I, A> implements BinaryInplace1OnlyOp<A, I>
 {
 
 	// -- Parameters --
@@ -55,11 +55,6 @@ public abstract class AbstractBinaryInplace1Op<A, I> extends
 	// -- BinaryInput methods --
 
 	@Override
-	public A in1() {
-		return arg;
-	}
-
-	@Override
 	public I in2() {
 		return in;
 	}
@@ -67,12 +62,18 @@ public abstract class AbstractBinaryInplace1Op<A, I> extends
 	@Override
 	public void setInput1(final A input1) {
 		arg = input1;
-		
 	}
 
 	@Override
 	public void setInput2(final I input2) {
 		in = input2;
+	}
+
+	// -- Output methods --
+
+	@Override
+	public A out() {
+		return arg;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/special/inplace/AbstractBinaryInplaceOp.java
+++ b/src/main/java/net/imagej/ops/special/inplace/AbstractBinaryInplaceOp.java
@@ -31,12 +31,12 @@
 package net.imagej.ops.special.inplace;
 
 /**
- * Abstract superclass for {@link BinaryInplaceOp} implementations.
+ * Abstract superclass for {@link BinaryInplaceOnlyOp} implementations.
  * 
  * @author Curtis Rueden
  */
 public abstract class AbstractBinaryInplaceOp<A> extends
-	AbstractBinaryInplace1Op<A, A> implements BinaryInplaceOp<A>
+	AbstractBinaryInplace1Op<A, A> implements BinaryInplaceOnlyOp<A>
 {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/ops/special/inplace/AbstractUnaryInplaceOp.java
+++ b/src/main/java/net/imagej/ops/special/inplace/AbstractUnaryInplaceOp.java
@@ -36,12 +36,12 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 
 /**
- * Abstract superclass for {@link UnaryInplaceOp} implementations.
+ * Abstract superclass for {@link UnaryInplaceOnlyOp} implementations.
  * 
  * @author Curtis Rueden
  */
 public abstract class AbstractUnaryInplaceOp<A> extends AbstractUnaryOp<A, A>
-	implements UnaryInplaceOp<A>
+	implements UnaryInplaceOnlyOp<A>
 {
 
 	// -- Parameters --
@@ -49,16 +49,18 @@ public abstract class AbstractUnaryInplaceOp<A> extends AbstractUnaryOp<A, A>
 	@Parameter(type = ItemIO.BOTH)
 	private A arg;
 
-	// -- UnaryInplaceOp methods --
-
-	@Override
-	public A in() {
-		return arg;
-	}
+	// -- UnaryInput methods --
 
 	@Override
 	public void setInput(final A in) {
 		this.arg = in;
+	}
+
+	// -- Output methods --
+
+	@Override
+	public A out() {
+		return arg;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/special/inplace/BinaryInplace1OnlyOp.java
+++ b/src/main/java/net/imagej/ops/special/inplace/BinaryInplace1OnlyOp.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.inplace;
+
+import net.imagej.ops.special.hybrid.BinaryHybridCFI1;
+
+/**
+ * A {@link BinaryInplace1Op} which is <em>not</em> a hybrid.
+ * <p>
+ * Hence, even though it is a binary op, it has only <em>TWO</em> inputs:
+ * {@code arg} (the first input, which is also the output) and {@code in} (the
+ * second input). In contrast, a {@link BinaryHybridCFI1} has <em>THREE</em>
+ * inputs: {@code out} (the output, which is of type BOTH), {@code in1} (the
+ * first input) and {@code in2} (the second input).
+ * </p>
+ * 
+ * @author Curtis Rueden
+ * @param <A> type of first input + output
+ * @param <I> type of second input
+ */
+public interface BinaryInplace1OnlyOp<A, I> extends BinaryInplace1Op<A, I, A> {
+
+	// -- Threadable methods --
+
+	@Override
+	default BinaryInplace1OnlyOp<A, I> getIndependentInstance() {
+		// NB: We assume the op instance is thread-safe by default.
+		// Individual implementations can override this assumption if they
+		// have state (such as buffers) that cannot be shared across threads.
+		return this;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/special/inplace/BinaryInplaceOnlyOp.java
+++ b/src/main/java/net/imagej/ops/special/inplace/BinaryInplaceOnlyOp.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.inplace;
+
+import net.imagej.ops.special.hybrid.BinaryHybridCFI;
+
+/**
+ * A {@link BinaryInplaceOp} which is <em>not</em> a hybrid.
+ * <p>
+ * Like its supertype {@link BinaryInplace1OnlyOp}, even though it is a binary
+ * op, it has only <em>TWO</em> inputs: {@code arg} (the first input, which is
+ * also the output) and {@code in} (the second input). In contrast, a
+ * {@link BinaryHybridCFI} has <em>THREE</em> inputs: {@code out} (the output,
+ * which is of type BOTH), {@code in1} (the first input) and {@code in2} (the
+ * second input).
+ * </p>
+ * 
+ * @author Curtis Rueden
+ * @param <A> type of inputs + output
+ */
+public interface BinaryInplaceOnlyOp<A> extends BinaryInplaceOp<A, A>,
+	BinaryInplace1OnlyOp<A, A>
+{
+
+	// -- Threadable methods --
+
+	@Override
+	default BinaryInplaceOnlyOp<A> getIndependentInstance() {
+		// NB: We assume the op instance is thread-safe by default.
+		// Individual implementations can override this assumption if they
+		// have state (such as buffers) that cannot be shared across threads.
+		return this;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/special/inplace/Inplaces.java
+++ b/src/main/java/net/imagej/ops/special/inplace/Inplaces.java
@@ -30,10 +30,15 @@
 
 package net.imagej.ops.special.inplace;
 
+import java.util.Arrays;
+
 import net.imagej.ops.Op;
 import net.imagej.ops.OpEnvironment;
+import net.imagej.ops.OpRef;
 import net.imagej.ops.OpUtils;
-import net.imagej.ops.special.SpecialOp;
+import net.imagej.ops.special.hybrid.BinaryHybridCI;
+import net.imagej.ops.special.hybrid.BinaryHybridCI1;
+import net.imagej.ops.special.hybrid.UnaryHybridCI;
 
 /**
  * Utility class for looking up inplace ops in a type-safe way.
@@ -63,13 +68,18 @@ public final class Inplaces {
 	 *          value.
 	 * @return An {@link UnaryInplaceOp} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryInplaceOp<A> unary(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
+	public static <O, OP extends Op> UnaryInplaceOp<? super O, O> unary(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> argType,
 		final Object... otherArgs)
 	{
+		final OpRef<?>[] refs = new OpRef<?>[2];
+		refs[0] = OpRef.createTypes(opType, UnaryInplaceOnlyOp.class, null, OpUtils
+			.args(otherArgs, argType));
+		refs[1] = OpRef.createTypes(opType, UnaryHybridCI.class, null, OpUtils.args(
+			otherArgs, null, argType));
 		@SuppressWarnings("unchecked")
-		final UnaryInplaceOp<A> op = SpecialOp.op(ops, opType, UnaryInplaceOp.class,
-			null, OpUtils.args(otherArgs, argType));
+		final UnaryInplaceOp<? super O, O> op = (UnaryInplaceOp<? super O, O>) ops
+			.op(Arrays.asList(refs));
 		return op;
 	}
 
@@ -88,13 +98,18 @@ public final class Inplaces {
 	 *          value.
 	 * @return An {@link UnaryInplaceOp} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> UnaryInplaceOp<A> unary(
-		final OpEnvironment ops, final Class<OP> opType, final A arg,
+	public static <O, OP extends Op> UnaryInplaceOp<? super O, O> unary(
+		final OpEnvironment ops, final Class<OP> opType, final O arg,
 		final Object... otherArgs)
 	{
+		final OpRef<?>[] refs = new OpRef<?>[2];
+		refs[0] = OpRef.createTypes(opType, UnaryInplaceOnlyOp.class, null, OpUtils
+			.args(otherArgs, arg));
+		refs[1] = OpRef.createTypes(opType, UnaryHybridCI.class, null, OpUtils.args(
+			otherArgs, null, arg));
 		@SuppressWarnings("unchecked")
-		final UnaryInplaceOp<A> op = SpecialOp.op(ops, opType, UnaryInplaceOp.class,
-			null, OpUtils.args(otherArgs, arg));
+		final UnaryInplaceOp<? super O, O> op = (UnaryInplaceOp<? super O, O>) ops
+			.op(Arrays.asList(refs));
 		return op;
 	}
 
@@ -116,13 +131,20 @@ public final class Inplaces {
 	 *          values.
 	 * @return An {@link BinaryInplace1Op} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryInplace1Op<A, I> binary1(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
-		final Class<I> inType, final Object... otherArgs)
+
+	public static <I2, O, OP extends Op> BinaryInplace1Op<? super O, I2, O>
+		binary1(final OpEnvironment ops, final Class<OP> opType,
+			final Class<O> argType, final Class<I2> inType,
+			final Object... otherArgs)
 	{
+		final OpRef<?>[] refs = new OpRef<?>[2];
+		refs[0] = OpRef.createTypes(opType, BinaryInplace1OnlyOp.class, null,
+			OpUtils.args(otherArgs, argType, inType));
+		refs[1] = OpRef.createTypes(opType, BinaryHybridCI1.class, null, OpUtils
+			.args(otherArgs, null, argType, inType));
 		@SuppressWarnings("unchecked")
-		final BinaryInplace1Op<A, I> op = SpecialOp.op(ops, opType,
-			BinaryInplace1Op.class, null, OpUtils.args(otherArgs, argType, inType));
+		final BinaryInplace1Op<? super O, I2, O> op =
+			(BinaryInplace1Op<? super O, I2, O>) ops.op(Arrays.asList(refs));
 		return op;
 	}
 
@@ -142,13 +164,18 @@ public final class Inplaces {
 	 *          values.
 	 * @return An {@link BinaryInplace1Op} with populated inputs, ready to use.
 	 */
-	public static <A, I, OP extends Op> BinaryInplace1Op<A, I> binary1(
-		final OpEnvironment ops, final Class<OP> opType, final A arg, final I in,
-		final Object... otherArgs)
+	public static <I2, O, OP extends Op> BinaryInplace1Op<? super O, I2, O>
+		binary1(final OpEnvironment ops, final Class<OP> opType, final O arg,
+			final I2 in, final Object... otherArgs)
 	{
+		final OpRef<?>[] refs = new OpRef<?>[2];
+		refs[0] = OpRef.createTypes(opType, BinaryInplace1OnlyOp.class, null,
+			OpUtils.args(otherArgs, arg, in));
+		refs[1] = OpRef.createTypes(opType, BinaryHybridCI1.class, null, OpUtils
+			.args(otherArgs, null, arg, in));
 		@SuppressWarnings("unchecked")
-		final BinaryInplace1Op<A, I> op = SpecialOp.op(ops, opType,
-			BinaryInplace1Op.class, null, OpUtils.args(otherArgs, arg, in));
+		final BinaryInplace1Op<? super O, I2, O> op =
+			(BinaryInplace1Op<? super O, I2, O>) ops.op(Arrays.asList(refs));
 		return op;
 	}
 
@@ -168,13 +195,18 @@ public final class Inplaces {
 	 *          values.
 	 * @return An {@link BinaryInplaceOp} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> BinaryInplaceOp<A> binary(
-		final OpEnvironment ops, final Class<OP> opType, final Class<A> argType,
+	public static <O, OP extends Op> BinaryInplaceOp<? super O, O> binary(
+		final OpEnvironment ops, final Class<OP> opType, final Class<O> argType,
 		final Object... otherArgs)
 	{
+		final OpRef<?>[] refs = new OpRef<?>[2];
+		refs[0] = OpRef.createTypes(opType, BinaryInplaceOnlyOp.class, null, OpUtils
+			.args(otherArgs, argType, argType));
+		refs[1] = OpRef.createTypes(opType, BinaryHybridCI.class, null, OpUtils
+			.args(otherArgs, null, argType, argType));
 		@SuppressWarnings("unchecked")
-		final BinaryInplaceOp<A> op = SpecialOp.op(ops, opType,
-			BinaryInplaceOp.class, null, OpUtils.args(otherArgs, argType, argType));
+		final BinaryInplaceOp<? super O, O> op = (BinaryInplaceOp<? super O, O>) ops
+			.op(Arrays.asList(refs));
 		return op;
 	}
 
@@ -194,13 +226,18 @@ public final class Inplaces {
 	 *          values.
 	 * @return An {@link BinaryInplaceOp} with populated inputs, ready to use.
 	 */
-	public static <A, OP extends Op> BinaryInplaceOp<A> binary(
-		final OpEnvironment ops, final Class<OP> opType, final A arg1, final A arg2,
+	public static <O, OP extends Op> BinaryInplaceOp<? super O, O> binary(
+		final OpEnvironment ops, final Class<OP> opType, final O arg1, final O arg2,
 		final Object... otherArgs)
 	{
+		final OpRef<?>[] refs = new OpRef<?>[2];
+		refs[0] = OpRef.createTypes(opType, BinaryInplaceOnlyOp.class, null, OpUtils
+			.args(otherArgs, arg1, arg2));
+		refs[1] = OpRef.createTypes(opType, BinaryHybridCI.class, null, OpUtils
+			.args(otherArgs, null, arg1, arg2));
 		@SuppressWarnings("unchecked")
-		final BinaryInplaceOp<A> op = SpecialOp.op(ops, opType,
-			BinaryInplaceOp.class, null, OpUtils.args(otherArgs, arg1, arg2));
+		final BinaryInplaceOp<? super O, O> op = (BinaryInplaceOp<? super O, O>) ops
+			.op(Arrays.asList(refs));
 		return op;
 	}
 

--- a/src/main/java/net/imagej/ops/special/inplace/UnaryInplaceOnlyOp.java
+++ b/src/main/java/net/imagej/ops/special/inplace/UnaryInplaceOnlyOp.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.special.inplace;
+
+/**
+ * A {@link UnaryInplaceOp} which is <em>not</em> a hybrid.
+ * 
+ * @author Curtis Rueden
+ * @param <A> type of input + output
+ */
+public interface UnaryInplaceOnlyOp<A> extends UnaryInplaceOp<A, A> {
+
+	// -- Threadable methods --
+
+	@Override
+	default UnaryInplaceOnlyOp<A> getIndependentInstance() {
+		// NB: We assume the op instance is thread-safe by default.
+		// Individual implementations can override this assumption if they
+		// have state (such as buffers) that cannot be shared across threads.
+		return this;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/special/inplace/UnaryInplaceOp.java
+++ b/src/main/java/net/imagej/ops/special/inplace/UnaryInplaceOp.java
@@ -33,28 +33,35 @@ package net.imagej.ops.special.inplace;
 import net.imagej.ops.special.UnaryOp;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.UnaryHybridCI;
 
 /**
  * A unary <em>inplace</em> operation is an op which mutates a parameter.
+ * <p>
+ * Note that the {@code <I>} and {@code <O>} type parameters are kept distinct
+ * for special hybrid ops, which may <em>allow</em> inplace mutation without
+ * <em>requiring</em> it; see e.g. {@link UnaryHybridCI}.
+ * </p>
  * 
  * @author Curtis Rueden
- * @param <A> type of argument
+ * @param <I> type of input
+ * @param <O> type of output
  * @see UnaryComputerOp
  * @see UnaryFunctionOp
  */
-public interface UnaryInplaceOp<A> extends UnaryOp<A, A> {
+public interface UnaryInplaceOp<I, O extends I> extends UnaryOp<I, O> {
 
 	/**
 	 * Mutates the given input argument in-place.
 	 * 
 	 * @param arg of the {@link UnaryInplaceOp}
 	 */
-	void mutate(A arg);
+	void mutate(O arg);
 
 	// -- UnaryOp methods --
 
 	@Override
-	default A run(final A input, final A output) {
+	default O run(final I input, final O output) {
 		// check inplace preconditions
 		if (input == null) throw new NullPointerException("input is null");
 		if (input != output) {
@@ -62,14 +69,14 @@ public interface UnaryInplaceOp<A> extends UnaryOp<A, A> {
 		}
 
 		// compute the result
-		mutate(input);
+		mutate(output);
 		return output;
 	}
 
 	// -- NullaryOp methods --
 
 	@Override
-	default A run(final A output) {
+	default O run(final O output) {
 		// check inplace preconditions
 		if (output == null) throw new NullPointerException("output is null");
 
@@ -78,17 +85,17 @@ public interface UnaryInplaceOp<A> extends UnaryOp<A, A> {
 		return output;
 	}
 
-	// -- Output methods --
+	// -- UnaryInput methods --
 
 	@Override
-	default A out() {
-		return in();
+	default I in() {
+		return out();
 	}
 
 	// -- Threadable methods --
 
 	@Override
-	default UnaryInplaceOp<A> getIndependentInstance() {
+	default UnaryInplaceOp<I, O> getIndependentInstance() {
 		// NB: We assume the op instance is thread-safe by default.
 		// Individual implementations can override this assumption if they
 		// have state (such as buffers) that cannot be shared across threads.

--- a/src/main/templates/net/imagej/ops/map/MapBinaryInplace1s.vm
+++ b/src/main/templates/net/imagej/ops/map/MapBinaryInplace1s.vm
@@ -64,7 +64,7 @@ public class MapBinaryInplace1s {
 	 */
 	@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + $priority)
 	public static class ${argType.alias}And${inType.alias}<EA, EI> extends
-		AbstractMapBinaryInplace1<EA, EI, ${argType.name}<EA>, ${inType.name}<EI>>
+		AbstractMapBinaryInplace1<EA, EI, EA, ${argType.name}<EA>, ${inType.name}<EI>>
 		implements Contingent
 	{
 		@Override
@@ -89,7 +89,7 @@ public class MapBinaryInplace1s {
 	 */
 	@Plugin(type = Ops.Map.class, priority = Priority.LOW_PRIORITY + $paraPrio)
 	public static class ${argType.alias}And${inType.alias}Parallel<EA, EI> extends
-		AbstractMapBinaryInplace1<EA, EI, ${argType.name}<EA>, ${inType.name}<EI>>
+		AbstractMapBinaryInplace1<EA, EI, EA, ${argType.name}<EA>, ${inType.name}<EI>>
 		implements Contingent, Parallel
 	{
 		@Override

--- a/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToIIOutputII.vm
@@ -59,7 +59,7 @@ public final class ConstantToIIOutputII {
 
 	@Plugin(type = ${iface}.class)
 	public static class ${op.name}<T extends NumericType<T>> extends
-		AbstractUnaryHybridCFI<IterableInterval<T>>
+		AbstractUnaryHybridCFI<IterableInterval<T>, IterableInterval<T>>
 		implements Contingent, $iface
 	{
 

--- a/src/main/templates/net/imagej/ops/math/IIToIIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/IIToIIOutputII.vm
@@ -59,8 +59,8 @@ public final class IIToIIOutputII {
 	
 	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
 	public static class ${op.name}<T extends NumericType<T>> extends
-		AbstractBinaryHybridCFI<IterableInterval<T>> implements $iface,
-		Contingent
+		AbstractBinaryHybridCFI<IterableInterval<T>, IterableInterval<T>>
+		implements $iface, Contingent
 	{
 
 		private UnaryFunctionOp<IterableInterval<T>, IterableInterval<T>> outputCreator;

--- a/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.vm
+++ b/src/main/templates/net/imagej/ops/math/IIToRAIOutputII.vm
@@ -61,7 +61,7 @@ public final class IIToRAIOutputII {
 
 	@Plugin(type = ${iface}.class)
 	public static class ${op.name}<T extends NumericType<T>> extends
-		AbstractBinaryHybridCFI1<IterableInterval<T>, RandomAccessibleInterval<T>>
+		AbstractBinaryHybridCFI1<IterableInterval<T>, RandomAccessibleInterval<T>, IterableInterval<T>>
 		implements $iface, Contingent
 	{
 

--- a/src/main/templates/net/imagej/ops/math/NumericTypeBinaryMath.vm
+++ b/src/main/templates/net/imagej/ops/math/NumericTypeBinaryMath.vm
@@ -66,7 +66,7 @@ public final class NumericTypeBinaryMath {
 	/** Op that $op.verbs two NumericType values. */
 	@Plugin(type = ${iface}.class, priority = Priority.HIGH_PRIORITY)
 	public static class $op.name<T extends NumericType<T>> extends
-		AbstractBinaryHybridCFI<T> implements $iface, Contingent
+		AbstractBinaryHybridCFI<T, T> implements $iface, Contingent
 	{
 
 		@Override

--- a/src/test/java/net/imagej/ops/convert/ConvertIIsTest.java
+++ b/src/test/java/net/imagej/ops/convert/ConvertIIsTest.java
@@ -116,8 +116,9 @@ public class ConvertIIsTest extends AbstractOpTest {
 	}
 
 	private void addNoise(final Iterable<ShortType> image) {
-		final UnaryInplaceOp<ShortType> noiseOp = Inplaces.unary(ops,
-			Ops.Filter.AddNoise.class, ShortType.class, -32768, 32767, 10000);
+		// NB: Need "? super ShortType" instead of "?" to make javac happy.
+		final UnaryInplaceOp<? super ShortType, ShortType> noiseOp = Inplaces.unary(
+			ops, Ops.Filter.AddNoise.class, ShortType.class, -32768, 32767, 10000);
 		ops.map(image, noiseOp);
 	}
 

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -48,7 +48,7 @@ import org.junit.rules.ExpectedException;
 
 /**
  * Tests for {@link MapOp}s that are not covered in the auto generated tests.
- *  
+ * 
  * @author Leon Yang
  * @author Christian Dietz (University of Konstanz)
  */
@@ -92,10 +92,9 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> secondDiffDims = generateByteArrayTestImg(false, 10, 10,
 			2);
 
-		sub = Inplaces.binary(ops, Ops.Math.Subtract.class, ByteType.class,
-			ByteType.class);
-		final BinaryInplaceOp<Img<ByteType>> map = Inplaces.binary(ops,
-			MapIIAndIIInplaceParallel.class, firstCopy, second, sub);
+		sub = Inplaces.binary(ops, Ops.Math.Subtract.class, ByteType.class);
+		final BinaryInplaceOp<? super Img<ByteType>, Img<ByteType>> map = Inplaces
+			.binary(ops, MapIIAndIIInplaceParallel.class, firstCopy, second, sub);
 		map.run(firstCopy, second, firstCopy);
 		map.run(first, secondCopy, secondCopy);
 
@@ -118,10 +117,9 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> secondDiffDims = generateByteArrayTestImg(false, 10, 10,
 			2);
 
-		sub = Inplaces.binary(ops, Ops.Math.Subtract.class, ByteType.class,
-			ByteType.class);
-		final BinaryInplaceOp<Img<ByteType>> map = Inplaces.binary(ops,
-			MapIIAndIIInplaceParallel.class, firstCopy, second, sub);
+		sub = Inplaces.binary(ops, Ops.Math.Subtract.class, ByteType.class);
+		final BinaryInplaceOp<? super Img<ByteType>, Img<ByteType>> map = Inplaces
+			.binary(ops, MapIIAndIIInplaceParallel.class, firstCopy, second, sub);
 		map.run(firstCopy, second, firstCopy);
 		map.run(first, secondCopy, secondCopy);
 
@@ -139,7 +137,7 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> argCopy = arg.copy();
 
 		sub = Inplaces.unary(ops, Ops.Math.Subtract.class, ByteType.class,
-			ByteType.class, new ByteType((byte) 1));
+			new ByteType((byte) 1));
 		ops.run(MapIIInplaceParallel.class, argCopy, sub);
 
 		assertImgSubOneEquals(arg, argCopy);
@@ -151,7 +149,7 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> argCopy = arg.copy();
 
 		sub = Inplaces.unary(ops, Ops.Math.Subtract.class, ByteType.class,
-			ByteType.class, new ByteType((byte) 1));
+			new ByteType((byte) 1));
 		ops.run(MapIterableInplace.class, argCopy, sub);
 
 		assertImgSubOneEquals(arg, argCopy);
@@ -163,7 +161,7 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> out = generateByteArrayTestImg(false, 10, 10);
 
 		sub = Computers.unary(ops, Ops.Math.Subtract.class, ByteType.class,
-			ByteType.class, new ByteType((byte) 1));
+			new ByteType((byte) 1));
 		ops.run(MapIterableToIterable.class, out, in, sub);
 
 		assertImgSubOneEquals(in, out);

--- a/src/test/java/net/imagej/ops/special/SpecialOpMatchingTest.java
+++ b/src/test/java/net/imagej/ops/special/SpecialOpMatchingTest.java
@@ -50,13 +50,29 @@ import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.NullaryFunctionOp;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCFI;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCFI1;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCI;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCI1;
 import net.imagej.ops.special.hybrid.AbstractNullaryHybridCF;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imagej.ops.special.hybrid.AbstractUnaryHybridCFI;
+import net.imagej.ops.special.hybrid.AbstractUnaryHybridCI;
 import net.imagej.ops.special.hybrid.BinaryHybridCF;
+import net.imagej.ops.special.hybrid.BinaryHybridCFI;
+import net.imagej.ops.special.hybrid.BinaryHybridCFI1;
+import net.imagej.ops.special.hybrid.BinaryHybridCI;
+import net.imagej.ops.special.hybrid.BinaryHybridCI1;
 import net.imagej.ops.special.hybrid.Hybrids;
 import net.imagej.ops.special.hybrid.NullaryHybridCF;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
+import net.imagej.ops.special.hybrid.UnaryHybridCFI;
+import net.imagej.ops.special.hybrid.UnaryHybridCI;
+import net.imagej.ops.special.inplace.AbstractBinaryInplace1Op;
+import net.imagej.ops.special.inplace.AbstractBinaryInplaceOp;
 import net.imagej.ops.special.inplace.AbstractUnaryInplaceOp;
+import net.imagej.ops.special.inplace.BinaryInplace1Op;
+import net.imagej.ops.special.inplace.BinaryInplaceOp;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
 
@@ -361,34 +377,183 @@ public class SpecialOpMatchingTest extends AbstractOpTest {
 	}
 
 	/**
+	 * Tests {@link Hybrids#unaryCI(OpEnvironment, Class, Class, Class, Object...)}
+	 * (i.e.: with neither output nor input specified).
+	 */
+	@Test
+	public void testUnaryHybridCI() {
+		final UnaryHybridCI<Apple, Apple> unaryHybridCIAA = Hybrids.unaryCI(ops,
+			FruitOp.class, Apple.class, Apple.class);
+		assertSame(unaryHybridCIAA.getClass(), UnaryHybridCIAA.class);
+
+		final UnaryHybridCI<Orange, Orange> unaryHybridCIOO = Hybrids.unaryCI(ops,
+			FruitOp.class, Orange.class, Orange.class);
+		assertSame(unaryHybridCIOO.getClass(), UnaryHybridCIOO.class);
+
+		final UnaryHybridCI<Lemon, Lemon> unaryHybridCILL = Hybrids.unaryCI(ops,
+			FruitOp.class, Lemon.class, Lemon.class);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(unaryHybridCILL.getClass(), UnaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests {@link Hybrids#unaryCI(OpEnvironment, Class, Class, Object, Object...)}
+	 * (i.e.: with the input specified).
+	 */
+	@Test
+	public void testUnaryHybridCIIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final UnaryHybridCI<Apple, Apple> unaryHybridCIAA = Hybrids.unaryCI(ops,
+			FruitOp.class, Apple.class, a);
+		assertSame(unaryHybridCIAA.getClass(), UnaryHybridCIAA.class);
+
+		final UnaryHybridCI<Orange, Orange> unaryHybridCIOO = Hybrids.unaryCI(ops,
+			FruitOp.class, Orange.class, o);
+		assertSame(unaryHybridCIOO.getClass(), UnaryHybridCIOO.class);
+
+		final UnaryHybridCI<Lemon, Lemon> unaryHybridCILL = Hybrids.unaryCI(ops,
+			FruitOp.class, Lemon.class, l);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(unaryHybridCILL.getClass(), UnaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#unaryCI(OpEnvironment, Class, Object, Object, Object...)}
+	 * (i.e.: with the output and input specified).
+	 */
+	@Test
+	public void testUnaryHybridCIOutIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final UnaryHybridCI<Apple, Apple> unaryHybridCIAA = Hybrids.unaryCI(ops,
+			FruitOp.class, a, a);
+		assertSame(unaryHybridCIAA.getClass(), UnaryHybridCIAA.class);
+
+		final UnaryHybridCI<Orange, Orange> unaryHybridCIOO = Hybrids.unaryCI(ops,
+			FruitOp.class, o, o);
+		assertSame(unaryHybridCIOO.getClass(), UnaryHybridCIOO.class);
+
+		final UnaryHybridCI<Lemon, Lemon> unaryHybridCILL = Hybrids.unaryCI(ops,
+			FruitOp.class, l, l);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(unaryHybridCILL.getClass(), UnaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests {@link Hybrids#unaryCFI(OpEnvironment, Class, Class, Class, Object...)}
+	 * (i.e.: with neither output nor input speCFIfied).
+	 */
+	@Test
+	public void testUnaryHybridCFI() {
+		final UnaryHybridCFI<Apple, Apple> unaryHybridCFIAA = Hybrids.unaryCFI(ops,
+			FruitOp.class, Apple.class, Apple.class);
+		assertSame(unaryHybridCFIAA.getClass(), UnaryHybridCFIAA.class);
+
+		final UnaryHybridCFI<Orange, Orange> unaryHybridCFIOO = Hybrids.unaryCFI(ops,
+			FruitOp.class, Orange.class, Orange.class);
+		assertSame(unaryHybridCFIOO.getClass(), UnaryHybridCFIOO.class);
+
+		final UnaryHybridCFI<Lemon, Lemon> unaryHybridCFILL = Hybrids.unaryCFI(ops,
+			FruitOp.class, Lemon.class, Lemon.class);
+		assertSame(unaryHybridCFILL.getClass(), UnaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests {@link Hybrids#unaryCFI(OpEnvironment, Class, Class, Object, Object...)}
+	 * (i.e.: with the input speCFIfied).
+	 */
+	@Test
+	public void testUnaryHybridCFIIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final UnaryHybridCFI<Apple, Apple> unaryHybridCFIAA = Hybrids.unaryCFI(ops,
+			FruitOp.class, Apple.class, a);
+		assertSame(unaryHybridCFIAA.getClass(), UnaryHybridCFIAA.class);
+
+		final UnaryHybridCFI<Orange, Orange> unaryHybridCFIOO = Hybrids.unaryCFI(ops,
+			FruitOp.class, Orange.class, o);
+		assertSame(unaryHybridCFIOO.getClass(), UnaryHybridCFIOO.class);
+
+		final UnaryHybridCFI<Lemon, Lemon> unaryHybridCFILL = Hybrids.unaryCFI(ops,
+			FruitOp.class, Lemon.class, l);
+		assertSame(unaryHybridCFILL.getClass(), UnaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#unaryCFI(OpEnvironment, Class, Object, Object, Object...)}
+	 * (i.e.: with the output and input speCFIfied).
+	 */
+	@Test
+	public void testUnaryHybridCFIOutIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final UnaryHybridCFI<Apple, Apple> unaryHybridCFIAA = Hybrids.unaryCFI(ops,
+			FruitOp.class, a, a);
+		assertSame(unaryHybridCFIAA.getClass(), UnaryHybridCFIAA.class);
+
+		final UnaryHybridCFI<Orange, Orange> unaryHybridCFIOO = Hybrids.unaryCFI(ops,
+			FruitOp.class, o, o);
+		assertSame(unaryHybridCFIOO.getClass(), UnaryHybridCFIOO.class);
+
+		final UnaryHybridCFI<Lemon, Lemon> unaryHybridCFILL = Hybrids.unaryCFI(ops,
+			FruitOp.class, l, l);
+		assertSame(unaryHybridCFILL.getClass(), UnaryHybridCFILL.class);
+	}
+
+	/**
 	 * Tests {@link Inplaces#unary(OpEnvironment, Class, Class, Object...)} (i.e.:
-	 * without the argument specified).
+	 * without the argument specified). UnaryHybridCI/CFI should be matched if
+	 * types are matched and it has higher priority. 
 	 */
 	@Test
 	public void testInplace() {
-		final UnaryInplaceOp<Apple> inplaceA = Inplaces.unary(ops, FruitOp.class,
-			Apple.class);
+		final UnaryInplaceOp<? super Apple, Apple> inplaceA = Inplaces.unary(ops, FruitOp.class,
+			Apple.class, String.class);
 		assertSame(inplaceA.getClass(), InplaceA.class);
 
-		final UnaryInplaceOp<Orange> inplaceO = Inplaces.unary(ops, FruitOp.class,
-			Orange.class);
-		assertSame(inplaceO.getClass(), InplaceO.class);
+		final UnaryInplaceOp<? super Orange, Orange> inplaceO = Inplaces.unary(ops, FruitOp.class,
+			Orange.class, String.class);
+		assertSame(inplaceO.getClass(), UnaryHybridCIOO.class);
+
+		final UnaryInplaceOp<? super Lemon, Lemon> inplaceL = Inplaces.unary(ops, FruitOp.class,
+			Lemon.class, String.class);
+		assertSame(inplaceL.getClass(), UnaryHybridCFILL.class);
 	}
 
 	/**
 	 * Tests {@link Inplaces#unary(OpEnvironment, Class, Object, Object...)}
-	 * (i.e.: with the argument specified).
+	 * (i.e.: with the argument specified). UnaryHybridCI/CFI should be matched if
+	 * types are matched and it has higher priority.
 	 */
 	@Test
 	public void testInplaceIn() {
 		final Apple a = new Apple();
 		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+		final String foo = "optional parameter placeholder";
 
-		final UnaryInplaceOp<Apple> inplaceA = Inplaces.unary(ops, FruitOp.class, a);
+		final UnaryInplaceOp<? super Apple, Apple> inplaceA = Inplaces.unary(ops,
+			FruitOp.class, a, foo);
 		assertSame(inplaceA.getClass(), InplaceA.class);
 
-		final UnaryInplaceOp<Orange> inplaceO = Inplaces.unary(ops, FruitOp.class, o);
-		assertSame(inplaceO.getClass(), InplaceO.class);
+		final UnaryInplaceOp<? super Orange, Orange> inplaceO = Inplaces.unary(ops,
+			FruitOp.class, o, foo);
+		assertSame(inplaceO.getClass(), UnaryHybridCIOO.class);
+
+		final UnaryInplaceOp<? super Lemon, Lemon> inplaceL = Inplaces.unary(ops,
+			FruitOp.class, l, foo);
+		assertSame(inplaceL.getClass(), UnaryHybridCFILL.class);
 	}
 
 	/**
@@ -600,6 +765,387 @@ public class SpecialOpMatchingTest extends AbstractOpTest {
 		assertSame(binaryHybridOOL.getClass(), BinaryHybridOOL.class);
 	}
 
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCI1(OpEnvironment, Class, Class, Class, Class, Object...)}
+	 * (i.e.: with neither output nor inputs specified).
+	 */
+	@Test
+	public void testBinaryHybridCI1() {
+		final BinaryHybridCI1<Apple, Orange, Apple> binaryHybridCI1AOA = Hybrids
+			.binaryCI1(ops, FruitOp.class, Apple.class, Apple.class, Orange.class);
+		assertSame(binaryHybridCI1AOA.getClass(), BinaryHybridCI1AOA.class);
+
+		final BinaryHybridCI1<Orange, Lemon, Orange> binaryHybridCI1OLO = Hybrids
+			.binaryCI1(ops, FruitOp.class, Orange.class, Orange.class, Lemon.class);
+		assertSame(binaryHybridCI1OLO.getClass(), BinaryHybridCI1OLO.class);
+
+		final BinaryHybridCI1<Lemon, Apple, Lemon> binaryHybridCI1LAL = Hybrids
+			.binaryCI1(ops, FruitOp.class, Lemon.class, Lemon.class, Apple.class);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridCI1LAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCI1(OpEnvironment, Class, Class, Object, Object, Object...)}
+	 * (i.e.: with the inputs specified).
+	 */
+	@Test
+	public void testBinaryHybridCI1In() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCI1<Apple, Orange, Apple> binaryHybridCI1AOA = Hybrids
+			.binaryCI1(ops, FruitOp.class, Apple.class, a, o);
+		assertSame(binaryHybridCI1AOA.getClass(), BinaryHybridCI1AOA.class);
+
+		final BinaryHybridCI1<Orange, Lemon, Orange> binaryHybridCI1OLO = Hybrids
+			.binaryCI1(ops, FruitOp.class, Orange.class, o, l);
+		assertSame(binaryHybridCI1OLO.getClass(), BinaryHybridCI1OLO.class);
+
+		final BinaryHybridCI1<Lemon, Apple, Lemon> binaryHybridCI1LAL = Hybrids
+			.binaryCI1(ops, FruitOp.class, Lemon.class, l, a);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridCI1LAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCI1(OpEnvironment, Class, Object, Object, Object, Object...)}
+	 * (i.e.: with the output and inputs specified).
+	 */
+	@Test
+	public void testBinaryHybridCI1OutIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCI1<Apple, Orange, Apple> binaryHybridAOA = Hybrids
+			.binaryCI1(ops, FruitOp.class, a, a, o);
+		assertSame(binaryHybridAOA.getClass(), BinaryHybridCI1AOA.class);
+
+		final BinaryHybridCI1<Orange, Lemon, Orange> binaryHybridOLO = Hybrids
+			.binaryCI1(ops, FruitOp.class, o, o, l);
+		assertSame(binaryHybridOLO.getClass(), BinaryHybridCI1OLO.class);
+
+		final BinaryHybridCI1<Lemon, Apple, Lemon> binaryHybridOAL = Hybrids
+			.binaryCI1(ops, FruitOp.class, l, l, a);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridOAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCFI1(OpEnvironment, Class, Class, Class, Class, Object...)}
+	 * (i.e.: with neither output nor inputs speCFIfied).
+	 */
+	@Test
+	public void testBinaryHybridCFI1() {
+		final BinaryHybridCFI1<Apple, Orange, Apple> binaryHybridCFI1AOA = Hybrids
+			.binaryCFI1(ops, FruitOp.class, Apple.class, Apple.class, Orange.class);
+		assertSame(binaryHybridCFI1AOA.getClass(), BinaryHybridCFI1AOA.class);
+
+		final BinaryHybridCFI1<Orange, Lemon, Orange> binaryHybridCFI1OLO = Hybrids
+			.binaryCFI1(ops, FruitOp.class, Orange.class, Orange.class, Lemon.class);
+		assertSame(binaryHybridCFI1OLO.getClass(), BinaryHybridCFI1OLO.class);
+
+		final BinaryHybridCFI1<Lemon, Apple, Lemon> binaryHybridCFI1LAL = Hybrids
+			.binaryCFI1(ops, FruitOp.class, Lemon.class, Lemon.class, Apple.class);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridCFI1LAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCFI1(OpEnvironment, Class, Class, Object, Object, Object...)}
+	 * (i.e.: with the inputs speCFIfied).
+	 */
+	@Test
+	public void testBinaryHybridCFI1In() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCFI1<Apple, Orange, Apple> binaryHybridCFI1AOA = Hybrids
+			.binaryCFI1(ops, FruitOp.class, Apple.class, a, o);
+		assertSame(binaryHybridCFI1AOA.getClass(), BinaryHybridCFI1AOA.class);
+
+		final BinaryHybridCFI1<Orange, Lemon, Orange> binaryHybridCFI1OLO = Hybrids
+			.binaryCFI1(ops, FruitOp.class, Orange.class, o, l);
+		assertSame(binaryHybridCFI1OLO.getClass(), BinaryHybridCFI1OLO.class);
+
+		final BinaryHybridCFI1<Lemon, Apple, Lemon> binaryHybridCFI1LAL = Hybrids
+			.binaryCFI1(ops, FruitOp.class, Lemon.class, l, a);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridCFI1LAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCFI1(OpEnvironment, Class, Object, Object, Object, Object...)}
+	 * (i.e.: with the output and inputs speCFIfied).
+	 */
+	@Test
+	public void testBinaryHybridCFI1OutIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCFI1<Apple, Orange, Apple> binaryHybridAOA = Hybrids
+			.binaryCFI1(ops, FruitOp.class, a, a, o);
+		assertSame(binaryHybridAOA.getClass(), BinaryHybridCFI1AOA.class);
+
+		final BinaryHybridCFI1<Orange, Lemon, Orange> binaryHybridOLO = Hybrids
+			.binaryCFI1(ops, FruitOp.class, o, o, l);
+		assertSame(binaryHybridOLO.getClass(), BinaryHybridCFI1OLO.class);
+
+		final BinaryHybridCFI1<Lemon, Apple, Lemon> binaryHybridOAL = Hybrids
+			.binaryCFI1(ops, FruitOp.class, l, l, a);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridOAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCI(OpEnvironment, Class, Class, Class, Class, Object...)}
+	 * (i.e.: with neither output nor inputs specified).
+	 */
+	@Test
+	public void testBinaryHybridCI() {
+		final BinaryHybridCI<Apple, Apple> binaryHybridCIAA = Hybrids
+			.binaryCI(ops, FruitOp.class, Apple.class, Apple.class);
+		assertSame(binaryHybridCIAA.getClass(), BinaryHybridCIAA.class);
+
+		final BinaryHybridCI<Orange, Orange> binaryHybridCIOO = Hybrids
+			.binaryCI(ops, FruitOp.class, Orange.class, Orange.class);
+		assertSame(binaryHybridCIOO.getClass(), BinaryHybridCIOO.class);
+
+		final BinaryHybridCI<Lemon, Lemon> binaryHybridCILL = Hybrids
+			.binaryCI(ops, FruitOp.class, Lemon.class, Lemon.class);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridCILL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCI(OpEnvironment, Class, Class, Object, Object, Object...)}
+	 * (i.e.: with the inputs specified).
+	 */
+	@Test
+	public void testBinaryHybridCIIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCI<Apple, Apple> binaryHybridCIAA = Hybrids
+			.binaryCI(ops, FruitOp.class, Apple.class, a, a);
+		assertSame(binaryHybridCIAA.getClass(), BinaryHybridCIAA.class);
+
+		final BinaryHybridCI<Orange, Orange> binaryHybridCIOO = Hybrids
+			.binaryCI(ops, FruitOp.class, Orange.class, o, o);
+		assertSame(binaryHybridCIOO.getClass(), BinaryHybridCIOO.class);
+
+		final BinaryHybridCI<Lemon, Lemon> binaryHybridCILL = Hybrids
+			.binaryCI(ops, FruitOp.class, Lemon.class, l, l);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridCILL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCI(OpEnvironment, Class, Object, Object, Object, Object...)}
+	 * (i.e.: with the output and inputs specified).
+	 */
+	@Test
+	public void testBinaryHybridCIOutIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCI<Apple, Apple> binaryHybridAA = Hybrids
+			.binaryCI(ops, FruitOp.class, a, a, a);
+		assertSame(binaryHybridAA.getClass(), BinaryHybridCIAA.class);
+
+		final BinaryHybridCI<Orange, Orange> binaryHybridOO = Hybrids
+			.binaryCI(ops, FruitOp.class, o, o, o);
+		assertSame(binaryHybridOO.getClass(), BinaryHybridCIOO.class);
+
+		final BinaryHybridCI<Lemon, Lemon> binaryHybridOAL = Hybrids
+			.binaryCI(ops, FruitOp.class, l, l, l);
+		// CFI is expected because of its higher priority, which is for inplace test
+		assertSame(binaryHybridOAL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCFI(OpEnvironment, Class, Class, Class, Class, Object...)}
+	 * (i.e.: with neither output nor inputs speCFIfied).
+	 */
+	@Test
+	public void testBinaryHybridCFI() {
+		final BinaryHybridCFI<Apple, Apple> binaryHybridCFIAA = Hybrids
+			.binaryCFI(ops, FruitOp.class, Apple.class, Apple.class);
+		assertSame(binaryHybridCFIAA.getClass(), BinaryHybridCFIAA.class);
+
+		final BinaryHybridCFI<Orange, Orange> binaryHybridCFIOO = Hybrids
+			.binaryCFI(ops, FruitOp.class, Orange.class, Orange.class);
+		assertSame(binaryHybridCFIOO.getClass(), BinaryHybridCFIOO.class);
+
+		final BinaryHybridCFI<Lemon, Lemon> binaryHybridCFILL = Hybrids
+			.binaryCFI(ops, FruitOp.class, Lemon.class, Lemon.class);
+		assertSame(binaryHybridCFILL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCFI(OpEnvironment, Class, Class, Object, Object, Object...)}
+	 * (i.e.: with the inputs speCFIfied).
+	 */
+	@Test
+	public void testBinaryHybridCFIIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCFI<Apple, Apple> binaryHybridCFIAA = Hybrids
+			.binaryCFI(ops, FruitOp.class, Apple.class, a, a);
+		assertSame(binaryHybridCFIAA.getClass(), BinaryHybridCFIAA.class);
+
+		final BinaryHybridCFI<Orange, Orange> binaryHybridCFIOO = Hybrids
+			.binaryCFI(ops, FruitOp.class, Orange.class, o, o);
+		assertSame(binaryHybridCFIOO.getClass(), BinaryHybridCFIOO.class);
+
+		final BinaryHybridCFI<Lemon, Lemon> binaryHybridCFILL = Hybrids
+			.binaryCFI(ops, FruitOp.class, Lemon.class, l, l);
+		assertSame(binaryHybridCFILL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Hybrids#binaryCFI(OpEnvironment, Class, Object, Object, Object, Object...)}
+	 * (i.e.: with the output and inputs speCFIfied).
+	 */
+	@Test
+	public void testBinaryHybridCFIOutIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		final BinaryHybridCFI<Apple, Apple> binaryHybridAA = Hybrids
+			.binaryCFI(ops, FruitOp.class, a, a, a);
+		assertSame(binaryHybridAA.getClass(), BinaryHybridCFIAA.class);
+
+		final BinaryHybridCFI<Orange, Orange> binaryHybridOO = Hybrids
+			.binaryCFI(ops, FruitOp.class, o, o, o);
+		assertSame(binaryHybridOO.getClass(), BinaryHybridCFIOO.class);
+
+		final BinaryHybridCFI<Lemon, Lemon> binaryHybridOAL = Hybrids
+			.binaryCFI(ops, FruitOp.class, l, l, l);
+		assertSame(binaryHybridOAL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Inplaces#binary1(OpEnvironment, Class, Class, Class, Object...)}
+	 * (i.e.: without the argument specified).
+	 */
+	@Test
+	public void testBinaryInplace1() {
+		// NB: Need "? super Apple" instead of "?" to make javac happy.
+		final BinaryInplace1Op<? super Apple, Orange, Apple> binaryInplace1AOA = Inplaces
+			.binary1(ops, FruitOp.class, Apple.class, Orange.class);
+		assertSame(binaryInplace1AOA.getClass(), BinaryInplace1AO.class);
+
+		// NB: Need "? super Orange" instead of "?" to make javac happy.
+		final BinaryInplace1Op<? super Orange, Lemon, Orange> binaryInplace1OLO = Inplaces
+			.binary1(ops, FruitOp.class, Orange.class, Lemon.class);
+		assertSame(binaryInplace1OLO.getClass(), BinaryHybridCI1OLO.class);
+
+		// NB: Need "? super Lemon" instead of "?" to make javac happy.
+		final BinaryInplace1Op<? super Lemon, Apple, Lemon> binaryInplace1LAL = Inplaces
+			.binary1(ops, FruitOp.class, Lemon.class, Apple.class);
+		assertSame(binaryInplace1LAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Inplaces#binary1(OpEnvironment, Class, Object, Object, Object...)}
+	 * (i.e.: with the argument specified).
+	 */
+	@Test
+	public void testBinaryInplace1In() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		// NB: Need "? super Apple" instead of "?" to make javac happy.
+		final BinaryInplace1Op<? super Apple, Orange, Apple> binaryInplace1AOA =
+			Inplaces.binary1(ops, FruitOp.class, a, o);
+		assertSame(binaryInplace1AOA.getClass(), BinaryInplace1AO.class);
+
+		// NB: Need "? super Orange" instead of "?" to make javac happy.
+		final BinaryInplace1Op<? super Orange, Lemon, Orange> binaryInplace1OLO =
+			Inplaces.binary1(ops, FruitOp.class, o, l);
+		assertSame(binaryInplace1OLO.getClass(), BinaryHybridCI1OLO.class);
+
+		// NB: Need "? super Lemon" instead of "?" to make javac happy.
+		final BinaryInplace1Op<? super Lemon, Apple, Lemon> binaryInplace1LAL =
+			Inplaces.binary1(ops, FruitOp.class, l, a);
+		assertSame(binaryInplace1LAL.getClass(), BinaryHybridCFI1LAL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Inplaces#binary(OpEnvironment, Class, Class, Object...)}
+	 * (i.e.: without the argument specified).
+	 */
+	@Test
+	public void testBinaryInplace() {
+		// NB: Need "? super Apple" instead of "?" to make javac happy.
+		final BinaryInplaceOp<? super Apple, Apple> binaryInplaceA = //
+			Inplaces.binary(ops, FruitOp.class, Apple.class);
+		assertSame(binaryInplaceA.getClass(), BinaryInplaceA.class);
+
+		// NB: Need "? super Orange" instead of "?" to make javac happy.
+		final BinaryInplaceOp<? super Orange, Orange> binaryInplaceO = //
+			Inplaces.binary(ops, FruitOp.class, Orange.class);
+		assertSame(binaryInplaceO.getClass(), BinaryHybridCIOO.class);
+
+		// NB: Need "? super Lemon" instead of "?" to make javac happy.
+		final BinaryInplaceOp<? super Lemon, Lemon> binaryInplaceL = //
+			Inplaces.binary(ops, FruitOp.class, Lemon.class);
+		assertSame(binaryInplaceL.getClass(), BinaryHybridCFILL.class);
+	}
+
+	/**
+	 * Tests
+	 * {@link Inplaces#binary(OpEnvironment, Class, Object, Object, Object...)}
+	 * (i.e.: with the argument specified).
+	 */
+	@Test
+	public void testBinaryInplaceIn() {
+		final Apple a = new Apple();
+		final Orange o = new Orange();
+		final Lemon l = new Lemon();
+
+		// NB: Need "? super Apple" instead of "?" to make javac happy.
+		final BinaryInplaceOp<? super Apple, Apple> binaryInplaceA = //
+			Inplaces.binary(ops, FruitOp.class, a, a);
+		assertSame(binaryInplaceA.getClass(), BinaryInplaceA.class);
+
+		// NB: Need "? super Orange" instead of "?" to make javac happy.
+		final BinaryInplaceOp<? super Orange, Orange> binaryInplaceO = //
+			Inplaces.binary(ops, FruitOp.class, o, o);
+		assertSame(binaryInplaceO.getClass(), BinaryHybridCIOO.class);
+
+		// NB: Need "? super Lemon" instead of "?" to make javac happy.
+		final BinaryInplaceOp<? super Lemon, Lemon> binaryInplaceL = //
+			Inplaces.binary(ops, FruitOp.class, l, l);
+		assertSame(binaryInplaceL.getClass(), BinaryHybridCFILL.class);
+	}
+
 	// -- Helper classes --
 
 	public static class Apple {
@@ -688,9 +1234,43 @@ public class SpecialOpMatchingTest extends AbstractOpTest {
 		}
 	}
 
+	public abstract static class UnaryFruitHybridCI<I, O extends I> extends
+		AbstractUnaryHybridCI<I, O> implements FruitOp
+	{
+
+		@Parameter(required = false)
+		private String foo;
+
+		@Override
+		public void compute1(final I in, final O out) {
+		// NB: No implementation needed.
+		}
+	}
+
+	public abstract static class UnaryFruitHybridCFI<I, O extends I> extends
+		AbstractUnaryHybridCFI<I, O> implements FruitOp
+	{
+
+		@Parameter(required = false)
+		private String foo;
+
+		@Override
+		public O createOutput(final I input) {
+			return null;
+		}
+
+		@Override
+		public void compute1(final I in, final O out) {
+		// NB: No implementation needed.
+		}
+	}
+
 	public abstract static class FruitInplace<A> extends AbstractUnaryInplaceOp<A>
 		implements FruitOp
 	{
+
+		@Parameter(required = false)
+		private String foo;
 
 		@Override
 		public void mutate(final A arg) {
@@ -801,15 +1381,57 @@ public class SpecialOpMatchingTest extends AbstractOpTest {
 		// NB: No implementation needed.
 	}
 
+	@Plugin(type = FruitOp.class, name = "test.unaryHybridCIAA",
+		priority = Priority.VERY_LOW_PRIORITY + 20)
+	public static class UnaryHybridCIAA extends UnaryFruitHybridCI<Apple, Apple> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.unaryHybridCIOO",
+		priority = Priority.VERY_LOW_PRIORITY + 21)
+	public static class UnaryHybridCIOO extends UnaryFruitHybridCI<Orange, Orange> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.unaryHybridCILL",
+		priority = Priority.VERY_LOW_PRIORITY + 20)
+	public static class UnaryHybridCILL extends UnaryFruitHybridCI<Lemon, Lemon> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.unaryHybridCFIAA",
+		priority = Priority.VERY_LOW_PRIORITY + 15)
+	public static class UnaryHybridCFIAA extends UnaryFruitHybridCFI<Apple, Apple> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.unaryHybridCFIOO",
+		priority = Priority.VERY_LOW_PRIORITY + 15)
+	public static class UnaryHybridCFIOO extends UnaryFruitHybridCFI<Orange, Orange> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.unaryHybridCFILL",
+		priority = Priority.VERY_LOW_PRIORITY + 21)
+	public static class UnaryHybridCFILL extends UnaryFruitHybridCFI<Lemon, Lemon> {
+		// NB: No implementation needed.
+	}
+
 	@Plugin(type = FruitOp.class, name = "test.inplaceA",
-		priority = Priority.VERY_LOW_PRIORITY)
+		priority = Priority.VERY_LOW_PRIORITY + 21)
 	public static class InplaceA extends FruitInplace<Apple> {
 		// NB: No implementation needed.
 	}
 
 	@Plugin(type = FruitOp.class, name = "test.inplaceO",
-		priority = Priority.VERY_LOW_PRIORITY)
+		priority = Priority.VERY_LOW_PRIORITY + 20)
 	public static class InplaceO extends FruitInplace<Orange> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.inplaceL",
+		priority = Priority.VERY_LOW_PRIORITY + 20)
+	public static class InplaceL extends FruitInplace<Lemon> {
 		// NB: No implementation needed.
 	}
 
@@ -972,6 +1594,112 @@ public class SpecialOpMatchingTest extends AbstractOpTest {
 		}
 	}
 
+	public abstract static class BinaryFruitHybridCI1<I1, I2, O extends I1>
+		extends AbstractBinaryHybridCI1<I1, I2, O> implements FruitOp
+	{
+
+		@Override
+		public void compute2(final I1 in1, final I2 in2, final O out) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate1(final O arg, final I2 in) {
+			// NB: No implementation needed.
+		}
+	}
+
+	public abstract static class BinaryFruitHybridCFI1<I1, I2, O extends I1>
+		extends AbstractBinaryHybridCFI1<I1, I2, O> implements FruitOp
+	{
+
+		@Override
+		public O createOutput(final I1 in1, final I2 in2) {
+			return null;
+		}
+
+		@Override
+		public void compute2(final I1 in1, final I2 in2, final O out) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate1(final O arg, final I2 in) {
+			// NB: No implementation needed.
+		}
+
+	}
+
+	public abstract static class BinaryFruitHybridCI<I, O extends I> extends
+		AbstractBinaryHybridCI<I, O> implements FruitOp
+	{
+
+		@Override
+		public void compute2(final I in1, final I in2, final O out) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate1(final O arg, final I in) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate2(final I in, final O arg) {
+			// NB: No implementation needed.
+		}
+	}
+
+	public abstract static class BinaryFruitHybridCFI<I, O extends I> extends
+		AbstractBinaryHybridCFI<I, O> implements FruitOp
+	{
+
+		@Override
+		public O createOutput(final I in1, final I in2) {
+			return null;
+		}
+
+		@Override
+		public void compute2(final I in1, final I in2, final O out) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate1(final O arg, final I in) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate2(final I in, final O arg) {
+			// NB: No implementation needed.
+		}
+	}
+
+	public abstract static class BinaryFruitInplace1<A, I> extends
+		AbstractBinaryInplace1Op<A, I> implements FruitOp
+	{
+
+		@Override
+		public void mutate1(final A arg, final I in) {
+			// NB: No implementation needed.
+		}
+	}
+
+	public abstract static class BinaryFruitInplace<A> extends
+		AbstractBinaryInplaceOp<A> implements FruitOp
+	{
+
+		@Override
+		public void mutate1(final A arg, final A in) {
+			// NB: No implementation needed.
+		}
+
+		@Override
+		public void mutate2(final A in, final A arg) {
+			// NB: No implementation needed.
+		}
+	}
+
 	@Plugin(type = FruitOp.class, name = "test.binaryComputerAAL")
 	public static class BinaryComputerAAL extends
 		BinaryFruitComputer<Apple, Apple, Lemon>
@@ -1059,6 +1787,144 @@ public class SpecialOpMatchingTest extends AbstractOpTest {
 	public static class BinaryHybridOOL extends
 		BinaryFruitHybrid<Orange, Orange, Lemon>
 	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCI1AOA",
+		priority = Priority.VERY_LOW_PRIORITY + 10)
+	public static class BinaryHybridCI1AOA extends
+		BinaryFruitHybridCI1<Apple, Orange, Apple>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCI1OLO",
+		priority = Priority.VERY_LOW_PRIORITY + 11)
+	public static class BinaryHybridCI1OLO extends
+		BinaryFruitHybridCI1<Orange, Lemon, Orange>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCI1LAL",
+		priority = Priority.VERY_LOW_PRIORITY + 10)
+	public static class BinaryHybridCI1LAL extends
+		BinaryFruitHybridCI1<Lemon, Apple, Lemon>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCFI1AOA",
+		priority = Priority.VERY_LOW_PRIORITY + 5)
+	public static class BinaryHybridCFI1AOA extends
+		BinaryFruitHybridCFI1<Apple, Orange, Apple>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCFI1OLO",
+		priority = Priority.VERY_LOW_PRIORITY + 5)
+	public static class BinaryHybridCFI1OLO extends
+		BinaryFruitHybridCFI1<Orange, Lemon, Orange>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCFI1LAL",
+		priority = Priority.VERY_LOW_PRIORITY + 11)
+	public static class BinaryHybridCFI1LAL extends
+		BinaryFruitHybridCFI1<Lemon, Apple, Lemon>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCIAA",
+		priority = Priority.VERY_LOW_PRIORITY + 5)
+	public static class BinaryHybridCIAA extends
+		BinaryFruitHybridCI<Apple, Apple>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCIOO",
+		priority = Priority.VERY_LOW_PRIORITY + 11)
+	public static class BinaryHybridCIOO extends
+		BinaryFruitHybridCI<Orange, Orange>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCILL",
+		priority = Priority.VERY_LOW_PRIORITY + 5)
+	public static class BinaryHybridCILL extends
+		BinaryFruitHybridCI<Lemon, Lemon>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCFIAA",
+		priority = Priority.VERY_LOW_PRIORITY)
+	public static class BinaryHybridCFIAA extends
+		BinaryFruitHybridCFI<Apple, Apple>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCFIOO",
+		priority = Priority.VERY_LOW_PRIORITY)
+	public static class BinaryHybridCFIOO extends
+		BinaryFruitHybridCFI<Orange, Orange>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryHybridCFILL",
+		priority = Priority.VERY_LOW_PRIORITY + 11)
+	public static class BinaryHybridCFILL extends
+		BinaryFruitHybridCFI<Lemon, Lemon>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryInplace1AO",
+		priority = Priority.VERY_LOW_PRIORITY + 11)
+	public static class BinaryInplace1AO extends
+		BinaryFruitInplace1<Apple, Orange>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryInplace1OL",
+		priority = Priority.VERY_LOW_PRIORITY + 5)
+	public static class BinaryInplace1OL extends
+		BinaryFruitInplace1<Orange, Lemon>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryInplace1LA",
+		priority = Priority.VERY_LOW_PRIORITY + 5)
+	public static class BinaryInplace1LA extends
+		BinaryFruitInplace1<Lemon, Apple>
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryInplaceA",
+		priority = Priority.VERY_LOW_PRIORITY + 11)
+	public static class BinaryInplaceA extends BinaryFruitInplace<Apple> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryInplaceO",
+		priority = Priority.VERY_LOW_PRIORITY)
+	public static class BinaryInplaceO extends BinaryFruitInplace<Orange> {
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = FruitOp.class, name = "test.binaryInplaceL",
+		priority = Priority.VERY_LOW_PRIORITY)
+	public static class BinaryInplaceL extends BinaryFruitInplace<Lemon> {
 		// NB: No implementation needed.
 	}
 


### PR DESCRIPTION
I made a rebase and clean up the history. Unfortunately, changing the framework produces a bunch of compile errors, so that I think we need to fix them in one commit, which lead to the huge commit 79b64b0 By making this rebase, the branch differs a lot from the original one, so I just create a new one. I wish I know some git tricks to add a merge history at the tail of this branch to "connect" it with the original one.

I also created the binary CI1 CFI1 CI CFI interfaces/abstract classes. We can keep or remove them. By the way, the SpecialOpMatchingTest is getting huge because of those new interfaces.

This branch also depends on the granular matching branch, which is WIP. Therefore, this branch should not be merge before that one.

@ctrueden please check it out once you have time