### PR TITLE
Remove varargs

### DIFF
--- a/src/main/java/net/imagej/ops/OpEnvironment.java
+++ b/src/main/java/net/imagej/ops/OpEnvironment.java
@@ -323,12 +323,6 @@ public interface OpEnvironment extends Contextual {
 	// -- Operation shortcuts - global namespace --
 
 	/** Executes the "eval" operation on the given arguments. */
-	@OpMethod(op = Ops.Eval.class)
-	default Object eval(final Object... args) {
-		return run(Ops.Eval.NAME, args);
-	}
-
-	/** Executes the "eval" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.eval.DefaultEval.class)
 	default Object eval(final String expression) {
 		final Object result = run(net.imagej.ops.Ops.Eval.class,
@@ -342,12 +336,6 @@ public interface OpEnvironment extends Contextual {
 		final Object result = run(net.imagej.ops.Ops.Eval.class, expression,
 			vars);
 		return result;
-	}
-
-	/** Executes the "help" operation on the given arguments. */
-	@OpMethod(op = Ops.Help.class)
-	default Object help(final Object... args) {
-		return run(Ops.Help.NAME, args);
 	}
 
 	/** Executes the "help" operation on the given arguments. */
@@ -410,24 +398,12 @@ public interface OpEnvironment extends Contextual {
 	}
 
 	/** Executes the "identity" operation on the given arguments. */
-	@OpMethod(op = Ops.Identity.class)
-	default Object identity(final Object... args) {
-		return run(Ops.Identity.NAME, args);
-	}
-
-	/** Executes the "identity" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.identity.DefaultIdentity.class)
 	default <A> A identity(final A arg) {
 		@SuppressWarnings("unchecked")
 		final A result = (A) run(net.imagej.ops.Ops.Identity.class,
 			arg);
 		return result;
-	}
-
-	/** Executes the "join" operation on the given arguments. */
-	@OpMethod(op = Ops.Join.class)
-	default Object join(final Object... args) {
-		return run(Ops.Join.NAME, args);
 	}
 
 	/** Executes the "join" operation on the given arguments. */
@@ -497,12 +473,6 @@ public interface OpEnvironment extends Contextual {
 	}
 
 	/** Executes the "loop" operation on the given arguments. */
-	@OpMethod(op = Ops.Loop.class)
-	default Object loop(final Object... args) {
-		return run(Ops.Loop.NAME, args);
-	}
-
-	/** Executes the "loop" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.loop.DefaultLoopInplace.class)
 	default <I, O extends I> O loop(final O arg, final UnaryInplaceOp<I, O> op,
 		final int n)
@@ -521,12 +491,6 @@ public interface OpEnvironment extends Contextual {
 		final A result = (A) run(net.imagej.ops.Ops.Loop.class, out,
 			in, op, outputFactory, n);
 		return result;
-	}
-
-	/** Executes the "map" operation on the given arguments. */
-	@OpMethod(op = Ops.Map.class)
-	default Object map(final Object... args) {
-		return run(Ops.Map.NAME, args);
 	}
 
 	/** Executes the "map" operation on the given arguments. */
@@ -834,12 +798,6 @@ public interface OpEnvironment extends Contextual {
 		final RandomAccessibleInterval<EO> result =
 			(RandomAccessibleInterval<EO>) run(Ops.Map.class, arg, in, op);
 		return result;
-	}
-
-	/** Executes the "slicewise" operation on the given arguments. */
-	@OpMethod(op = Ops.Slice.class)
-	default Object slice(final Object... args) {
-		return run(Ops.Slice.NAME, args);
 	}
 
 	/** Executes the "slicewise" operation on the given arguments. */

--- a/src/main/java/net/imagej/ops/commands/convolve/Convolve.java
+++ b/src/main/java/net/imagej/ops/commands/convolve/Convolve.java
@@ -121,7 +121,7 @@ public class Convolve<I extends RealType<I>, K extends RealType<K>, O extends Re
 				// if the selected convolve op is a function and the kernel dimensions
 				// doesn't match the input image dimensions, than we can still convolve
 				// each slice individually
-				ops.slice(out, in, op, axisIndices);
+				ops.run(Ops.Slice.class, out, in, op, axisIndices);
 			} else {
 				throw new IllegalArgumentException(
 						"The input image has more dimensions than the kernel!");

--- a/src/main/java/net/imagej/ops/commands/threshold/GlobalThresholder.java
+++ b/src/main/java/net/imagej/ops/commands/threshold/GlobalThresholder.java
@@ -34,6 +34,7 @@ import net.imagej.ImgPlus;
 import net.imagej.axis.Axis;
 import net.imagej.ops.AbstractOp;
 import net.imagej.ops.Op;
+import net.imagej.ops.Ops;
 import net.imagej.ops.threshold.ComputeThreshold;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
@@ -71,7 +72,7 @@ public class GlobalThresholder<T extends RealType<T>> extends AbstractOp {
         Op threshold = ops().op("threshold", out, in, method);
 
         // TODO actually map axes to int array
-        ops().slice(out, in, threshold, new int[]{0, 1});
+        ops().run(Ops.Slice.class, out, in, threshold, new int[]{0, 1});
     }
     
     // TODO call otsu: out = ops.run(GlobalThresholder.class, ops.ops(Otsu...),in).

--- a/src/main/java/net/imagej/ops/convert/ConvertNamespace.java
+++ b/src/main/java/net/imagej/ops/convert/ConvertNamespace.java
@@ -70,11 +70,6 @@ public class ConvertNamespace extends AbstractNamespace {
 
 	// -- Convert namespace ops --
 
-	@OpMethod(op = Ops.Convert.Clip.class)
-	public Object clip(final Object... args) {
-		return ops().run(Ops.Convert.Clip.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.clip.ClipRealTypes.class)
 	public <I extends RealType<I>, O extends RealType<O>> O clip(final O out,
 		final I in)
@@ -85,11 +80,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Copy.class)
-	public Object copy(final Object... args) {
-		return ops().run(Ops.Convert.Copy.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.copy.CopyRealTypes.class)
 	public <I extends RealType<I>, O extends RealType<O>> O copy(final O out,
 		final I in)
@@ -98,11 +88,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(
 			Ops.Convert.Copy.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.ImageType.class)
-	public Object imageType(final Object... args) {
-		return ops().run(Ops.Convert.ImageType.class, args);
 	}
 
 	@OpMethod(
@@ -118,11 +103,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.NormalizeScale.class)
-	public Object normalizeScale(final Object... args) {
-		return ops().run(Ops.Convert.NormalizeScale.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.convert.normalizeScale.NormalizeScaleRealTypes.class)
 	public <I extends RealType<I>, O extends RealType<O>> O normalizeScale(
@@ -135,11 +115,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Scale.class)
-	public Object scale(final Object... args) {
-		return ops().run(Ops.Convert.Scale.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.scale.ScaleRealTypes.class)
 	public <I extends RealType<I>, O extends RealType<O>> O scale(final O out,
 		final I in)
@@ -148,11 +123,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(
 			Ops.Convert.Scale.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Bit.class)
-	public Object bit(final Object... args) {
-		return ops().run(Ops.Convert.Bit.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Bit.class)
@@ -187,11 +157,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final BitType result = (BitType) ops().run(
 			Ops.Convert.Bit.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Uint2.class)
-	public Object uint2(final Object... args) {
-		return ops().run(Ops.Convert.Uint2.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint2.class)
@@ -246,11 +211,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Uint4.class)
-	public Object uint4(final Object... args) {
-		return ops().run(Ops.Convert.Uint4.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint4.class)
 	public <C extends ComplexType<C>> Img<Unsigned4BitType> uint4(
 		final IterableInterval<C> in)
@@ -301,11 +261,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final Unsigned4BitType result = (Unsigned4BitType) ops().run(
 			Ops.Convert.Uint4.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Int8.class)
-	public Object int8(final Object... args) {
-		return ops().run(Ops.Convert.Int8.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Int8.class)
@@ -360,11 +315,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Uint8.class)
-	public Object uint8(final Object... args) {
-		return ops().run(Ops.Convert.Uint8.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint8.class)
 	public <C extends ComplexType<C>> Img<UnsignedByteType> uint8(
 		final IterableInterval<C> in)
@@ -415,11 +365,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final UnsignedByteType result = (UnsignedByteType) ops().run(
 			Ops.Convert.Uint8.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Uint12.class)
-	public Object uint12(final Object... args) {
-		return ops().run(Ops.Convert.Uint12.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint12.class)
@@ -474,11 +419,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Int16.class)
-	public Object int16(final Object... args) {
-		return ops().run(Ops.Convert.Int16.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Int16.class)
 	public <C extends ComplexType<C>> Img<ShortType> int16(
 		final IterableInterval<C> in)
@@ -529,11 +469,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final ShortType result = (ShortType) ops().run(
 			Ops.Convert.Int16.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Uint16.class)
-	public Object uint16(final Object... args) {
-		return ops().run(Ops.Convert.Uint16.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint16.class)
@@ -588,11 +523,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Int32.class)
-	public Object int32(final Object... args) {
-		return ops().run(Ops.Convert.Int32.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Int32.class)
 	public <C extends ComplexType<C>> Img<IntType> int32(
 		final IterableInterval<C> in)
@@ -643,11 +573,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final IntType result = (IntType) ops().run(
 			Ops.Convert.Int32.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Uint32.class)
-	public Object uint32(final Object... args) {
-		return ops().run(Ops.Convert.Uint32.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint32.class)
@@ -702,11 +627,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Int64.class)
-	public Object int64(final Object... args) {
-		return ops().run(Ops.Convert.Int64.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Int64.class)
 	public <C extends ComplexType<C>> Img<LongType> int64(
 		final IterableInterval<C> in)
@@ -757,11 +677,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final LongType result = (LongType) ops().run(
 			Ops.Convert.Int64.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Uint64.class)
-	public Object uint64(final Object... args) {
-		return ops().run(Ops.Convert.Uint64.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint64.class)
@@ -816,11 +731,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Uint128.class)
-	public Object uint128(final Object... args) {
-		return ops().run(Ops.Convert.Uint128.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint128.class)
 	public <C extends ComplexType<C>> Img<Unsigned128BitType> uint128(
 		final IterableInterval<C> in)
@@ -873,11 +783,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Float32.class)
-	public Object float32(final Object... args) {
-		return ops().run(Ops.Convert.Float32.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Float32.class)
 	public <C extends ComplexType<C>> Img<FloatType> float32(
 		final IterableInterval<C> in)
@@ -912,11 +817,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final FloatType result = (FloatType) ops().run(
 			Ops.Convert.Float32.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Cfloat32.class)
-	public Object cfloat32(final Object... args) {
-		return ops().run(Ops.Convert.Cfloat32.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Cfloat32.class)
@@ -955,11 +855,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = Ops.Convert.Float64.class)
-	public Object float64(final Object... args) {
-		return ops().run(Ops.Convert.Float64.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Float64.class)
 	public <C extends ComplexType<C>> Img<DoubleType> float64(
 		final IterableInterval<C> in)
@@ -994,11 +889,6 @@ public class ConvertNamespace extends AbstractNamespace {
 		final DoubleType result = (DoubleType) ops().run(
 			Ops.Convert.Float64.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = Ops.Convert.Cfloat64.class)
-	public Object cfloat64(final Object... args) {
-		return ops().run(Ops.Convert.Cfloat64.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Cfloat64.class)

--- a/src/main/java/net/imagej/ops/create/CreateNamespace.java
+++ b/src/main/java/net/imagej/ops/create/CreateNamespace.java
@@ -46,10 +46,8 @@ import net.imglib2.img.ImgFactory;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.roi.labeling.LabelingMapping;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.IntegerType;
-import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
 import org.scijava.plugin.Plugin;
@@ -164,11 +162,6 @@ public class CreateNamespace extends AbstractNamespace {
 
 	// -- imgFactory --
 
-	@OpMethod(op = net.imagej.ops.Ops.Create.ImgFactory.class)
-	public Object imgFactory(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Create.ImgFactory.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.create.imgFactory.DefaultCreateImgFactory.class)
 	public <T extends NativeType<T>> ImgFactory<T> imgFactory() {
 		// NB: The generic typing of ImgFactory is broken; see:
@@ -202,11 +195,6 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 
 	// -- imgLabeling --
-
-	@OpMethod(op = net.imagej.ops.Ops.Create.ImgLabeling.class)
-	public Object imgLabeling(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Create.ImgLabeling.class, args);
-	}
 
 	@OpMethod(
 		op = net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling.class)
@@ -315,11 +303,6 @@ public class CreateNamespace extends AbstractNamespace {
 
 	// -- imgPlus --
 
-	@OpMethod(op = net.imagej.ops.Ops.Create.ImgPlus.class)
-	public Object imgPlus(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Create.ImgPlus.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.create.imgPlus.DefaultCreateImgPlus.class)
 	public <T> ImgPlus<T> imgPlus(final Img<T> img) {
 		@SuppressWarnings("unchecked")
@@ -343,11 +326,6 @@ public class CreateNamespace extends AbstractNamespace {
 
 	// -- integerType --
 
-	@OpMethod(op = net.imagej.ops.Ops.Create.IntegerType.class)
-	public Object integerType(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Create.IntegerType.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.create.integerType.DefaultCreateIntegerType.class)
 	public IntegerType integerType() {
@@ -368,12 +346,6 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 	
 	// -- kernel --
-
-	/** Executes the "kernel" operation on the given arguments. */
-	@OpMethod(op = Ops.Create.Kernel.class)
-	public Object kernel(final Object... args) {
-		return ops().run(Ops.Create.Kernel.NAME, args);
-	}
 
 	/** Executes the "kernel" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.create.kernel.CreateKernel.class)
@@ -402,12 +374,6 @@ public class CreateNamespace extends AbstractNamespace {
 	}
 
 	// -- kernelGauss --
-
-	/** Executes the "kernelGauss" operation on the given arguments. */
-	@OpMethod(op = Ops.Create.KernelGauss.class)
-	public Object kernelGauss(final Object... args) {
-		return ops().run(Ops.Create.KernelGauss.NAME, args);
-	}
 
 	/** Executes the "kernelGauss" operation on the given arguments. */
 	@OpMethod(
@@ -451,7 +417,6 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-
 	/** Executes the "kernelGauss" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.create.kernelGauss.CreateKernelGauss.class)
 	public <T extends ComplexType<T> & NativeType<T>> Img<T> kernelGauss(
@@ -490,15 +455,7 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-
-
 	// -- kernelLog --
-
-	/** Executes the "kernelLog" operation on the given arguments. */
-	@OpMethod(op = Ops.Create.KernelLog.class)
-	public Object kernelLog(final Object... args) {
-		return ops().run(Ops.Create.KernelLog.NAME, args);
-	}
 
 	/** Executes the "kernelLog" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric.class)
@@ -578,13 +535,7 @@ public class CreateNamespace extends AbstractNamespace {
 		return result;
 	}
 
-
 	// -- labelingMapping --
-
-	@OpMethod(op = net.imagej.ops.Ops.Create.LabelingMapping.class)
-	public Object labelingMapping(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Create.LabelingMapping.class, args);
-	}
 
 	@OpMethod(
 		op = net.imagej.ops.create.labelingMapping.DefaultCreateLabelingMapping.class)

--- a/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGaussSymmetric.java
+++ b/src/main/java/net/imagej/ops/create/kernelGauss/CreateKernelGaussSymmetric.java
@@ -32,7 +32,7 @@ package net.imagej.ops.create.kernelGauss;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.create.AbstractCreateSymmetricGaussianKernel;
-import net.imglib2.img.Img;
+import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ComplexType;
 
 import org.scijava.Priority;
@@ -45,8 +45,9 @@ import org.scijava.plugin.Plugin;
  * @param <T>
  */
 @Plugin(type = Ops.Create.KernelGauss.class, priority = Priority.HIGH_PRIORITY)
-public class CreateKernelGaussSymmetric<T extends ComplexType<T>> extends
-	AbstractCreateSymmetricGaussianKernel<T> implements Ops.Create.KernelGauss
+public class CreateKernelGaussSymmetric<T extends ComplexType<T> & NativeType<T>>
+	extends AbstractCreateSymmetricGaussianKernel<T> implements
+	Ops.Create.KernelGauss
 {
 
 	@Override
@@ -57,7 +58,6 @@ public class CreateKernelGaussSymmetric<T extends ComplexType<T>> extends
 			sigmas[d] = sigma;
 		}
 
-		output =
-			(Img<T>) ops().create().kernelGauss(outType, fac, sigmas);
+		output = ops().create().kernelGauss(outType, fac, sigmas);
 	}
 }

--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -56,11 +56,6 @@ public class DeconvolveNamespace extends AbstractNamespace {
 
 	// -- DeconvolveOps.RichardsonLucy
 
-	@OpMethod(op = net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class)
-	public Object richardsonLucy(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Deconvolve.RichardsonLucy.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyImg.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 		Img<O> richardsonLucy(final Img<I> in,
@@ -427,12 +422,6 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 //-- DeconvolveOps.RichardsonLucyTV
-
-	@OpMethod(op = net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class)
-	public Object richardsonLucyTV(final Object... args) {
-		return ops()
-			.run(net.imagej.ops.Ops.Deconvolve.RichardsonLucyTV.class, args);
-	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyTVImg.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -65,11 +65,6 @@ public class FilterNamespace extends AbstractNamespace {
 
 	// -- addNoise --
 
-	@OpMethod(op = net.imagej.ops.Ops.Filter.AddNoise.class)
-	public Object addNoise(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Filter.AddNoise.class, args);
-	}
-
 	@OpMethod(ops = { net.imagej.ops.filter.addNoise.AddNoiseRealType.class,
 		net.imagej.ops.filter.addNoise.AddNoiseRealTypeCFI.class })
 	public <I extends RealType<I>, O extends RealType<O>> O addNoise(final O out,
@@ -108,11 +103,6 @@ public class FilterNamespace extends AbstractNamespace {
 
 	// -- addPoissonNoise --
 
-	@OpMethod(op = net.imagej.ops.Ops.Filter.AddPoissonNoise.class)
-	public Object addPoissonNoise(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Filter.AddPoissonNoise.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.filter.addPoissonNoise.AddPoissonNoiseRealType.class)
 	public <I extends RealType<I>, O extends RealType<O>> O addPoissonNoise(final O out,
 		final I in)
@@ -136,12 +126,6 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	// -- convolve --
-
-	/** Executes the "convolve" operation on the given arguments. */
-	@OpMethod(op = Ops.Filter.Convolve.class)
-	public Object convolve(final Object... args) {
-		return ops().run(Ops.Filter.Convolve.NAME, args);
-	}
 
 	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveFFTImg.class,
@@ -387,12 +371,6 @@ public class FilterNamespace extends AbstractNamespace {
 	// -- correlate --
 
 	/** Executes the "correlate" operation on the given arguments. */
-	@OpMethod(op = Ops.Filter.Correlate.class)
-	public Object correlate(final Object... args) {
-		return ops().run(Ops.Filter.Correlate.NAME, args);
-	}
-
-	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.correlate.CorrelateFFTImg.class)
 	public
 		<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -626,12 +604,6 @@ public class FilterNamespace extends AbstractNamespace {
 	// -- fft --
 
 	/** Executes the "fft" operation on the given arguments. */
-	@OpMethod(op = Ops.Filter.FFT.class)
-	public Object fft(final Object... args) {
-		return ops().run(Ops.Filter.FFT.NAME, args);
-	}
-
-	/** Executes the "fft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fft.FFTImg.class)
 	public <T extends RealType<T>, I extends Img<T>> Img<ComplexFloatType> fft(
 		final I in)
@@ -739,12 +711,6 @@ public class FilterNamespace extends AbstractNamespace {
 	// -- fftSize --
 
 	/** Executes the "fftSize" operation on the given arguments. */
-	@OpMethod(op = Ops.Filter.FFTSize.class)
-	public Object fftSize(final Object... args) {
-		return ops().run(Ops.Filter.FFTSize.NAME, args);
-	}
-
-	/** Executes the "fftSize" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fftSize.ComputeFFTSize.class)
 	public List<long[]> fftSize(final long[] inputSize, final long[] paddedSize,
 		final long[] fftSize, final Boolean forward, final Boolean fast)
@@ -758,11 +724,6 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	// -- dog --
-
-	@OpMethod(op = Ops.Filter.DoG.class)
-	public Object dog(Object... args) {
-		return ops().run(Ops.Filter.DoG.class, args);
-	}
 
 	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoG.class)
 	public
@@ -909,12 +870,6 @@ public class FilterNamespace extends AbstractNamespace {
 	// -- gauss --
 
 	/** Executes the "gauss" operation on the given arguments. */
-	@OpMethod(op = Ops.Filter.Gauss.class)
-	public Object gauss(final Object... args) {
-		return ops().run(Ops.Filter.Gauss.NAME, args);
-	}
-
-	/** Executes the "gauss" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.gauss.DefaultGaussRAI.class)
 	public <T extends RealType<T>, V extends RealType<V>>
 		RandomAccessibleInterval<V> gauss(final RandomAccessibleInterval<V> out,
@@ -994,12 +949,6 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	// -- ifft --
-
-	/** Executes the "ifft" operation on the given arguments. */
-	@OpMethod(op = Ops.Filter.IFFT.class)
-	public Object ifft(final Object... args) {
-		return ops().run(Ops.Filter.IFFT.NAME, args);
-	}
 
 	/** Executes the "ifft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.ifft.IFFTImg.class)

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -634,7 +634,7 @@ public class FilterNamespace extends AbstractNamespace {
 	/** Executes the "fft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fft.FFTImg.class)
 	public <T extends RealType<T>, I extends Img<T>> Img<ComplexFloatType> fft(
-		final Img<I> in)
+		final I in)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexFloatType> result =
@@ -646,7 +646,7 @@ public class FilterNamespace extends AbstractNamespace {
 	/** Executes the "fft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fft.FFTImg.class)
 	public <T extends RealType<T>, I extends Img<T>> Img<ComplexFloatType> fft(
-		final Img<ComplexFloatType> out, final Img<I> in)
+		final Img<ComplexFloatType> out, final I in)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexFloatType> result =
@@ -658,7 +658,7 @@ public class FilterNamespace extends AbstractNamespace {
 	/** Executes the "fft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fft.FFTImg.class)
 	public <T extends RealType<T>, I extends Img<T>> Img<ComplexFloatType> fft(
-		final Img<ComplexFloatType> out, final Img<I> in, final long... borderSize)
+		final Img<ComplexFloatType> out, final I in, final long... borderSize)
 	{
 		@SuppressWarnings("unchecked")
 		final Img<ComplexFloatType> result =
@@ -670,7 +670,7 @@ public class FilterNamespace extends AbstractNamespace {
 	/** Executes the "fft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fft.FFTImg.class)
 	public <T extends RealType<T>, I extends Img<T>> Img<ComplexFloatType> fft(
-		final Img<ComplexFloatType> out, final Img<I> in, final long[] borderSize,
+		final Img<ComplexFloatType> out, final I in, final long[] borderSize,
 		final Boolean fast)
 	{
 		@SuppressWarnings("unchecked")
@@ -683,7 +683,7 @@ public class FilterNamespace extends AbstractNamespace {
 	/** Executes the "fft" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.fft.FFTImg.class)
 	public <T extends RealType<T>, I extends Img<T>> Img<ComplexFloatType> fft(
-		final Img<ComplexFloatType> out, final Img<I> in, final long[] borderSize,
+		final Img<ComplexFloatType> out, final I in, final long[] borderSize,
 		final Boolean fast,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> obf)
 	{

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -63,12 +63,6 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- ascii --
 
 	/** Executes the "ascii" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.ASCII.class)
-	public Object ascii(final Object... args) {
-		return ops().run(Ops.Image.ASCII.class, args);
-	}
-
-	/** Executes the "ascii" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.ascii.DefaultASCII.class)
 	public <T extends RealType<T>> String ascii(final IterableInterval<T> image) {
 		final String result = (String) ops().run(
@@ -111,12 +105,6 @@ public class ImageNamespace extends AbstractNamespace {
 	}
 
 	// -- crop --
-
-	/** Executes the "crop" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Crop.class)
-	public Object crop(final Object... args) {
-		return ops().run(Ops.Image.Crop.class, args);
-	}
 
 	/** Executes the "crop" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.crop.CropImgPlus.class)
@@ -190,12 +178,6 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- equation --
 
 	/** Executes the "equation" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Equation.class)
-	public Object equation(final Object... args) {
-		return ops().run(Ops.Image.Equation.class, args);
-	}
-
-	/** Executes the "equation" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.equation.DefaultEquation.class)
 	public <T extends RealType<T>> IterableInterval<T> equation(final String in) {
 		@SuppressWarnings("unchecked")
@@ -217,12 +199,6 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- fill --
 
 	/** Executes the "fill" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.Ops.Image.Fill.class)
-	public Object fill(final Object... args) {
-		return ops().run(Ops.Image.Fill.class, args);
-	}
-
-	/** Executes the "fill" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.fill.DefaultFill.class)
 	public <T extends Type<T>> Iterable<T> fill(final Iterable<T> out,
 		final T in)
@@ -234,12 +210,6 @@ public class ImageNamespace extends AbstractNamespace {
 	}
 
 	// -- histogram --
-
-	/** Executes the "histogram" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Histogram.class)
-	public Object histogram(final Object... args) {
-		return ops().run(Ops.Image.Histogram.class, args);
-	}
 
 	/** Executes the "histogram" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.histogram.HistogramCreate.class)
@@ -312,12 +282,6 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- invert --
 
 	/** Executes the "invert" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Invert.class)
-	public Object invert(final Object... args) {
-		return ops().run(Ops.Image.Invert.class, args);
-	}
-
-	/** Executes the "invert" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
 	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
 			final IterableInterval<O> out, final IterableInterval<I> in) {
@@ -329,12 +293,6 @@ public class ImageNamespace extends AbstractNamespace {
 	}
 
 	// -- normalize --
-
-	/** Executes the "normalize" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Normalize.class)
-	public Object normalize(final Object... args) {
-		return ops().run(Ops.Image.Normalize.class, args);
-	}
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
 	public
@@ -496,12 +454,6 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- project --
 
 	/** Executes the "project" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Project.class)
-	public Object project(final Object... args) {
-		return ops().run(Ops.Image.Project.class, args);
-	}
-
-	/** Executes the "project" operation on the given arguments. */
 	@OpMethod(ops = {
 			net.imagej.ops.image.project.DefaultProjectParallel.class,
 			net.imagej.ops.image.project.ProjectRAIToII.class })
@@ -515,12 +467,6 @@ public class ImageNamespace extends AbstractNamespace {
 	}
 
 	// -- scale --
-
-	/** Executes the "scale" operation on the given arguments. */
-	@OpMethod(op = Ops.Image.Scale.class)
-	public Object scale(final Object... args) {
-		return ops().run(Ops.Image.Scale.class, args);
-	}
 
 	/** Executes the "scale" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.scale.ScaleImg.class)

--- a/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
+++ b/src/main/java/net/imagej/ops/labeling/LabelingNamespace.java
@@ -51,11 +51,6 @@ import org.scijava.plugin.Plugin;
 @Plugin(type = Namespace.class)
 public class LabelingNamespace extends AbstractNamespace {
 
-	@OpMethod(op = net.imagej.ops.Ops.Labeling.CCA.class)
-	public Object cca(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Labeling.CCA.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.labeling.cca.DefaultCCA.class)
 	public <T extends IntegerType<T>, L, I extends IntegerType<I>>
 		ImgLabeling<L, I> cca(final ImgLabeling<L, I> out,

--- a/src/main/java/net/imagej/ops/math/MathNamespace.java
+++ b/src/main/java/net/imagej/ops/math/MathNamespace.java
@@ -105,11 +105,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Abs.class)
-	public Object abs(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Abs.class, args);
-	}
-
 	@OpMethod(ops = {
 		net.imagej.ops.math.ConstantToArrayImageP.MultiplyByte.class,
 		net.imagej.ops.math.ConstantToArrayImage.MultiplyByte.class,
@@ -293,11 +288,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Add.class)
-	public Object add(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Add.class, args);
-	}
-
 	@OpMethod(ops = { net.imagej.ops.math.ConstantToPlanarImage.AddByte.class,
 		net.imagej.ops.math.ConstantToPlanarImage.AddUnsignedByte.class })
 	public <B extends GenericByteType<B>> PlanarImg<B, ByteArray> add(
@@ -418,11 +408,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.And.class)
-	public Object and(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.And.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArccos.class)
 	public double arccos(final double a) {
 		final double result = (Double) ops().run(
@@ -440,11 +425,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccos.class)
-	public Object arccos(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccos.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arccosh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccosh(final O out,
 		final I in)
@@ -453,11 +433,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccosh.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccosh.class)
-	public Object arccosh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccosh.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arccot.class)
@@ -470,11 +445,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccot.class)
-	public Object arccot(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccot.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arccoth.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccoth(final O out,
 		final I in)
@@ -483,11 +453,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccoth.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccoth.class)
-	public Object arccoth(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccoth.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arccsc.class)
@@ -500,11 +465,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccsc.class)
-	public Object arccsc(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccsc.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arccsch.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arccsch(final O out,
 		final I in)
@@ -513,11 +473,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arccsch.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arccsch.class)
-	public Object arccsch(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arccsch.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arcsec.class)
@@ -530,11 +485,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsec.class)
-	public Object arcsec(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsec.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arcsech.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arcsech(final O out,
 		final I in)
@@ -543,11 +493,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arcsech.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsech.class)
-	public Object arcsech(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsech.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArcsin.class)
@@ -567,11 +512,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsin.class)
-	public Object arcsin(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsin.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arcsinh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arcsinh(final O out,
 		final I in)
@@ -580,11 +520,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Arcsinh.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arcsinh.class)
-	public Object arcsinh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arcsinh.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleArctan.class)
@@ -604,11 +539,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arctan.class)
-	public Object arctan(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arctan.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Arctanh.class)
 	public <I extends RealType<I>, O extends RealType<O>> O arctanh(final O out,
 		final I in)
@@ -619,22 +549,12 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Arctanh.class)
-	public Object arctanh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Arctanh.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.NullaryNumericTypeMath.Assign.class)
 	public <T extends Type<T>> T assign(final T out, final T constant) {
 		@SuppressWarnings("unchecked")
 		final T result = (T) ops().run(
 			net.imagej.ops.math.NullaryNumericTypeMath.Assign.class, out, constant);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Assign.class)
-	public Object assign(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Assign.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCeil.class)
@@ -653,11 +573,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Ceil.class)
-	public Object ceil(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Ceil.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerComplement.class)
 	public int complement(final int a) {
 		final int result = (Integer) ops().run(
@@ -670,11 +585,6 @@ public class MathNamespace extends AbstractNamespace {
 		final long result = (Long) ops().run(
 			net.imagej.ops.math.PrimitiveMath.LongComplement.class, a);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Complement.class)
-	public Object complement(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Complement.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCos.class)
@@ -693,11 +603,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Cos.class)
-	public Object cos(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Cos.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCosh.class)
 	public double cosh(final double a) {
 		final double result = (Double) ops().run(
@@ -714,11 +619,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Cosh.class)
-	public Object cosh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Cosh.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Cot.class)
 	public <I extends RealType<I>, O extends RealType<O>> O cot(final O out,
 		final I in)
@@ -726,11 +626,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Cot.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Cot.class)
-	public Object cot(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Cot.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Coth.class)
@@ -742,11 +637,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Coth.class)
-	public Object coth(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Coth.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Csc.class)
 	public <I extends RealType<I>, O extends RealType<O>> O csc(final O out,
 		final I in)
@@ -756,11 +646,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Csc.class)
-	public Object csc(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Csc.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Csch.class)
 	public <I extends RealType<I>, O extends RealType<O>> O csch(final O out,
 		final I in)
@@ -768,11 +653,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Csch.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Csch.class)
-	public Object csch(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Csch.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleCubeRoot.class)
@@ -790,11 +670,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.CubeRoot.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.CubeRoot.class)
-	public Object cubeRoot(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.CubeRoot.class, args);
 	}
 
 	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.DivideByte.class,
@@ -976,11 +851,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Divide.class)
-	public Object divide(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Divide.class, args);
-	}
-
 	@OpMethod(ops = { net.imagej.ops.math.ConstantToPlanarImage.DivideByte.class,
 		net.imagej.ops.math.ConstantToPlanarImage.DivideUnsignedByte.class })
 	public <B extends GenericByteType<B>> PlanarImg<B, ByteArray> divide(
@@ -1092,11 +962,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Exp.class)
-	public Object exp(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Exp.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.ExpMinusOne.class)
 	public <I extends RealType<I>, O extends RealType<O>> O expMinusOne(
 		final O out, final I in)
@@ -1105,11 +970,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.ExpMinusOne.class,
 			out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.ExpMinusOne.class)
-	public Object expMinusOne(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.ExpMinusOne.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleFloor.class)
@@ -1129,11 +989,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Floor.class)
-	public Object floor(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Floor.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.GammaConstant.class)
 	public <I extends RealType<I>, O extends RealType<O>> O gamma(final O out,
 		final I in, final double constant)
@@ -1144,11 +999,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Gamma.class)
-	public Object gamma(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Gamma.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Invert.class)
 	public <I extends RealType<I>, O extends RealType<O>> O invert(final O out,
 		final I in, final double specifiedMin, final double specifiedMax)
@@ -1157,11 +1007,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Invert.class, out,
 			in, specifiedMin, specifiedMax);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Invert.class)
-	public Object invert(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Invert.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerLeftShift.class)
@@ -1178,11 +1023,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.LeftShift.class)
-	public Object leftShift(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.LeftShift.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLog.class)
 	public double log(final double a) {
 		final double result = (Double) ops().run(
@@ -1197,11 +1037,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Log.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Log.class)
-	public Object log(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Log.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLog10.class)
@@ -1221,11 +1056,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Log10.class)
-	public Object log10(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Log10.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Log2.class)
 	public <I extends RealType<I>, O extends RealType<O>> O log2(final O out,
 		final I in)
@@ -1233,11 +1063,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Log2.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Log2.class)
-	public Object log2(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Log2.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleLogOnePlusX.class)
@@ -1255,11 +1080,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.LogOnePlusX.class,
 			out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.LogOnePlusX.class)
-	public Object logOnePlusX(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.LogOnePlusX.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMax.class)
@@ -1300,11 +1120,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Max.class)
-	public Object max(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Max.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleMin.class)
 	public double min(final double a, final double b) {
 		final double result = (Double) ops().run(
@@ -1341,11 +1156,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Min.class, out, in,
 			constant);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Min.class)
-	public Object min(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Min.class, args);
 	}
 
 	@OpMethod(ops = { net.imagej.ops.math.ConstantToArrayImageP.AddByte.class,
@@ -1526,11 +1336,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Multiply.class)
-	public Object multiply(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Multiply.class, args);
-	}
-
 	@OpMethod(ops = {
 		net.imagej.ops.math.ConstantToPlanarImage.MultiplyByte.class,
 		net.imagej.ops.math.ConstantToPlanarImage.MultiplyUnsignedByte.class })
@@ -1640,11 +1445,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.NearestInt.class)
-	public Object nearestInt(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.NearestInt.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleNegate.class)
 	public double negate(final double a) {
 		final double result = (Double) ops().run(
@@ -1683,11 +1483,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Negate.class)
-	public Object negate(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Negate.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerOr.class)
 	public int or(final int a, final int b) {
 		final int result = (Integer) ops().run(
@@ -1713,11 +1508,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Or.class)
-	public Object or(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Or.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoublePower.class)
 	public double power(final double a, final double b) {
 		final double result = (Double) ops().run(
@@ -1735,11 +1525,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Power.class)
-	public Object power(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Power.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.RandomGaussian.class)
 	public <I extends RealType<I>, O extends RealType<O>> O randomGaussian(
 		final O out, final I in)
@@ -1760,11 +1545,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.RandomGaussian.class)
-	public Object randomGaussian(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.RandomGaussian.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.RandomUniform.class)
 	public <I extends RealType<I>, O extends RealType<O>> O randomUniform(
 		final O out, final I in)
@@ -1783,11 +1563,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.RandomUniform.class,
 			out, in, seed);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.RandomUniform.class)
-	public Object randomUniform(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.RandomUniform.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Reciprocal.class)
@@ -1798,11 +1573,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Reciprocal.class,
 			out, in, dbzVal);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Reciprocal.class)
-	public Object reciprocal(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Reciprocal.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleRemainder.class)
@@ -1833,11 +1603,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Remainder.class)
-	public Object remainder(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Remainder.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerRightShift.class)
 	public int rightShift(final int a, final int b) {
 		final int result = (Integer) ops().run(
@@ -1850,11 +1615,6 @@ public class MathNamespace extends AbstractNamespace {
 		final long result = (Long) ops().run(
 			net.imagej.ops.math.PrimitiveMath.LongRightShift.class, a, b);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.RightShift.class)
-	public Object rightShift(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.RightShift.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleRound.class)
@@ -1881,11 +1641,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Round.class)
-	public Object round(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Round.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Sec.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sec(final O out,
 		final I in)
@@ -1895,11 +1650,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sec.class)
-	public Object sec(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sec.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Sech.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sech(final O out,
 		final I in)
@@ -1907,11 +1657,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sech.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sech.class)
-	public Object sech(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sech.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSignum.class)
@@ -1938,11 +1683,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Signum.class)
-	public Object signum(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Signum.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSin.class)
 	public double sin(final double a) {
 		final double result = (Double) ops().run(
@@ -1959,11 +1699,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sin.class)
-	public Object sin(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sin.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Sinc.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sinc(final O out,
 		final I in)
@@ -1971,11 +1706,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sinc.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sinc.class)
-	public Object sinc(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sinc.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.SincPi.class)
@@ -1986,11 +1716,6 @@ public class MathNamespace extends AbstractNamespace {
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.SincPi.class, out,
 			in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.SincPi.class)
-	public Object sincPi(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.SincPi.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSinh.class)
@@ -2009,11 +1734,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sinh.class)
-	public Object sinh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sinh.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Sqr.class)
 	public <I extends RealType<I>, O extends RealType<O>> O sqr(final O out,
 		final I in)
@@ -2021,11 +1741,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Sqr.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sqr.class)
-	public Object sqr(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sqr.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleSqrt.class)
@@ -2044,11 +1759,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Sqrt.class)
-	public Object sqrt(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Sqrt.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Step.class)
 	public <I extends RealType<I>, O extends RealType<O>> O step(final O out,
 		final I in)
@@ -2056,11 +1766,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Step.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Step.class)
-	public Object step(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Step.class, args);
 	}
 
 	@OpMethod(ops = {
@@ -2246,11 +1951,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Subtract.class)
-	public Object subtract(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Subtract.class, args);
-	}
-
 	@OpMethod(ops = {
 		net.imagej.ops.math.ConstantToPlanarImage.SubtractByte.class,
 		net.imagej.ops.math.ConstantToPlanarImage.SubtractUnsignedByte.class })
@@ -2366,11 +2066,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Tan.class)
-	public Object tan(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Tan.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.DoubleTanh.class)
 	public double tanh(final double a) {
 		final double result = (Double) ops().run(net.imagej.ops.Ops.Math.Tanh.class,
@@ -2387,11 +2082,6 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Tanh.class)
-	public Object tanh(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Tanh.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.UnaryRealTypeMath.Ulp.class)
 	public <I extends RealType<I>, O extends RealType<O>> O ulp(final O out,
 		final I in)
@@ -2399,11 +2089,6 @@ public class MathNamespace extends AbstractNamespace {
 		@SuppressWarnings("unchecked")
 		final O result = (O) ops().run(net.imagej.ops.Ops.Math.Ulp.class, out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Ulp.class)
-	public Object ulp(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Ulp.class, args);
 	}
 
 	@OpMethod(
@@ -2419,11 +2104,6 @@ public class MathNamespace extends AbstractNamespace {
 		final long result = (Long) ops().run(
 			net.imagej.ops.math.PrimitiveMath.LongUnsignedRightShift.class, a, b);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.UnsignedRightShift.class)
-	public Object unsignedRightShift(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.UnsignedRightShift.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.math.PrimitiveMath.IntegerXor.class)
@@ -2451,21 +2131,11 @@ public class MathNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Math.Xor.class)
-	public Object xor(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Xor.class, args);
-	}
-
 	@OpMethod(op = net.imagej.ops.math.NullaryNumericTypeMath.Zero.class)
 	public <T extends NumericType<T>> T zero(final T out) {
 		@SuppressWarnings("unchecked")
 		final T result = (T) ops().run(net.imagej.ops.Ops.Math.Zero.class, out);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Math.Zero.class)
-	public Object zero(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Math.Zero.class, args);
 	}
 
 	// -- Named methods --

--- a/src/main/java/net/imagej/ops/thread/ThreadNamespace.java
+++ b/src/main/java/net/imagej/ops/thread/ThreadNamespace.java
@@ -48,12 +48,6 @@ public class ThreadNamespace extends AbstractNamespace {
 	// -- Thread namespace ops --
 
 	/** Executes the "chunker" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.Ops.Thread.Chunker.class)
-	public Object chunker(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Thread.Chunker.class, args);
-	}
-
-	/** Executes the "chunker" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.thread.chunker.DefaultChunker.class,
 		net.imagej.ops.thread.chunker.ChunkerInterleaved.class })
 	public void chunker(final Chunk chunkable, final long numberOfElements) {

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -36,7 +36,6 @@ import java.util.List;
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
-import net.imagej.ops.Ops;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
@@ -58,11 +57,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 	// -- Threshold namespace ops --
 
 	// -- apply --
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Apply.class)
-	public Object apply(final Object... args) {
-		return ops().run(Ops.Threshold.Apply.NAME, args);
-	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.apply.ApplyConstantThreshold.class)
@@ -129,11 +123,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	// -- huang --
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Huang.class)
-	public Object huang(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Huang.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.huang.ComputeHuangThreshold.class)
 	public <T extends RealType<T>> T huang(final Histogram1d<T> in) {
@@ -178,11 +167,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.Huang.class, out,
 				in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.IJ1.class)
-	public Object ij1(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.IJ1.class, args);
 	}
 
 	@OpMethod(
@@ -230,11 +214,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.IJ1.class,
 				out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Intermodes.class)
-	public Object intermodes(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Intermodes.class, args);
 	}
 
 	@OpMethod(
@@ -291,11 +270,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.IsoData.class)
-	public Object isoData(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.IsoData.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.IsoData.class)
 	public <T extends RealType<T>> IterableInterval<BitType> isoData(final IterableInterval<T> in) {
@@ -343,11 +317,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.IsoData.class,
 				out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Li.class)
-	public Object li(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Li.class, args);
 	}
 
 	@OpMethod(op = net.imagej.ops.threshold.ApplyThresholdMethod.Li.class)
@@ -682,11 +651,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.LocalSauvolaThreshold.class, out, in, shape);
 		return result;
 	}
-	
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxEntropy.class)
-	public Object maxEntropy(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.MaxEntropy.class, args);
-	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.MaxEntropy.class)
@@ -738,11 +702,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 					net.imagej.ops.Ops.Threshold.MaxEntropy.class,
 					out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.MaxLikelihood.class)
-	public Object maxLikelihood(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.MaxLikelihood.class, args);
 	}
 
 	@OpMethod(
@@ -802,11 +761,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Mean.class)
-	public Object mean(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Mean.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.Mean.class)
 	public <T extends RealType<T>> IterableInterval<BitType> mean(final IterableInterval<T> in) {
@@ -849,11 +803,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.Mean.class,
 				out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.MinError.class)
-	public Object minError(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.MinError.class, args);
 	}
 
 	@OpMethod(
@@ -906,11 +855,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Minimum.class)
-	public Object minimum(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Minimum.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.Minimum.class)
 	public <T extends RealType<T>> IterableInterval<BitType> minimum(final IterableInterval<T> in) {
@@ -958,11 +902,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.Minimum.class,
 				out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Moments.class)
-	public Object moments(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Moments.class, args);
 	}
 
 	@OpMethod(
@@ -1014,11 +953,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Otsu.class)
-	public Object otsu(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Otsu.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.otsu.ComputeOtsuThreshold.class)
 	public <T extends RealType<T>> T otsu(final Histogram1d<T> in) {
@@ -1061,11 +995,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.Otsu.class, out,
 				in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Percentile.class)
-	public Object percentile(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Percentile.class, args);
 	}
 
 	@OpMethod(
@@ -1118,11 +1047,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 					net.imagej.ops.Ops.Threshold.Percentile.class,
 					out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.RenyiEntropy.class)
-	public Object renyiEntropy(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.RenyiEntropy.class, args);
 	}
 
 	@OpMethod(
@@ -1182,11 +1106,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Shanbhag.class)
-	public Object shanbhag(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Shanbhag.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.Shanbhag.class)
 	public <T extends RealType<T>> IterableInterval<BitType> shanbhag(final IterableInterval<T> in) {
@@ -1235,11 +1154,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Triangle.class)
-	public Object triangle(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Triangle.class, args);
-	}
-
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.Triangle.class)
 	public <T extends RealType<T>> IterableInterval<BitType> triangle(final IterableInterval<T> in) {
@@ -1286,11 +1200,6 @@ public class ThresholdNamespace extends AbstractNamespace {
 				net.imagej.ops.Ops.Threshold.Triangle.class,
 				out, in);
 		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.Ops.Threshold.Yen.class)
-	public Object yen(final Object... args) {
-		return ops().run(net.imagej.ops.Ops.Threshold.Yen.class, args);
 	}
 
 	@OpMethod(

--- a/src/test/java/net/imagej/ops/AbstractNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/AbstractNamespaceTest.java
@@ -32,7 +32,6 @@ package net.imagej.ops;
 
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -185,12 +184,7 @@ public abstract class AbstractNamespaceTest extends AbstractOpTest {
 			if (!checkVarArgs(method)) success = false;
 
 			for (final Class<? extends Op> opType : opTypes(method)) {
-				if (opType.isInterface()) {
-					if (!checkOpIface(method, qName, opType)) success = false;
-				}
-				else {
-					if (!checkOpImpl(method, qName, opType, coverSet)) success = false;
-				}
+				if (!checkOpImpl(method, qName, opType, coverSet)) success = false;
 			}
 		}
 
@@ -254,48 +248,6 @@ public abstract class AbstractNamespaceTest extends AbstractOpTest {
 			}
 		}
 		return opSet;
-	}
-
-	/**
-	 * Checks whether the given op interface matches the specified method,
-	 * particularly with respect to the interface's {@code NAME} constant.
-	 * @param method The method to which the {@link Op} should be compared.
-	 * @param qName The fully qualified (with namespace) name of the op.
-	 * @param opType The {@link Op} to which the method should be compared.
-	 * @return true iff the method and {@link Op} match up.
-	 */
-	private boolean checkOpIface(final Method method, final String qName,
-		final Class<? extends Op> opType)
-	{
-		try {
-			final Field nameField = opType.getField("NAME");
-			if (nameField.getType() != String.class) {
-				error("Non-String NAME field", opType, method);
-				return false;
-			}
-			final String nameFieldValue = (String) nameField.get(null);
-			if (!qName.equals(nameFieldValue)) {
-				error("NAME field mismatch", opType, method);
-				return false;
-			}
-		}
-		catch (final NoSuchFieldException exc) {
-			error("No NAME field", opType, method);
-			return false;
-		}
-		catch (final IllegalAccessException exc) {
-			error("Inaccessible NAME field", opType, method);
-			return false;
-		}
-
-		final Object[] argTypes = method.getParameterTypes();
-		// verify that the method argument is "Object..." as expected
-		if (argTypes.length != 1 || argTypes[0] != Object[].class) {
-			error("Expected single Object... argument", opType, method);
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/src/test/java/net/imagej/ops/convert/ConvertMapTest.java
+++ b/src/test/java/net/imagej/ops/convert/ConvertMapTest.java
@@ -34,13 +34,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Ops;
 import net.imagej.ops.convert.ConvertTypes.ComplexToFloat32;
 import net.imagej.ops.convert.ConvertTypes.ComplexToUint8;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
@@ -58,7 +58,7 @@ public class ConvertMapTest extends AbstractOpTest {
 	private final static long[] dims = { 3, 3 };
 
 	@Test
-	public <C extends ComplexType<C>> void testLossless() {
+	public void testLossless() {
 
 		final byte[] inArray = { 12, 122, 9, -6, 56, 34, 108, 1, 73 };
 		final Img<UnsignedByteType> in = generateUnsignedByteImg(inArray);
@@ -76,7 +76,7 @@ public class ConvertMapTest extends AbstractOpTest {
 				outC1.next().getRealDouble(), 0d);
 		}
 
-		ops.map(out, in, new ComplexToFloat32<C>());
+		ops.run(Ops.Map.class, out, in, new ComplexToFloat32<UnsignedByteType>());
 
 		final Cursor<UnsignedByteType> inC2 = in.cursor();
 		final Cursor<FloatType> outC2 = out.cursor();
@@ -87,7 +87,7 @@ public class ConvertMapTest extends AbstractOpTest {
 	}
 
 	@Test
-	public <C extends ComplexType<C>> void testLossy() {
+	public void testLossy() {
 
 		final float[] inArray =
 			{ 12.7f, -13089.3208f, 78.023f, 0.04f, 12.01f, -1208.90f, 109432.109f,
@@ -97,7 +97,7 @@ public class ConvertMapTest extends AbstractOpTest {
 		final byte[] outArray = { 4, 123, 18, 64, 90, 120, 12, 17, 73 };
 		final Img<UnsignedByteType> out = generateUnsignedByteImg(outArray);
 
-		ops.map(out, in, new ComplexToUint8<C>());
+		ops.run(Ops.Map.class, out, in, new ComplexToUint8<FloatType>());
 
 		final Cursor<FloatType> inC = in.cursor();
 		final Cursor<UnsignedByteType> outC = out.cursor();

--- a/src/test/java/net/imagej/ops/copy/CopyImgLabelingTest.java
+++ b/src/test/java/net/imagej/ops/copy/CopyImgLabelingTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling;
 import net.imglib2.Cursor;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.roi.labeling.LabelingType;
@@ -53,8 +54,8 @@ public class CopyImgLabelingTest extends AbstractOpTest {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void createData() {
-		input = (ImgLabeling<String, IntType>) ops.create().imgLabeling(
-				new long[] { 10, 10 }, new IntType());
+		input = (ImgLabeling<String, IntType>) ops.run(
+			DefaultCreateImgLabeling.class, new long[] { 10, 10 }, new IntType());
 
 		final Cursor<LabelingType<String>> inc = input.cursor();
 

--- a/src/test/java/net/imagej/ops/copy/CopyLabelingMappingTest.java
+++ b/src/test/java/net/imagej/ops/copy/CopyLabelingMappingTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Iterator;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling;
 import net.imglib2.Cursor;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.roi.labeling.LabelingMapping;
@@ -55,8 +56,10 @@ public class CopyLabelingMappingTest extends AbstractOpTest {
 
 	@Before
 	public void createData() {
-		ImgLabeling<String, IntType> imgL = (ImgLabeling<String, IntType>) ops
-				.create().imgLabeling(new long[] { 10, 10 }, new IntType());
+		@SuppressWarnings("unchecked")
+		final ImgLabeling<String, IntType> imgL = (ImgLabeling<String, IntType>) ops
+			.run(DefaultCreateImgLabeling.class, new long[] { 10, 10 },
+				new IntType());
 
 		final Cursor<LabelingType<String>> inc = imgL.cursor();
 

--- a/src/test/java/net/imagej/ops/create/CreateLabelingTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateLabelingTest.java
@@ -36,6 +36,9 @@ import static org.junit.Assert.assertEquals;
 import java.util.Random;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.imgLabeling.DefaultCreateImgLabeling;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.img.cell.CellImgFactory;
@@ -73,8 +76,8 @@ public class CreateLabelingTest extends AbstractOpTest {
 
 			// create imglabeling
 			@SuppressWarnings("unchecked")
-			final ImgLabeling<String, ?> img =
-				(ImgLabeling<String, ?>) ops.create().imgLabeling(dim);
+			final ImgLabeling<String, ?> img = (ImgLabeling<String, ?>) ops.run(
+				DefaultCreateImgLabeling.class, dim);
 
 			assertArrayEquals("Labeling Dimensions:", dim, Intervals
 				.dimensionsAsLongArray(img));
@@ -85,17 +88,17 @@ public class CreateLabelingTest extends AbstractOpTest {
 	@Test
 	public void testImageFactory() {
 
-		final long[] dim = new long[] { 10, 10, 10 };
+		final Dimensions dim = new FinalDimensions( 10, 10, 10 );
 
 		assertEquals("Labeling Factory: ", ArrayImgFactory.class,
-			((Img<?>) ((ImgLabeling<String, ?>) ops.create().imgLabeling(dim,
-				null, new ArrayImgFactory<IntType>())).getIndexImg()).factory()
-				.getClass());
+			((Img<?>) ((ImgLabeling<String, ?>) ops.run(
+				DefaultCreateImgLabeling.class, dim, null,
+				new ArrayImgFactory<IntType>())).getIndexImg()).factory().getClass());
 
 		assertEquals("Labeling Factory: ", CellImgFactory.class,
-			((Img<?>) ((ImgLabeling<String, ?>) ops.create().imgLabeling(dim,
-				null, new CellImgFactory<IntType>())).getIndexImg()).factory()
-				.getClass());
+			((Img<?>) ((ImgLabeling<String, ?>) ops.run(
+				DefaultCreateImgLabeling.class, dim, null,
+				new CellImgFactory<IntType>())).getIndexImg()).factory().getClass());
 
 	}
 
@@ -118,9 +121,8 @@ public class CreateLabelingTest extends AbstractOpTest {
 	@SuppressWarnings("unchecked")
 	private <I> ImgLabeling<I, ?> createLabelingWithType(final I type) {
 
-		final ImgLabeling<I, ?> imgLabeling =
-			((ImgLabeling<I, ?>) ops.create().imgLabeling(new long[] { 10,
-				10, 10 }));
+		final ImgLabeling<I, ?> imgLabeling = ((ImgLabeling<I, ?>) ops.run(
+			DefaultCreateImgLabeling.class, new long[] { 10, 10, 10 }));
 		imgLabeling.cursor().next().add(type);
 		return imgLabeling;
 	}

--- a/src/test/java/net/imagej/ops/filter/FFTTest.java
+++ b/src/test/java/net/imagej/ops/filter/FFTTest.java
@@ -73,9 +73,7 @@ public class FFTTest extends AbstractOpTest {
 			final Img<FloatType> inverse = generateFloatArrayTestImg(false,
 				dimensions);
 
-			@SuppressWarnings("unchecked")
-			final Img<ComplexFloatType> out = (Img<ComplexFloatType>) ops.filter()
-				.fft(in);
+			final Img<ComplexFloatType> out = ops.filter().fft(in);
 			ops.filter().ifft(inverse, out);
 
 			assertImagesEqual(in, inverse, .00005f);
@@ -118,22 +116,18 @@ public class FFTTest extends AbstractOpTest {
 			// call FFT passing false for "fast" (in order to pass the optional
 			// parameter we have to pass null for the
 			// output parameter).
-			@SuppressWarnings("unchecked")
-			final Img<ComplexFloatType> fft1 = (Img<ComplexFloatType>) ops.filter()
-				.fft(null, inOriginal, null, false);
+			final Img<ComplexFloatType> fft1 = ops.filter().fft(null, inOriginal,
+				null, false);
 
 			// call FFT passing true for "fast" (in order to pass the optional
 			// parameter we have to pass null for the
 			// output parameter). The FFT op will pad the input to the fast
 			// size.
-			@SuppressWarnings("unchecked")
-			final Img<ComplexFloatType> fft2 = (Img<ComplexFloatType>) ops.filter()
-				.fft(null, inOriginal, null, true);
+			final Img<ComplexFloatType> fft2 = ops.filter().fft(null, inOriginal,
+				null, true);
 
 			// call fft using the img that was created with the fast size
-			@SuppressWarnings("unchecked")
-			final Img<ComplexFloatType> fft3 = (Img<ComplexFloatType>) ops.filter()
-				.fft(inFast);
+			final Img<ComplexFloatType> fft3 = ops.filter().fft(inFast);
 
 			// create an image to be used for the inverse, using the original
 			// size

--- a/src/test/java/net/imagej/ops/filter/convolve/ConvolveTest.java
+++ b/src/test/java/net/imagej/ops/filter/convolve/ConvolveTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertSame;
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.create.kernelGauss.CreateKernelGauss;
 import net.imagej.ops.filter.CreateFFTFilterMemory;
 import net.imglib2.Point;
 import net.imglib2.RandomAccess;
@@ -213,7 +214,7 @@ public class ConvolveTest extends AbstractOpTest {
 		}
 		
 		// create psf using the gaussian kernel op (alternatively PSF could be an input to the script)
-		Img<DoubleType> psf=(Img<DoubleType>)ops.create().kernelGauss(new long[]{5, 5, 5});
+		Img<DoubleType> psf=(Img<DoubleType>)ops.run(CreateKernelGauss.class, new long[]{5, 5, 5});
 
 		// convolve psf with phantom
 		Img<DoubleType> convolved=ops.filter().convolve(phantom, psf);

--- a/src/test/java/net/imagej/ops/image/project/ProjectTest.java
+++ b/src/test/java/net/imagej/ops/image/project/ProjectTest.java
@@ -33,11 +33,11 @@ package net.imagej.ops.image.project;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
-import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
-import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.Before;
@@ -50,7 +50,7 @@ public class ProjectTest extends AbstractOpTest {
 	private Img<UnsignedByteType> in;
 	private Img<UnsignedByteType> out1;
 	private Img<UnsignedByteType> out2;
-	private Op op;
+	private UnaryComputerOp<Iterable<UnsignedByteType>, UnsignedByteType> op;
 
 	@Before
 	public void initImg() {
@@ -71,7 +71,8 @@ public class ProjectTest extends AbstractOpTest {
 		out1 = generateUnsignedByteArrayTestImg(false, 10, 10);
 		out2 = generateUnsignedByteArrayTestImg(false, 10, 10);
 
-		op = ops.op(Ops.Stats.Sum.class, RealType.class, out1);
+		op = Computers.unary(ops, Ops.Stats.Sum.class, UnsignedByteType.class,
+			out1);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/join/JoinTest.java
+++ b/src/test/java/net/imagej/ops/join/JoinTest.java
@@ -41,8 +41,11 @@ import net.imagej.ops.bufferfactories.ImgImgSameTypeFactory;
 import net.imagej.ops.map.MapOp;
 import net.imagej.ops.special.UnaryOutputFactory;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.inplace.AbstractUnaryInplaceOp;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -54,17 +57,17 @@ public class JoinTest extends AbstractOpTest {
 
 	private Img<ByteType> in;
 	private Img<ByteType> out;
-	private Op inplaceOp;
-	private Op computerOp;
+	private UnaryInplaceOp<? super Img<ByteType>, Img<ByteType>> inplaceOp;
+	private UnaryComputerOp<Img<ByteType>, Img<ByteType>> computerOp;
 
 	@Before
 	public void init() {
 		final long[] dims = new long[] { 10, 10 };
 		in = generateByteArrayTestImg(false, dims);
 		out = generateByteArrayTestImg(false, dims);
-		inplaceOp = ops.op(MapOp.class, Img.class, new AddOneInplace());
-		computerOp =
-			ops.op(MapOp.class, Img.class, Img.class, new AddOneComputer());
+		inplaceOp = Inplaces.unary(ops, MapOp.class, out, new AddOneInplace());
+		computerOp = Computers.unary(ops, MapOp.class, out, in,
+			new AddOneComputer());
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/loop/LoopTest.java
+++ b/src/test/java/net/imagej/ops/loop/LoopTest.java
@@ -31,11 +31,14 @@
 package net.imagej.ops.loop;
 
 import net.imagej.ops.AbstractOpTest;
-import net.imagej.ops.Op;
 import net.imagej.ops.bufferfactories.ImgImgSameTypeFactory;
 import net.imagej.ops.map.MapOp;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.inplace.AbstractUnaryInplaceOp;
+import net.imagej.ops.special.inplace.Inplaces;
+import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -54,8 +57,8 @@ public class LoopTest extends AbstractOpTest {
 	private Img<ByteType> out;
 
 	private int numIterations;
-	private Op functionalOp;
-	private Op inplaceOp;
+	private UnaryComputerOp<Img<ByteType>, Img<ByteType>> computerOp;
+	private UnaryInplaceOp<? super Img<ByteType>, Img<ByteType>> inplaceOp;
 
 	@Before
 	public void init() {
@@ -63,8 +66,8 @@ public class LoopTest extends AbstractOpTest {
 		in = generateByteArrayTestImg(false, dims);
 		out = generateByteArrayTestImg(false, dims);
 		numIterations = 10;
-		functionalOp = ops.op(MapOp.class, out, in, new AddOneFunctional());
-		inplaceOp = ops.op(MapOp.class, in, new AddOneInplace());
+		computerOp = Computers.unary(ops, MapOp.class, out, in, new AddOneFunctional());
+		inplaceOp = Inplaces.unary(ops, MapOp.class, in, new AddOneInplace());
 	}
 
 	@Test
@@ -81,7 +84,7 @@ public class LoopTest extends AbstractOpTest {
 
 	@Test
 	public void testFunctionalEven() {
-		ops.loop(out, in, functionalOp, new ImgImgSameTypeFactory<ByteType>(), numIterations);
+		ops.loop(out, in, computerOp, new ImgImgSameTypeFactory<ByteType>(), numIterations);
 
 		// test
 		final Cursor<ByteType> c = out.cursor();
@@ -93,7 +96,7 @@ public class LoopTest extends AbstractOpTest {
 
 	@Test
 	public void testFunctionalOdd() {
-		ops.loop(out, in, functionalOp, new ImgImgSameTypeFactory<ByteType>(),
+		ops.loop(out, in, computerOp, new ImgImgSameTypeFactory<ByteType>(),
 			numIterations - 1);
 
 		// test

--- a/src/test/java/net/imagej/ops/slice/SliceTest.java
+++ b/src/test/java/net/imagej/ops/slice/SliceTest.java
@@ -88,7 +88,7 @@ public class SliceTest extends AbstractOpTest {
 		// selected interval XY
 		final int[] xyAxis = new int[] { 0, 1 };
 
-		ops.slice(out, in, new DummyOp(), xyAxis);
+		ops.run(SliceRAI2RAI.class, out, in, new DummyOp(), xyAxis);
 
 		for (final Cursor<ByteType> cur = out.cursor(); cur.hasNext();) {
 			cur.fwd();
@@ -122,7 +122,7 @@ public class SliceTest extends AbstractOpTest {
 		// selected interval XYZ
 		final int[] xyAxis = new int[] { 0, 1, 2 };
 
-		ops.slice(outSequence, inSequence, new DummyOp(), xyAxis);
+		ops.run(SliceRAI2RAI.class, outSequence, inSequence, new DummyOp(), xyAxis);
 
 		for (final Cursor<ByteType> cur = outSequence.cursor(); cur.hasNext();) {
 			cur.fwd();


### PR DESCRIPTION
varargs OpMethods (with single parameter `Object... args`) in all namespaces are removed, so that we only have type-safe signatures. See #296 