### PR TITLE
Explicit match in test

### DIFF
--- a/src/main/java/net/imagej/ops/convert/ConvertNamespace.java
+++ b/src/main/java/net/imagej/ops/convert/ConvertNamespace.java
@@ -159,6 +159,19 @@ public class ConvertNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToBit.class)
+	public <T extends IntegerType<T>> BitType bit(final T in) {
+		final BitType result = (BitType) ops().run(Ops.Convert.Uint2.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.convert.ConvertTypes.IntegerToBit.class)
+	public <T extends IntegerType<T>> BitType bit(final BitType out, final T in) {
+		final BitType result = (BitType) ops().run(Ops.Convert.Uint2.class, out,
+			in);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.convert.ConvertImages.Uint2.class)
 	public <C extends ComplexType<C>> Img<Unsigned2BitType> uint2(
 		final IterableInterval<C> in)

--- a/src/main/java/net/imagej/ops/convert/ConvertTypes.java
+++ b/src/main/java/net/imagej/ops/convert/ConvertTypes.java
@@ -87,6 +87,24 @@ public final class ConvertTypes {
 
 	}
 
+	@Plugin(type = Ops.Convert.Bit.class, name = Ops.Convert.Bit.NAME,
+		priority = Priority.HIGH_PRIORITY)
+	public static class IntegerToBit<T extends IntegerType<T>> extends
+		AbstractUnaryHybridCF<T, BitType> implements Convert.Bit
+	{
+
+		@Override
+		public BitType createOutput(final T input) {
+			return new BitType();
+		}
+
+		@Override
+		public void compute1(final T input, final BitType output) {
+			output.set(input.getIntegerLong() != 0);
+		}
+
+	}
+
 	@Plugin(type = Ops.Convert.Uint2.class, name = Ops.Convert.Uint2.NAME)
 	public static class ComplexToUint2<C extends ComplexType<C>> extends
 		AbstractUnaryHybridCF<C, Unsigned2BitType> implements Convert.Uint2

--- a/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTImg.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTImg.java
@@ -30,7 +30,6 @@
 
 package net.imagej.ops.filter.convolve;
 
-import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.filter.AbstractFFTFilterImg;
 import net.imglib2.Interval;
@@ -38,7 +37,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Intervals;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
@@ -54,8 +52,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Filter.Convolve.class, priority = Priority.HIGH_PRIORITY)
 public class ConvolveFFTImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-	extends AbstractFFTFilterImg<I, O, K, C> implements Ops.Filter.Convolve,
-	Contingent
+	extends AbstractFFTFilterImg<I, O, K, C> implements Ops.Filter.Convolve
 {
 
 	/**
@@ -68,13 +65,6 @@ public class ConvolveFFTImg<I extends RealType<I>, O extends RealType<O>, K exte
 	{
 		ops().filter().convolve(raiExtendedInput, raiExtendedKernel, fftImg,
 			fftKernel, output);
-	}
-
-	@Override
-	public boolean conforms() {
-		// TODO: only conforms if the kernel is sufficiently large (else the
-		// naive approach should be used) -> what is a good heuristic??
-		return Intervals.numElements(getKernel()) > 9;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/filter/convolve/ConvolveNaiveImg.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/ConvolveNaiveImg.java
@@ -48,7 +48,7 @@ import org.scijava.plugin.Plugin;
 /**
  * Convolves an image naively (no FFTs).
  */
-@Plugin(type = Ops.Filter.Convolve.class, priority = Priority.HIGH_PRIORITY)
+@Plugin(type = Ops.Filter.Convolve.class, priority = Priority.HIGH_PRIORITY + 1)
 public class ConvolveNaiveImg<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 	extends AbstractFilterImg<I, O, K> implements Ops.Filter.Convolve, Contingent
 {

--- a/src/main/java/net/imagej/ops/math/UnaryRealTypeMath.java
+++ b/src/main/java/net/imagej/ops/math/UnaryRealTypeMath.java
@@ -744,7 +744,7 @@ public final class UnaryRealTypeMath {
 
 		@Override
 		public void compute1(final I input, final O output) {
-			output.setReal(Math.round(input.getRealDouble()));
+			output.setReal((double) Math.round(input.getRealDouble()));
 		}
 	}
 

--- a/src/test/java/net/imagej/ops/convert/ConvertIIsTest.java
+++ b/src/test/java/net/imagej/ops/convert/ConvertIIsTest.java
@@ -71,7 +71,8 @@ public class ConvertIIsTest extends AbstractOpTest {
 
 	@Test
 	public void testClip() {
-		ops.convert().imageType(out, in, new ClipRealTypes<ShortType, ByteType>());
+		ops.run(ConvertIIs.class, out, in,
+			new ClipRealTypes<ShortType, ByteType>());
 
 		final Cursor<ShortType> c = in.localizingCursor();
 		final RandomAccess<ByteType> ra = out.randomAccess();
@@ -84,7 +85,8 @@ public class ConvertIIsTest extends AbstractOpTest {
 
 	@Test
 	public void testCopy() {
-		ops.convert().imageType(out, in, new CopyRealTypes<ShortType, ByteType>());
+		ops.run(ConvertIIs.class, out, in,
+			new CopyRealTypes<ShortType, ByteType>());
 
 		final Cursor<ShortType> c = in.localizingCursor();
 		final RandomAccess<ByteType> ra = out.randomAccess();
@@ -97,7 +99,8 @@ public class ConvertIIsTest extends AbstractOpTest {
 
 	@Test
 	public void testScale() {
-		ops.convert().imageType(out, in, new ScaleRealTypes<ShortType, ByteType>());
+		ops.run(ConvertIIs.class, out, in,
+			new ScaleRealTypes<ShortType, ByteType>());
 
 		final Cursor<ShortType> c = in.localizingCursor();
 		final RandomAccess<ByteType> ra = out.randomAccess();

--- a/src/test/java/net/imagej/ops/copy/CopyRAITest.java
+++ b/src/test/java/net/imagej/ops/copy/CopyRAITest.java
@@ -153,7 +153,7 @@ public class CopyRAITest extends AbstractOpTest {
 
 		// create a copy op
 		final UnaryHybridCF<IntervalView<UnsignedByteType>, RandomAccessibleInterval<UnsignedByteType>> copy =
-			(UnaryHybridCF) Hybrids.unaryCF(ops, Ops.Copy.RAI.class,
+			(UnaryHybridCF) Hybrids.unaryCF(ops, CopyRAI.class,
 				RandomAccessibleInterval.class, IntervalView.class);
 
 		assertNotNull(copy);

--- a/src/test/java/net/imagej/ops/create/CreateImgPlusTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgPlusTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 
 import net.imagej.ImgPlus;
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.imgPlus.DefaultCreateImgPlus;
 
 import org.junit.Test;
 
@@ -48,7 +49,7 @@ public class CreateImgPlusTest extends AbstractOpTest {
 
 	@Test
 	public void createImgPlusTest() {
-		assertEquals(ops.create().imgPlus(
+		assertEquals(ops.run(DefaultCreateImgPlus.class,
 			ops.create().img(new long[] { 10, 9, 8 })).getClass(), ImgPlus.class);
 	}
 }

--- a/src/test/java/net/imagej/ops/create/CreateImgTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateImgTest.java
@@ -36,6 +36,9 @@ import static org.junit.Assert.assertEquals;
 import java.util.Random;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.img.CreateImgFromDimsAndType;
+import net.imagej.ops.create.img.CreateImgFromImg;
+import net.imagej.ops.create.img.CreateImgFromInterval;
 import net.imglib2.Dimensions;
 import net.imglib2.FinalDimensions;
 import net.imglib2.FinalInterval;
@@ -85,7 +88,8 @@ public class CreateImgTest extends AbstractOpTest {
 			}
 
 			// create img
-			final Img<?> img = ops.create().img(new FinalInterval(min, max));
+			final Img<?> img = (Img<?>) ops.run(CreateImgFromInterval.class,
+				new FinalInterval(min, max));
 
 			assertArrayEquals("Image Minimum:", min, Intervals.minAsLongArray(img));
 			assertArrayEquals("Image Maximum:", max, Intervals.maxAsLongArray(img));
@@ -108,7 +112,9 @@ public class CreateImgTest extends AbstractOpTest {
 			}
 
 			// create img
-			final Img<DoubleType> img = ops.create().img(dim);
+			@SuppressWarnings("unchecked")
+			final Img<DoubleType> img = (Img<DoubleType>) ops.run(
+				CreateImgFromDimsAndType.class, dim, new DoubleType());
 
 			assertArrayEquals("Image Dimensions:", dim, Intervals
 				.dimensionsAsLongArray(img));
@@ -120,7 +126,9 @@ public class CreateImgTest extends AbstractOpTest {
 		// create img
 		final Img<ByteType> img =
 			ops.create().img(new FinalDimensions(1), new ByteType());
-		final Img<ByteType> newImg = ops.create().img(img);
+		@SuppressWarnings("unchecked")
+		final Img<ByteType> newImg = (Img<ByteType>) ops.run(CreateImgFromImg.class,
+			img);
 
 		// should both be ByteType. New Img shouldn't be DoubleType (default)
 		assertEquals(img.firstElement().getClass(), newImg.firstElement()
@@ -131,12 +139,16 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testImageFactory() {
 		final Dimensions dim = new FinalDimensions(10, 10, 10);
 
-		final Img<DoubleType> arrayImg = ops.create().img(dim, new DoubleType(),
+		@SuppressWarnings("unchecked")
+		final Img<DoubleType> arrayImg = (Img<DoubleType>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new DoubleType(),
 			new ArrayImgFactory<DoubleType>());
 		final Class<?> arrayFactoryClass = arrayImg.factory().getClass();
 		assertEquals("Image Factory: ", ArrayImgFactory.class, arrayFactoryClass);
 
-		final Img<DoubleType> cellImg = ops.create().img(dim, new DoubleType(),
+		@SuppressWarnings("unchecked")
+		final Img<DoubleType> cellImg = (Img<DoubleType>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new DoubleType(),
 			new CellImgFactory<DoubleType>());
 		final Class<?> cellFactoryClass = cellImg.factory().getClass();
 		assertEquals("Image Factory: ", CellImgFactory.class, cellFactoryClass);
@@ -146,30 +158,35 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testImageType() {
 		final Dimensions dim = new FinalDimensions(10, 10, 10);
 
-		assertEquals("Image Type: ", BitType.class, ((Img<?>) ops.create().img(dim,
-			new BitType())).firstElement().getClass());
+		assertEquals("Image Type: ", BitType.class, ((Img<?>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new BitType())).firstElement()
+				.getClass());
 
-		assertEquals("Image Type: ", ByteType.class, ((Img<?>) ops.create().img(
-			dim, new ByteType())).firstElement().getClass());
+		assertEquals("Image Type: ", ByteType.class, ((Img<?>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new ByteType())).firstElement()
+				.getClass());
 
 		assertEquals("Image Type: ", UnsignedByteType.class, ((Img<?>) ops.create()
 			.img(dim, new UnsignedByteType())).firstElement().getClass());
 
-		assertEquals("Image Type: ", IntType.class, ((Img<?>) ops.create().img(dim,
-			new IntType())).firstElement().getClass());
+		assertEquals("Image Type: ", IntType.class, ((Img<?>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new IntType())).firstElement()
+				.getClass());
 
-		assertEquals("Image Type: ", FloatType.class, ((Img<?>) ops.create().img(
-			dim, new FloatType())).firstElement().getClass());
+		assertEquals("Image Type: ", FloatType.class, ((Img<?>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new FloatType())).firstElement()
+				.getClass());
 
-		assertEquals("Image Type: ", DoubleType.class, ((Img<?>) ops.create().img(
-			dim, new DoubleType())).firstElement().getClass());
+		assertEquals("Image Type: ", DoubleType.class, ((Img<?>) ops.run(
+			CreateImgFromDimsAndType.class, dim, new DoubleType())).firstElement()
+				.getClass());
 	}
 
 	@Test
 	public void testCreateFromImgSameType() {
 		final Img<ByteType> input = PlanarImgs.bytes(10, 10, 10);
-		final Img<?> res =
-			ops.create().img(input, input.firstElement().createVariable());
+		final Img<?> res = (Img<?>) ops.run(CreateImgFromDimsAndType.class, input,
+			input.firstElement().createVariable());
 
 		assertEquals("Image Type: ", ByteType.class, res.firstElement().getClass());
 		assertArrayEquals("Image Dimensions: ", Intervals
@@ -181,7 +198,8 @@ public class CreateImgTest extends AbstractOpTest {
 	@Test
 	public void testCreateFromImgDifferentType() {
 		final Img<ByteType> input = PlanarImgs.bytes(10, 10, 10);
-		final Img<?> res = ops.create().img(input, new ShortType());
+		final Img<?> res = (Img<?>) ops.run(CreateImgFromDimsAndType.class, input,
+			new ShortType());
 
 		assertEquals("Image Type: ", ShortType.class, res.firstElement().getClass());
 		assertArrayEquals("Image Dimensions: ", Intervals
@@ -196,7 +214,8 @@ public class CreateImgTest extends AbstractOpTest {
 			Views.interval(PlanarImgs.bytes(10, 10, 10), new FinalInterval(
 				new long[] { 10, 10, 1 }));
 
-		final Img<?> res = ops.create().img(input, new ShortType());
+		final Img<?> res = (Img<?>) ops.run(CreateImgFromDimsAndType.class, input,
+			new ShortType());
 
 		assertEquals("Image Type: ", ShortType.class, res.firstElement().getClass());
 
@@ -215,7 +234,7 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testCreateFromIntegerArray() {
 		final Integer[] dims = new Integer[] {25, 25, 10};
 
-		final Img<?> res = (Img<?>) ops.create().img(dims);
+		final Img<?> res = ops.create().img(dims);
 
 		for (int i=0; i<dims.length; i++) {
 			assertEquals("Image Dimension " + i + ": ", dims[i].longValue(), res
@@ -231,7 +250,7 @@ public class CreateImgTest extends AbstractOpTest {
 	public void testCreateFromLongArray() {
 		final Long[] dims = new Long[] {25l, 25l, 10l};
 
-		final Img<?> res = (Img<?>) ops.create().img(dims);
+		final Img<?> res = ops.create().img(dims);
 
 		for (int i=0; i<dims.length; i++) {
 			assertEquals("Image Dimension " + i + ": ", dims[i].longValue(), res

--- a/src/test/java/net/imagej/ops/create/CreateIntegerTypeTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateIntegerTypeTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.integerType.DefaultCreateIntegerType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.IntType;
@@ -110,11 +111,12 @@ public class CreateIntegerTypeTest extends AbstractOpTest {
 	// -- Helper methods --
 
 	private void assertType(final Class<?> type, final long max) {
-		assertEquals(type, ops.create().integerType(max).getClass());
+		assertEquals(type, ops.run(DefaultCreateIntegerType.class, max).getClass());
 	}
 
 	private void assertNotType(final Class<?> type, final long max) {
-		assertNotEquals(type, ops.create().integerType(max).getClass());
+		assertNotEquals(type, ops.run(DefaultCreateIntegerType.class, max)
+			.getClass());
 	}
 
 }

--- a/src/test/java/net/imagej/ops/create/CreateKernelTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateKernelTest.java
@@ -33,6 +33,10 @@ package net.imagej.ops.create;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.kernelGauss.CreateKernelGauss;
+import net.imagej.ops.create.kernelGauss.CreateKernelGaussSymmetric;
+import net.imagej.ops.create.kernelLog.CreateKernelLog;
+import net.imagej.ops.create.kernelLog.CreateKernelLogSymmetric;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.numeric.real.FloatType;
@@ -59,21 +63,25 @@ public class CreateKernelTest extends AbstractOpTest {
 			sigmas[i] = sigma;
 		}
 
-		final Img<FloatType> gaussianKernel =
-			ops.create().kernelGauss(new FloatType(), new ArrayImgFactory<FloatType>(),
-				numDimensions, sigma);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> gaussianKernel = (Img<FloatType>) ops.run(
+			CreateKernelGaussSymmetric.class, new FloatType(),
+			new ArrayImgFactory<FloatType>(), numDimensions, sigma);
 
-		final Img<FloatType> gaussianKernel2 =
-			ops.create().kernelGauss(new FloatType(),
-				new ArrayImgFactory<FloatType>(), sigmas);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> gaussianKernel2 = (Img<FloatType>) ops.run(
+			CreateKernelGauss.class, new FloatType(),
+			new ArrayImgFactory<FloatType>(), sigmas);
 
-		final Img<FloatType> logKernel =
-			ops.create().kernelLog(new FloatType(), new ArrayImgFactory<FloatType>(),
-				numDimensions, sigma);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> logKernel = (Img<FloatType>) ops.run(
+			CreateKernelLogSymmetric.class, new FloatType(),
+			new ArrayImgFactory<FloatType>(), numDimensions, sigma);
 
-		final Img<FloatType> logKernel2 =
-			ops.create().kernelLog(new FloatType(), new ArrayImgFactory<FloatType>(),
-				sigmas);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> logKernel2 = (Img<FloatType>) ops.run(
+			CreateKernelLog.class, new FloatType(), new ArrayImgFactory<FloatType>(),
+			sigmas);
 
 		assertEquals(gaussianKernel.dimension(1), 31);
 		assertEquals(gaussianKernel2.dimension(1), 31);
@@ -99,37 +107,40 @@ public class CreateKernelTest extends AbstractOpTest {
 		/*Img<FloatType> gaussianKernel =
 			(Img<FloatType>) ops.create().kernelGauss(sigmas, null, new FloatType(),
 				new ArrayImgFactory());
-
+		
 		// no factory
 		Img<FloatType> gaussianKernel2 =
 			(Img<FloatType>) ops.create().kernelGauss(sigmas, null, new FloatType());
 		*/
-		final Img<FloatType> gaussianKernel =
-			ops.create().kernelGauss(new FloatType(),
-				new ArrayImgFactory<FloatType>(), sigmas);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> gaussianKernel = (Img<FloatType>) ops.run(
+			CreateKernelGauss.class, new FloatType(),
+			new ArrayImgFactory<FloatType>(), sigmas);
 
 		// no factory
-		final Img<FloatType> gaussianKernel2 =
-			ops.create().kernelGauss(new FloatType(), null, sigmas);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> gaussianKernel2 = (Img<FloatType>) ops.run(
+			CreateKernelGauss.class, new FloatType(), null, sigmas);
 		// no factory, no type
-		final Img<FloatType> gaussianKernel3 =
-			ops.create().<FloatType> kernelGauss(sigmas);
+		final Img<?> gaussianKernel3 = (Img<?>) ops.run(CreateKernelGauss.class,
+			sigmas);
 
 		assertEquals(gaussianKernel.dimension(1), 31);
 		assertEquals(gaussianKernel2.dimension(1), 31);
 		assertEquals(gaussianKernel3.dimension(1), 31);
 
-		final Img<FloatType> logKernel =
-			ops.create().kernelLog(new FloatType(), new ArrayImgFactory<FloatType>(),
-				sigmas);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> logKernel = (Img<FloatType>) ops.run(
+			CreateKernelLog.class, new FloatType(), new ArrayImgFactory<FloatType>(),
+			sigmas);
 
 		// no factory
-		final Img<FloatType> logKernel2 =
-			ops.create().kernelLog(new FloatType(), null, sigmas);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> logKernel2 = (Img<FloatType>) ops.run(
+			CreateKernelLog.class, new FloatType(), null, sigmas);
 
 		// no factory, no type
-		final Img<FloatType> logKernel3 =
-			ops.create().<FloatType> kernelLog(sigmas);
+		final Img<?> logKernel3 = (Img<?>) ops.run(CreateKernelLog.class, sigmas);
 
 		assertEquals(logKernel.dimension(1), 27);
 		assertEquals(logKernel2.dimension(1), 27);

--- a/src/test/java/net/imagej/ops/create/CreateNativeTypeTest.java
+++ b/src/test/java/net/imagej/ops/create/CreateNativeTypeTest.java
@@ -33,6 +33,8 @@ package net.imagej.ops.create;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.create.nativeType.CreateNativeTypeFromClass;
+import net.imagej.ops.create.nativeType.DefaultCreateNativeType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -51,23 +53,23 @@ public class CreateNativeTypeTest extends AbstractOpTest {
 	public void testCreateNativeType() {
 
 		// default
-		Object type = ops.create().nativeType();
+		Object type = ops.run(DefaultCreateNativeType.class);
 		assertEquals(type.getClass(), DoubleType.class);
 
 		// FloatType
-		type = ops.create().nativeType(FloatType.class);
+		type = ops.run(CreateNativeTypeFromClass.class, FloatType.class);
 		assertEquals(type.getClass(), FloatType.class);
 
 		// ComplexFloatType
-		type = ops.create().nativeType(ComplexFloatType.class);
+		type = ops.run(CreateNativeTypeFromClass.class, ComplexFloatType.class);
 		assertEquals(type.getClass(), ComplexFloatType.class);
 
 		// DoubleType
-		type = ops.create().nativeType(DoubleType.class);
+		type = ops.run(CreateNativeTypeFromClass.class, DoubleType.class);
 		assertEquals(type.getClass(), DoubleType.class);
 
 		// ComplexDoubleType
-		type = ops.create().nativeType(ComplexDoubleType.class);
+		type = ops.run(CreateNativeTypeFromClass.class, ComplexDoubleType.class);
 		assertEquals(type.getClass(), ComplexDoubleType.class);
 
 	}

--- a/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
+++ b/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
@@ -33,6 +33,7 @@ package net.imagej.ops.deconvolve;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.filter.convolve.ConvolveFFTImg;
 import net.imglib2.Cursor;
 import net.imglib2.Point;
 import net.imglib2.algorithm.region.hypersphere.HyperSphere;
@@ -63,10 +64,13 @@ public class DeconvolveTest extends AbstractOpTest {
 		placeSphereInCenter(kernel);
 
 		// convolve and calculate the sum of output
-		Img<FloatType> convolved = ops.filter().convolve(in, kernel);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> convolved = (Img<FloatType>) ops.run(
+			ConvolveFFTImg.class, in, kernel);
 
-		final Img<FloatType> deconvolved2 =
-			ops.deconvolve().richardsonLucy(convolved, kernel, 10);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> deconvolved2 = (Img<FloatType>) ops.run(
+			RichardsonLucyImg.class, convolved, kernel, 10);
 
 		assertEquals(size[0], deconvolved2.dimension(0));
 		assertEquals(size[1], deconvolved2.dimension(1));

--- a/src/test/java/net/imagej/ops/eval/EvalTest.java
+++ b/src/test/java/net/imagej/ops/eval/EvalTest.java
@@ -53,12 +53,12 @@ public class EvalTest extends AbstractOpTest {
 		vars.put("b", 3);
 		vars.put("c", 5);
 
-		assertEquals(7, ops.eval("a+c", vars));
-		assertEquals(3, ops.eval("c-a", vars));
-		assertEquals(6, ops.eval("a*b", vars));
-		assertEquals(2, ops.eval("c/a", vars));
-		assertEquals(1, ops.eval("c%a", vars));
-		assertEquals(17, ops.eval("a+b*c", vars));
+		assertEquals(7, ops.run(DefaultEval.class, "a+c", vars));
+		assertEquals(3, ops.run(DefaultEval.class, "c-a", vars));
+		assertEquals(6, ops.run(DefaultEval.class, "a*b", vars));
+		assertEquals(2, ops.run(DefaultEval.class, "c/a", vars));
+		assertEquals(1, ops.run(DefaultEval.class, "c%a", vars));
+		assertEquals(17, ops.run(DefaultEval.class, "a+b*c", vars));
 	}
 
 }

--- a/src/test/java/net/imagej/ops/features/lbp2d/LBP2dFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/lbp2d/LBP2dFeatureTest.java
@@ -50,7 +50,9 @@ public class LBP2dFeatureTest extends AbstractFeatureTest {
 
 	@Test
 	public void testLbp2d() {
-		ArrayList<LongType> hist = ops.lbp().lbp2D(random, 1,4);
+		@SuppressWarnings("unchecked")
+		final ArrayList<LongType> hist = (ArrayList<LongType>) ops.run(
+			DefaultLBP2D.class, random, 1, 4);
 	
 		// Test values proved by calculating small toy example by hand.
 		assertEquals(Ops.LBP.LBP2D.NAME, 5412.0, hist.get(0).getRealDouble(), 1e-3);

--- a/src/test/java/net/imagej/ops/features/tamura2d/Tamura2dFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/tamura2d/Tamura2dFeatureTest.java
@@ -35,6 +35,7 @@ import net.imagej.ops.Ops;
 import net.imagej.ops.features.AbstractFeatureTest;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.Test;
@@ -50,26 +51,28 @@ public class Tamura2dFeatureTest extends AbstractFeatureTest {
 
 	@Test
 	public void testContrastFeature() {
-		assertEquals(Ops.Tamura.Contrast.NAME, 63.7185, ops.tamura().contrast(
-			random).getRealDouble(), 1e-3);
+		assertEquals(Ops.Tamura.Contrast.NAME, 63.7185, ((RealType<?>) ops.run(
+			DefaultContrastFeature.class, random)).getRealDouble(), 1e-3);
 	}
 
 	@Test
 	public void testDirectionalityFeature() {
-		assertEquals(Ops.Tamura.Directionality.NAME, 0.007819, ops.tamura()
-				.directionality(random, 16).getRealDouble(), 1e-3);
+		assertEquals(Ops.Tamura.Directionality.NAME, 0.007819, ((RealType<?>) ops
+			.run(DefaultDirectionalityFeature.class, random, 16)).getRealDouble(),
+			1e-3);
 	}
 
 	@Test
 	public void testCoarsenessFeature() {
-		assertEquals(Ops.Tamura.Coarseness.NAME, 43.614, ops.tamura().coarseness(
-			random).getRealDouble(), 1e-3);
+		assertEquals(Ops.Tamura.Coarseness.NAME, 43.614, ((RealType<?>) ops.run(
+			DefaultCoarsenessFeature.class, random)).getRealDouble(), 1e-3);
 
 		// NB: according to the implementation, this 2x2 image should have exactly 0
 		// coarseness.
 		byte[] arr = new byte[] {0, -1, 0, 0};
 		Img<ByteType> in = ArrayImgs.bytes(arr, 2, 2);
-		assertEquals(Ops.Tamura.Coarseness.NAME, 0.0, ops.tamura().coarseness(in).getRealDouble(), 0.0);
+		assertEquals(Ops.Tamura.Coarseness.NAME, 0.0, ((RealType<?>) ops.run(
+			DefaultCoarsenessFeature.class, in)).getRealDouble(), 0.0);
 	}
 
 }

--- a/src/test/java/net/imagej/ops/features/zernike/ZernikeFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/zernike/ZernikeFeatureTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.features.AbstractFeatureTest;
+import net.imglib2.type.numeric.RealType;
 
 import org.junit.Test;
 
@@ -47,18 +48,22 @@ public class ZernikeFeatureTest extends AbstractFeatureTest {
 	
 	@Test
 	public void testPhaseFeature() {
-		
-		assertEquals(Ops.Zernike.Phase.NAME, 180.0, ops.zernike().phase(ellipse, 4, 2).getRealDouble(), 1e-3);
-		assertEquals(Ops.Zernike.Phase.NAME, 360.0, ops.zernike().phase(rotatedEllipse, 4, 2).getRealDouble(), 1e-3);
+
+		assertEquals(Ops.Zernike.Phase.NAME, 180.0, ((RealType<?>) ops.run(
+			DefaultPhaseFeature.class, ellipse, 4, 2)).getRealDouble(), 1e-3);
+		assertEquals(Ops.Zernike.Phase.NAME, 360.0, ((RealType<?>) ops.run(
+			DefaultPhaseFeature.class, rotatedEllipse, 4, 2)).getRealDouble(), 1e-3);
 	}
 	
 	@Test 
 	public void testMagnitudeFeature() {
-			
-		double v1 = ops.zernike().magnitude(ellipse, 4, 2).getRealDouble();
-		double v2 = ops.zernike().magnitude(rotatedEllipse, 4, 2).getRealDouble();
+
+		double v1 = ((RealType<?>) ops.run(DefaultMagnitudeFeature.class, ellipse,
+			4, 2)).getRealDouble();
+		double v2 = ((RealType<?>) ops.run(DefaultMagnitudeFeature.class,
+			rotatedEllipse, 4, 2)).getRealDouble();
 	
-		assertEquals(Ops.Zernike.Magnitude.NAME, 0.16684211008, ops.zernike().magnitude(ellipse, 4, 2).getRealDouble(), 1e-3);
+		assertEquals(Ops.Zernike.Magnitude.NAME, 0.16684211008, v1, 1e-3);
 		
 		// magnitude should be the same after rotating the image
 		assertEquals(Ops.Zernike.Magnitude.NAME, v1, v2, 1e-3);

--- a/src/test/java/net/imagej/ops/filter/FFTTest.java
+++ b/src/test/java/net/imagej/ops/filter/FFTTest.java
@@ -32,6 +32,9 @@ package net.imagej.ops.filter;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.filter.fft.FFTImg;
+import net.imagej.ops.filter.fftSize.ComputeFFTSize;
+import net.imagej.ops.filter.ifft.IFFTRAI;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.Point;
@@ -73,8 +76,10 @@ public class FFTTest extends AbstractOpTest {
 			final Img<FloatType> inverse = generateFloatArrayTestImg(false,
 				dimensions);
 
-			final Img<ComplexFloatType> out = ops.filter().fft(in);
-			ops.filter().ifft(inverse, out);
+			@SuppressWarnings("unchecked")
+			final Img<ComplexFloatType> out = (Img<ComplexFloatType>) ops.run(
+				FFTImg.class, in);
+			ops.run(IFFTRAI.class, inverse, out);
 
 			assertImagesEqual(in, inverse, .00005f);
 		}
@@ -100,8 +105,8 @@ public class FFTTest extends AbstractOpTest {
 			final long[] fftDimensions = new long[3];
 
 			// compute the dimensions that will result in the fastest FFT time
-			ops.filter().fftSize(originalDimensions, fastDimensions, fftDimensions,
-				true, true);
+			ops.run(ComputeFFTSize.class, originalDimensions, fastDimensions,
+				fftDimensions, true, true);
 
 			// create an input with a small sphere at the center
 			final Img<FloatType> inOriginal = generateFloatArrayTestImg(false,
@@ -116,18 +121,22 @@ public class FFTTest extends AbstractOpTest {
 			// call FFT passing false for "fast" (in order to pass the optional
 			// parameter we have to pass null for the
 			// output parameter).
-			final Img<ComplexFloatType> fft1 = ops.filter().fft(null, inOriginal,
-				null, false);
+			@SuppressWarnings("unchecked")
+			final Img<ComplexFloatType> fft1 = (Img<ComplexFloatType>) ops.run(
+				FFTImg.class, null, inOriginal, null, false);
 
 			// call FFT passing true for "fast" (in order to pass the optional
 			// parameter we have to pass null for the
 			// output parameter). The FFT op will pad the input to the fast
 			// size.
-			final Img<ComplexFloatType> fft2 = ops.filter().fft(null, inOriginal,
-				null, true);
+			@SuppressWarnings("unchecked")
+			final Img<ComplexFloatType> fft2 = (Img<ComplexFloatType>) ops.run(
+				FFTImg.class, null, inOriginal, null, true);
 
 			// call fft using the img that was created with the fast size
-			final Img<ComplexFloatType> fft3 = ops.filter().fft(inFast);
+			@SuppressWarnings("unchecked")
+			final Img<ComplexFloatType> fft3 = (Img<ComplexFloatType>) ops.run(
+				FFTImg.class, inFast);
 
 			// create an image to be used for the inverse, using the original
 			// size
@@ -146,18 +155,18 @@ public class FFTTest extends AbstractOpTest {
 				fastDimensions);
 
 			// invert the "small" FFT
-			ops.filter().ifft(inverseOriginalSmall, fft1);
+			ops.run(IFFTRAI.class, inverseOriginalSmall, fft1);
 
 			// invert the "fast" FFT. The inverse will should be the original
 			// size.
-			ops.filter().ifft(inverseOriginalFast, fft2);
+			ops.run(IFFTRAI.class, inverseOriginalFast, fft2);
 
 			// invert the "fast" FFT that was acheived by explicitly using an
 			// image
 			// that had "fast" dimensions. The inverse will be the fast size
 			// this
 			// time.
-			ops.filter().ifft(inverseFast, fft3);
+			ops.run(IFFTRAI.class, inverseFast, fft3);
 
 			// assert that the inverse images are equal to the original
 			assertImagesEqual(inverseOriginalSmall, inOriginal, .0001f);

--- a/src/test/java/net/imagej/ops/filter/convolve/ConvolveTest.java
+++ b/src/test/java/net/imagej/ops/filter/convolve/ConvolveTest.java
@@ -74,9 +74,11 @@ public class ConvolveTest extends AbstractOpTest {
 		assertSame(ConvolveNaiveImg.class, op.getClass());
 
 		// make sure it runs
-		Img<FloatType> out = ops.filter().convolve(in, kernel);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> out1 = (Img<FloatType>) ops.run(ConvolveNaiveImg.class,
+			in, kernel);
 
-		assertEquals(out.dimension(0), 20);
+		assertEquals(out1.dimension(0), 20);
 
 		// use a bigger kernel
 		kernelSize = new int[] { 30, 30 };
@@ -89,9 +91,11 @@ public class ConvolveTest extends AbstractOpTest {
 		assertSame(ConvolveFFTImg.class, op.getClass());
 
 		// make sure it runs
-		out = ops.filter().convolve(in, kernel);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> out2 = (Img<FloatType>) ops.run(ConvolveFFTImg.class,
+			in, kernel);
 
-		assertEquals(out.dimension(0), 20);
+		assertEquals(out2.dimension(0), 20);
 
 	}
 
@@ -128,7 +132,9 @@ public class ConvolveTest extends AbstractOpTest {
 		ops.stats().sum(kernelSum, kernel);
 
 		// convolve and calculate the sum of output
-		Img<FloatType> out = ops.filter().convolve(null, in, kernel, borderSize);
+		@SuppressWarnings("unchecked")
+		final Img<FloatType> out = (Img<FloatType>) ops.run(ConvolveFFTImg.class,
+			null, in, kernel, borderSize);
 
 		// create an output for the next test
 		Img<FloatType> out2 =
@@ -146,11 +152,11 @@ public class ConvolveTest extends AbstractOpTest {
 		createMemory.run();
 
 		// run convolve using the rai version with the memory created above
-		ops.filter().convolve(createMemory.getRAIExtendedInput(),
+		ops.run(ConvolveFFTRAI.class, createMemory.getRAIExtendedInput(),
 			createMemory.getRAIExtendedKernel(), createMemory.getFFTImg(),
 			createMemory.getFFTKernel(), out2);
 
-		ops.filter().convolve(createMemory.getRAIExtendedInput(), null,
+		ops.run(ConvolveFFTRAI.class, createMemory.getRAIExtendedInput(), null,
 			createMemory.getFFTImg(), createMemory.getFFTKernel(), out3, true, false);
 
 		ops.stats().sum(outSum, out);

--- a/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
+++ b/src/test/java/net/imagej/ops/filter/dog/DoGTest.java
@@ -60,7 +60,7 @@ public class DoGTest extends AbstractOpTest {
 		final Img<ByteType> out1 = generateByteArrayTestImg(false, dims);
 		final Img<ByteType> out2 = generateByteArrayTestImg(false, dims);
 
-		ops.filter().dog(out1, in, sigmas1, sigmas2);
+		ops.run(DoGVaryingSigmas.class, out1, in, sigmas1, sigmas2);
 
 		// test against native imglib2 implementation
 		DifferenceOfGaussian.DoG(sigmas1, sigmas2, Views.extendMirrorSingle(in),
@@ -77,8 +77,10 @@ public class DoGTest extends AbstractOpTest {
 
 	@Test
 	public void dogRAISingleSigmasTest() {
+		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<ByteType> res =
-			ops.filter().dog(generateByteArrayTestImg(true, new long[] { 10, 10 }), 1, 2);
+			(RandomAccessibleInterval<ByteType>) ops.run(DoGSingleSigmas.class,
+				generateByteArrayTestImg(true, new long[] { 10, 10 }), 1, 2);
 
 		org.junit.Assert.assertNotNull(res);
 	}

--- a/src/test/java/net/imagej/ops/filter/gauss/GaussTest.java
+++ b/src/test/java/net/imagej/ops/filter/gauss/GaussTest.java
@@ -60,7 +60,7 @@ public class GaussTest extends AbstractOpTest {
 		final Img<ByteType> out2 =
 			ops.create().img(in, Util.getTypeFromInterval(in));
 
-		ops.filter().gauss(out1, in, sigma);
+		ops.run(GaussRAISingleSigma.class, out1, in, sigma);
 		try {
 			Gauss3.gauss(sigma, Views.extendMirrorSingle(in), out2);
 		}

--- a/src/test/java/net/imagej/ops/help/HelpCandidatesTest.java
+++ b/src/test/java/net/imagej/ops/help/HelpCandidatesTest.java
@@ -56,7 +56,7 @@ public class HelpCandidatesTest extends AbstractOpTest {
 
 	@Test
 	public void testAll() {
-		final String actual = ops.help();
+		final String actual = (String) ops.run(HelpCandidates.class);
 		assertTrue(actual.startsWith("Available operations:\n"));
 		assertTrue(actual.length() > 50000); // lots of ops!
 	}
@@ -67,14 +67,14 @@ public class HelpCandidatesTest extends AbstractOpTest {
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YummyApple()\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YuckyApple()";
-		final String apple = ops.help("test.apple");
+		final String apple = (String) ops.run(HelpCandidates.class, "test.apple");
 		assertEquals(expectedApple, apple);
 
 		final String expectedOrange = "" + //
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YummyOrange()\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YuckyOrange()";
-		final String orange = ops.help("test.orange");
+		final String orange = (String) ops.run(HelpCandidates.class, "test.orange");
 		assertEquals(expectedOrange, orange);
 	}
 
@@ -84,14 +84,16 @@ public class HelpCandidatesTest extends AbstractOpTest {
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YummyApple()\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YummyOrange()";
-		final String actualYummy = ops.help(null, Yummy.class);
+		final String actualYummy = (String) ops.run(HelpCandidates.class, null,
+			Yummy.class);
 		assertEquals(expectedYummy, actualYummy);
 
 		final String expectedYucky = "" + //
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YuckyOrange()\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YuckyApple()";
-		final String yucky = ops.help(null, Yucky.class);
+		final String yucky = (String) ops.run(HelpCandidates.class, null,
+			Yucky.class);
 		assertEquals(expectedYucky, yucky);
 	}
 
@@ -100,28 +102,33 @@ public class HelpCandidatesTest extends AbstractOpTest {
 		final String expectedYummyApple = "" + //
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YummyApple()"; //
-		final String actualYummyApple = ops.help("test.apple", Yummy.class);
+		final String actualYummyApple = (String) ops.run(HelpCandidates.class,
+			"test.apple", Yummy.class);
 		assertEquals(expectedYummyApple, actualYummyApple);
 
 		final String expectedYuckyApple = "" + //
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YuckyApple()"; //
-		final String actualYuckyApple = ops.help("test.apple", Yucky.class);
+		final String actualYuckyApple = (String) ops.run(HelpCandidates.class,
+			"test.apple", Yucky.class);
 		assertEquals(expectedYuckyApple, actualYuckyApple);
 
 		final String expectedYummyOrange = "" + //
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YummyOrange()"; //
-		final String actualYummyOrange = ops.help("test.orange", Yummy.class);
+		final String actualYummyOrange = (String) ops.run(HelpCandidates.class,
+			"test.orange", Yummy.class);
 		assertEquals(expectedYummyOrange, actualYummyOrange);
 
 		final String expectedYuckyOrange = "" + //
 			"Available operations:\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$YuckyOrange()"; //
-		final String actualYuckyOrange = ops.help("test.orange", Yucky.class);
+		final String actualYuckyOrange = (String) ops.run(HelpCandidates.class,
+			"test.orange", Yucky.class);
 		assertEquals(expectedYuckyOrange, actualYuckyOrange);
-		
-		final String actualEmpty = ops.help("test.apple", Ops.Help.class);
+
+		final String actualEmpty = (String) ops.run(HelpCandidates.class,
+			"test.apple", Ops.Help.class);
 		assertEquals("No such operation.", actualEmpty);
 	}
 
@@ -131,8 +138,8 @@ public class HelpCandidatesTest extends AbstractOpTest {
 			"Available operations:\n" + //
 			"\t(Apple out) =\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$AppleF0()";
-		final String actualF0 = ops.help("test.special", null, 0,
-			SpecialOp.Flavor.FUNCTION);
+		final String actualF0 = (String) ops.run(HelpCandidates.class,
+			"test.special", null, 0, SpecialOp.Flavor.FUNCTION);
 		assertEquals(expectedF0, actualF0);
 
 		final String expectedF1 = "" + //
@@ -140,22 +147,20 @@ public class HelpCandidatesTest extends AbstractOpTest {
 			"\t(Apple out) =\n" + //
 			"\tnet.imagej.ops.help.HelpCandidatesTest$AppleF1(\n" + //
 			"\t\tApple in)";
-		final String actualF1 = ops.help("test.special", null, 1,
-			SpecialOp.Flavor.FUNCTION);
+		final String actualF1 = (String) ops.run(HelpCandidates.class,
+			"test.special", null, 1, SpecialOp.Flavor.FUNCTION);
 		assertEquals(expectedF1, actualF1);
 
-		final String expectedF2 = "Available operations:\n" +
-			"\t(Apple out) =\n" +
+		final String expectedF2 = "Available operations:\n" + "\t(Apple out) =\n" +
 			"\tnet.imagej.ops.help.HelpCandidatesTest$AppleF2(\n" +
-			"\t\tApple in1,\n" +
-			"\t\tApple in2)";
-		final String actualF2 = ops.help("test.special", null, 2,
-			SpecialOp.Flavor.FUNCTION);
+			"\t\tApple in1,\n" + "\t\tApple in2)";
+		final String actualF2 = (String) ops.run(HelpCandidates.class,
+			"test.special", null, 2, SpecialOp.Flavor.FUNCTION);
 		assertEquals(expectedF2, actualF2);
 
 		final String expectedC0 = "No such operation.";
-		final String actualC0 = ops.help("test.special", null, 0,
-			SpecialOp.Flavor.COMPUTER);
+		final String actualC0 = (String) ops.run(HelpCandidates.class,
+			"test.special", null, 0, SpecialOp.Flavor.COMPUTER);
 		assertEquals(expectedC0, actualC0);
 
 		final String expectedC1 = "" + //
@@ -164,13 +169,13 @@ public class HelpCandidatesTest extends AbstractOpTest {
 			"\tnet.imagej.ops.help.HelpCandidatesTest$AppleC1(\n" + //
 			"\t\tApple out,\n" + //
 			"\t\tApple in)";
-		final String actualC1 = ops.help("test.special", null, 1,
-			SpecialOp.Flavor.COMPUTER);
+		final String actualC1 = (String) ops.run(HelpCandidates.class,
+			"test.special", null, 1, SpecialOp.Flavor.COMPUTER);
 		assertEquals(expectedC1, actualC1);
 
 		final String expectedC2 = "No such operation.";
-		final String actualC2 = ops.help("test.special", null, 2,
-			SpecialOp.Flavor.COMPUTER);
+		final String actualC2 = (String) ops.run(HelpCandidates.class,
+			"test.special", null, 2, SpecialOp.Flavor.COMPUTER);
 		assertEquals(expectedC2, actualC2);
 	}
 
@@ -210,6 +215,7 @@ public class HelpCandidatesTest extends AbstractOpTest {
 
 	@Plugin(type = Op.class, name = "test.special")
 	public static class AppleF0 extends AbstractNullaryFunctionOp<Apple> {
+
 		@Override
 		public Apple compute0() {
 			return new Apple();
@@ -218,6 +224,7 @@ public class HelpCandidatesTest extends AbstractOpTest {
 
 	@Plugin(type = Op.class, name = "test.special")
 	public static class AppleF1 extends AbstractUnaryFunctionOp<Apple, Apple> {
+
 		@Override
 		public Apple compute1(final Apple in) {
 			return new Apple();
@@ -225,7 +232,10 @@ public class HelpCandidatesTest extends AbstractOpTest {
 	}
 
 	@Plugin(type = Op.class, name = "test.special")
-	public static class AppleF2 extends AbstractBinaryFunctionOp<Apple, Apple, Apple> {
+	public static class AppleF2 extends
+		AbstractBinaryFunctionOp<Apple, Apple, Apple>
+	{
+
 		@Override
 		public Apple compute2(final Apple in1, final Apple in2) {
 			return new Apple();
@@ -234,6 +244,7 @@ public class HelpCandidatesTest extends AbstractOpTest {
 
 	@Plugin(type = Op.class, name = "test.special")
 	public static class AppleC1 extends AbstractUnaryComputerOp<Apple, Apple> {
+
 		@Override
 		public void compute1(final Apple out, final Apple in) {
 			// NB: No implementation needed.

--- a/src/test/java/net/imagej/ops/identity/IdentityTest.java
+++ b/src/test/java/net/imagej/ops/identity/IdentityTest.java
@@ -46,15 +46,15 @@ public class IdentityTest extends AbstractOpTest {
 	@Test
 	public void testIdentity() {
 		final Byte b = 35;
-		final Object ib = ops.identity(b);
+		final Object ib = ops.run(DefaultIdentity.class, b);
 		assertSame(b, ib);
 
 		final int i = 23;
-		final Object ii = ops.identity(i);
+		final Object ii = ops.run(DefaultIdentity.class, i);
 		assertSame(i, ii);
 
 		final String s = "hello";
-		final Object is = ops.identity(s);
+		final Object is = ops.run(DefaultIdentity.class, s);
 		assertSame(s, is);
 	}
 

--- a/src/test/java/net/imagej/ops/image/crop/CropTest.java
+++ b/src/test/java/net/imagej/ops/image/crop/CropTest.java
@@ -65,24 +65,25 @@ public class CropTest extends AbstractOpTest {
 	@Test
 	public void testCropTypes() {
 		// Set-up interval
-		final Interval defInterval =
-			new FinalInterval(new long[] { 0, 0, 0 }, new long[] { 19, 19, 19 });
+		final Interval defInterval = new FinalInterval(new long[] { 0, 0, 0 },
+			new long[] { 19, 19, 19 });
 
-		final Interval smallerInterval =
-			new FinalInterval(new long[] { 0, 0, 0 }, new long[] { 19, 19, 18 });
+		final Interval smallerInterval = new FinalInterval(new long[] { 0, 0, 0 },
+			new long[] { 19, 19, 18 });
 
 		// check if result is ImgView
-		assertTrue(ops.image().crop(in, defInterval) instanceof Img);
+		assertTrue(ops.run(CropRAI.class, in, defInterval) instanceof Img);
 
 		// check if result is ImgPlus
-		final Object imgPlus =
-			ops.image().crop(new ImgPlus<>(in), defInterval);
+		final Object imgPlus = ops.run(CropImgPlus.class, new ImgPlus<>(in),
+			defInterval);
 		assertTrue(imgPlus instanceof ImgPlus);
 
 		// check if result is RandomAccessibleInterval
-		final Object run =
-			ops.image().crop(Views.interval(in, smallerInterval), smallerInterval);
-		assertTrue(run instanceof RandomAccessibleInterval && !(run instanceof Img));
+		final Object run = ops.run(CropRAI.class, Views.interval(in,
+			smallerInterval), smallerInterval);
+		assertTrue(run instanceof RandomAccessibleInterval &&
+			!(run instanceof Img));
 	}
 
 	/** Tests the result of the slicing. */
@@ -92,27 +93,35 @@ public class CropTest extends AbstractOpTest {
 		// Case 1: fix one dimension
 		long[] min = { 0, 0, 5 };
 		long[] max = { 19, 19, 5 };
-		RandomAccessibleInterval<ByteType> res =
-			ops.image().crop(in, new FinalInterval(min, max));
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<ByteType> res1 =
+			(RandomAccessibleInterval<ByteType>) ops.run(CropRAI.class, in,
+				new FinalInterval(min, max));
 
-		assertTrue(res.numDimensions() == 2);
-		assertTrue(res.min(0) == 0);
-		assertTrue(res.max(0) == 19);
+		assertTrue(res1.numDimensions() == 2);
+		assertTrue(res1.min(0) == 0);
+		assertTrue(res1.max(0) == 19);
 
-		// Case B: Fix one dimension and don't start at zero
+		// Case 2: Fix one dimension and don't start at zero
 		max = new long[] { 19, 0, 10 };
-		res = ops.image().crop(in, new FinalInterval(min, max));
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<ByteType> res2 =
+			(RandomAccessibleInterval<ByteType>) ops.run(CropRAI.class, in,
+				new FinalInterval(min, max));
 
-		assertTrue(res.numDimensions() == 2);
-		assertTrue(res.min(0) == 0);
-		assertTrue(res.max(1) == 5);
+		assertTrue(res2.numDimensions() == 2);
+		assertTrue(res2.min(0) == 0);
+		assertTrue(res2.max(1) == 5);
 
-		// Case C: fix two dimensions
+		// Case 3: fix two dimensions
 		min = new long[] { 0, 0, 0 };
 		max = new long[] { 0, 15, 0 };
-		res = ops.image().crop(in, new FinalInterval(min, max));
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<ByteType> res3 =
+			(RandomAccessibleInterval<ByteType>) ops.run(CropRAI.class, in,
+				new FinalInterval(min, max));
 
-		assertTrue(res.numDimensions() == 1);
-		assertTrue(res.max(0) == 15);
+		assertTrue(res3.numDimensions() == 1);
+		assertTrue(res3.max(0) == 15);
 	}
 }

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -51,7 +51,7 @@ public class InvertTest extends AbstractOpTest {
 		Img<ByteType> in = generateByteArrayTestImg(true, 5, 5);
 		Img<ByteType> out = in.factory().create(in, new ByteType());
 
-		ops.image().invert(out, in);
+		ops.run(InvertII.class, out, in);
 
 		ByteType firstIn = in.firstElement();
 		ByteType firstOut = out.firstElement();
@@ -67,7 +67,7 @@ public class InvertTest extends AbstractOpTest {
 		Img<UnsignedByteType> in = generateUnsignedByteArrayTestImg(true, 5, 5);
 		Img<UnsignedByteType> out = in.factory().create(in, new UnsignedByteType());
 
-		ops.image().invert(out, in);
+		ops.run(InvertII.class, out, in);
 
 		UnsignedByteType firstIn = in.firstElement();
 		UnsignedByteType firstOut = out.firstElement();

--- a/src/test/java/net/imagej/ops/image/normalize/NormalizeTest.java
+++ b/src/test/java/net/imagej/ops/image/normalize/NormalizeTest.java
@@ -52,7 +52,7 @@ public class NormalizeTest extends AbstractOpTest {
 		Img<ByteType> in = generateByteArrayTestImg(true, 5, 5);
 		Img<ByteType> out = in.factory().create(in, new ByteType());
 
-		ops.image().normalize(out, in);
+		ops.run(NormalizeIIComputer.class, out, in);
 
 		final Pair<ByteType, ByteType> minMax2 = ops.stats().minMax(out);
 

--- a/src/test/java/net/imagej/ops/image/project/ProjectTest.java
+++ b/src/test/java/net/imagej/ops/image/project/ProjectTest.java
@@ -77,8 +77,8 @@ public class ProjectTest extends AbstractOpTest {
 
 	@Test
 	public void testProjector() {
-		ops.image().project(out1, in, op, PROJECTION_DIM);
-		ops.image().project(out2, in, op, PROJECTION_DIM);
+		ops.run(DefaultProjectParallel.class, out1, in, op, PROJECTION_DIM);
+		ops.run(DefaultProjectParallel.class, out2, in, op, PROJECTION_DIM);
 		testEquality(out1, out2);
 
 		ops.run(ProjectRAIToII.class, out1, in, op, PROJECTION_DIM);

--- a/src/test/java/net/imagej/ops/image/scale/ScaleImgTest.java
+++ b/src/test/java/net/imagej/ops/image/scale/ScaleImgTest.java
@@ -49,9 +49,9 @@ public class ScaleImgTest extends AbstractOpTest {
 	public void test() {
 		Img<ByteType> in = generateByteArrayTestImg(true, new long[] { 10, 10 });
 		double[] scaleFactors = new double[] { 2, 2 };
-		Img<ByteType> out =
-			ops.image().scale(in, scaleFactors,
-				new NLinearInterpolatorFactory<ByteType>());
+		@SuppressWarnings("unchecked")
+		Img<ByteType> out = (Img<ByteType>) ops.run(ScaleImg.class, in,
+			scaleFactors, new NLinearInterpolatorFactory<ByteType>());
 
 		assertEquals(out.dimension(0), 20);
 		assertEquals(out.dimension(1), 20);

--- a/src/test/java/net/imagej/ops/imagemoments/ImageMomentsTest.java
+++ b/src/test/java/net/imagej/ops/imagemoments/ImageMomentsTest.java
@@ -36,10 +36,36 @@ import java.util.Random;
 
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment02;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment03;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment11;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment12;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment20;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment21;
+import net.imagej.ops.Ops.ImageMoments.CentralMoment30;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment1;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment2;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment3;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment4;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment5;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment6;
+import net.imagej.ops.imagemoments.hu.DefaultHuMoment7;
+import net.imagej.ops.imagemoments.moments.DefaultMoment00;
+import net.imagej.ops.imagemoments.moments.DefaultMoment01;
+import net.imagej.ops.imagemoments.moments.DefaultMoment10;
+import net.imagej.ops.imagemoments.moments.DefaultMoment11;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21;
+import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.DoubleType;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -74,13 +100,13 @@ public class ImageMomentsTest extends AbstractOpTest {
 	@Test
 	public void testMoments() {
 
-		assertEquals(Ops.ImageMoments.Moment00.NAME, 1277534.0, ops.imagemoments().moment00(img)
+		assertEquals(Ops.ImageMoments.Moment00.NAME, 1277534.0, ((DoubleType) ops.run(DefaultMoment00.class, img))
 			.getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.Moment10.NAME, 6.3018047E7, ops.imagemoments().moment10(img)
+		assertEquals(Ops.ImageMoments.Moment10.NAME, 6.3018047E7, ((DoubleType) ops.run(DefaultMoment10.class, img))
 			.getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.Moment01.NAME, 6.3535172E7, ops.imagemoments().moment01(img)
+		assertEquals(Ops.ImageMoments.Moment01.NAME, 6.3535172E7, ((DoubleType) ops.run(DefaultMoment01.class, img))
 			.getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.Moment11.NAME, 3.12877962E9, ops.imagemoments().moment11(img)
+		assertEquals(Ops.ImageMoments.Moment11.NAME, 3.12877962E9, ((DoubleType) ops.run(DefaultMoment11.class, img))
 			.getRealDouble(), 1e-3);
 	}
 
@@ -89,20 +115,20 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testCentralMoments() {
-		assertEquals(Ops.ImageMoments.CentralMoment11.NAME, -5275876.956702232, ops.imagemoments()
-			.centralMoment11(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment02.NAME, 1.0694469880269928E9, ops.imagemoments()
-			.centralMoment02(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment20.NAME, 1.0585772432642083E9, ops.imagemoments()
-			.centralMoment20(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment12.NAME, 5478324.271270752, ops.imagemoments()
-			.centralMoment12(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment21.NAME, -2.1636455685491943E8, ops
-			.imagemoments().centralMoment21(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment30.NAME, 1.735560232991333E8, ops.imagemoments()
-			.centralMoment30(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment03.NAME, -4.0994213161157227E8, ops
-			.imagemoments().centralMoment03(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment11.NAME, -5275876.956702232, ((DoubleType) ops
+			.run(CentralMoment11.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment02.NAME, 1.0694469880269928E9, ((DoubleType) ops
+			.run(CentralMoment02.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment20.NAME, 1.0585772432642083E9, ((DoubleType) ops
+			.run(CentralMoment20.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment12.NAME, 5478324.271270752, ((DoubleType) ops
+			.run(CentralMoment12.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment21.NAME, -2.1636455685491943E8, ((DoubleType) ops
+				.run(CentralMoment21.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment30.NAME, 1.735560232991333E8, ((DoubleType) ops
+			.run(CentralMoment30.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment03.NAME, -4.0994213161157227E8, ((DoubleType) ops
+				.run(CentralMoment03.class, img)).getRealDouble(), 1e-3);
 	}
 
 	/**
@@ -110,26 +136,33 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testNormalizedCentralMoments() {
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment11.NAME, -3.2325832933879204E-6, ops
-			.imagemoments().normalizedCentralMoment11(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment11.NAME,
+			-3.2325832933879204E-6, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment11.class, img)).getRealDouble(), 1e-3);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment02.NAME, 6.552610106398286E-4, ops
-			.imagemoments().normalizedCentralMoment02(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment02.NAME,
+			6.552610106398286E-4, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment02.class, img)).getRealDouble(), 1e-3);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment20.NAME, 6.486010078361372E-4, ops
-			.imagemoments().normalizedCentralMoment20(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment20.NAME,
+			6.486010078361372E-4, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment20.class, img)).getRealDouble(), 1e-3);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment12.NAME, 2.969727272701925E-9, ops
-			.imagemoments().normalizedCentralMoment12(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment12.NAME,
+			2.969727272701925E-9, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment12.class, img)).getRealDouble(), 1e-3);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment21.NAME, -1.1728837022440002E-7, ops
-			.imagemoments().normalizedCentralMoment21(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment21.NAME,
+			-1.1728837022440002E-7, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment21.class, img)).getRealDouble(), 1e-3);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment30.NAME, 9.408242926327751E-8, ops
-			.imagemoments().normalizedCentralMoment30(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment30.NAME,
+			9.408242926327751E-8, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment30.class, img)).getRealDouble(), 1e-3);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment03.NAME, -2.22224218245127E-7, ops
-			.imagemoments().normalizedCentralMoment03(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment03.NAME,
+			-2.22224218245127E-7, ((DoubleType) ops.run(
+				DefaultNormalizedCentralMoment03.class, img)).getRealDouble(), 1e-3);
 	}
 
 	/**
@@ -137,20 +170,20 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testHuMoments() {
-		assertEquals(Ops.ImageMoments.HuMoment1.NAME, 0.001303862018475966, ops.imagemoments()
-			.huMoment1(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment2.NAME, 8.615401633994056e-11, ops.imagemoments()
-			.huMoment2(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment3.NAME, 2.406124306990366e-14, ops.imagemoments()
-			.huMoment3(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment4.NAME, 1.246879188175627e-13, ops.imagemoments()
-			.huMoment4(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment5.NAME, -6.610443880647384e-27, ops.imagemoments()
-			.huMoment5(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment6.NAME, 1.131019166855569e-18, ops.imagemoments()
-			.huMoment6(img).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment7.NAME, 1.716256940536518e-27, ops.imagemoments()
-			.huMoment7(img).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment1.NAME, 0.001303862018475966, ((DoubleType) ops
+			.run(DefaultHuMoment1.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment2.NAME, 8.615401633994056e-11, ((DoubleType) ops
+			.run(DefaultHuMoment2.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment3.NAME, 2.406124306990366e-14, ((DoubleType) ops
+			.run(DefaultHuMoment3.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment4.NAME, 1.246879188175627e-13, ((DoubleType) ops
+			.run(DefaultHuMoment4.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment5.NAME, -6.610443880647384e-27, ((DoubleType) ops
+			.run(DefaultHuMoment5.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment6.NAME, 1.131019166855569e-18, ((DoubleType) ops
+			.run(DefaultHuMoment6.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment7.NAME, 1.716256940536518e-27, ((DoubleType) ops
+			.run(DefaultHuMoment7.class, img)).getRealDouble(), 1e-3);
 	}
 
 }

--- a/src/test/java/net/imagej/ops/join/JoinTest.java
+++ b/src/test/java/net/imagej/ops/join/JoinTest.java
@@ -118,7 +118,8 @@ public class JoinTest extends AbstractOpTest {
 		final UnaryOutputFactory<Img<ByteType>, Img<ByteType>> outputFactory =
 			new ImgImgSameTypeFactory<>();
 
-		ops.join(out, in, computerOp, computerOp, outputFactory);
+		ops.run(DefaultJoin2Computers.class, out, in, computerOp, computerOp,
+			outputFactory);
 
 		// test
 		final Cursor<ByteType> c = out.cursor();
@@ -140,7 +141,7 @@ public class JoinTest extends AbstractOpTest {
 		final UnaryOutputFactory<Img<ByteType>, Img<ByteType>> outputFactory =
 			new ImgImgSameTypeFactory<>();
 
-		ops.join(out, in, computers, outputFactory);
+		ops.run(DefaultJoinNComputers.class, out, in, computers, outputFactory);
 
 		// test
 		final Cursor<ByteType> c = out.cursor();

--- a/src/test/java/net/imagej/ops/logic/AndConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/AndConditionTest.java
@@ -44,22 +44,25 @@ public class AndConditionTest extends AbstractOpTest {
 	@Test
 	public void test() {
 		@SuppressWarnings("unchecked")
-		final Condition<Double> c1 =
-			ops.op(ComparableGreaterThan.class, Double.class, 3.0);
+		final Condition<Double> c1 = ops.op(ComparableGreaterThan.class,
+			Double.class, 3.0);
 		@SuppressWarnings("unchecked")
-		final Condition<Double> c2 =
-			ops.op(ComparableLessThan.class, Double.class, 6.0);
+		final Condition<Double> c2 = ops.op(ComparableLessThan.class, Double.class,
+			6.0);
 
-		final BoolType result = ops.logic().and(5.0, c1, c2);
+		final BoolType result = (BoolType) ops.run(AndCondition.class, 5.0, c1, c2);
 		assertTrue(result.get());
 
-		final BoolType result2 = ops.logic().and(2.0, c1, c2);
+		final BoolType result2 = (BoolType) ops.run(AndCondition.class, 2.0, c1,
+			c2);
 		assertFalse(result2.get());
 
-		final BoolType result3 = ops.logic().and(7.0, c1, c2);
+		final BoolType result3 = (BoolType) ops.run(AndCondition.class, 7.0, c1,
+			c2);
 		assertFalse(result3.get());
 
-		final BoolType result4 = ops.logic().and(Double.NaN, c1, c2);
+		final BoolType result4 = (BoolType) ops.run(AndCondition.class, Double.NaN,
+			c1, c2);
 		assertFalse(result4.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/BooleanConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/BooleanConditionTest.java
@@ -43,10 +43,10 @@ public class BooleanConditionTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		final BoolType result = ops.logic().bool(true);
+		final BoolType result = (BoolType) ops.run(BooleanCondition.class, true);
 		assertTrue(result.get());
 
-		final BoolType result1 = ops.logic().bool(false);
+		final BoolType result1 = (BoolType) ops.run(BooleanCondition.class, false);
 		assertFalse(result1.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/ComparableGreaterThanOrEqualTest.java
+++ b/src/test/java/net/imagej/ops/logic/ComparableGreaterThanOrEqualTest.java
@@ -43,16 +43,16 @@ public class ComparableGreaterThanOrEqualTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		final BoolType result =
-			ops.logic().greaterThanOrEqual(5.0, (Comparable<Double>) 3.0);
+		final BoolType result = (BoolType) ops.run(
+			ComparableGreaterThanOrEqual.class, 5.0, (Comparable<Double>) 3.0);
 		assertTrue(result.get());
 
-		final BoolType result3 =
-			ops.logic().greaterThanOrEqual(5.0, (Comparable<Double>) 5.0);
+		final BoolType result3 = (BoolType) ops.run(
+			ComparableGreaterThanOrEqual.class, 5.0, (Comparable<Double>) 5.0);
 		assertTrue(result3.get());
 
-		final BoolType result2 =
-			ops.logic().greaterThanOrEqual(5.0, (Comparable<Double>) 6.0);
+		final BoolType result2 = (BoolType) ops.run(
+			ComparableGreaterThanOrEqual.class, 5.0, (Comparable<Double>) 6.0);
 		assertFalse(result2.get());
 	}
 }

--- a/src/test/java/net/imagej/ops/logic/ComparableGreaterThanTest.java
+++ b/src/test/java/net/imagej/ops/logic/ComparableGreaterThanTest.java
@@ -43,12 +43,12 @@ public class ComparableGreaterThanTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		final BoolType result =
-			ops.logic().greaterThan(5.0, (Comparable<Double>) 3.0);
+		final BoolType result = (BoolType) ops.run(ComparableGreaterThan.class, 5.0,
+			(Comparable<Double>) 3.0);
 		assertTrue(result.get());
 
-		final BoolType result2 =
-			ops.logic().greaterThan(5.0, (Comparable<Double>) 6.0);
+		final BoolType result2 = (BoolType) ops.run(ComparableGreaterThan.class,
+			5.0, (Comparable<Double>) 6.0);
 		assertFalse(result2.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/ComparableLessThanOrEqualTest.java
+++ b/src/test/java/net/imagej/ops/logic/ComparableLessThanOrEqualTest.java
@@ -43,16 +43,16 @@ public class ComparableLessThanOrEqualTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		final BoolType result =
-			ops.logic().lessThanOrEqual(5.0, (Comparable<Double>) 3.0);
+		final BoolType result = (BoolType) ops.run(ComparableLessThanOrEqual.class,
+			5.0, (Comparable<Double>) 3.0);
 		assertFalse(result.get());
 
-		final BoolType result2 =
-			ops.logic().lessThanOrEqual(5.0, (Comparable<Double>) 6.0);
+		final BoolType result2 = (BoolType) ops.run(ComparableLessThanOrEqual.class,
+			5.0, (Comparable<Double>) 6.0);
 		assertTrue(result2.get());
 
-		final BoolType result3 =
-			ops.logic().lessThanOrEqual(5.0, (Comparable<Double>) 5.0);
+		final BoolType result3 = (BoolType) ops.run(ComparableLessThanOrEqual.class,
+			5.0, (Comparable<Double>) 5.0);
 		assertTrue(result3.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/ComparableLessThanTest.java
+++ b/src/test/java/net/imagej/ops/logic/ComparableLessThanTest.java
@@ -43,11 +43,12 @@ public class ComparableLessThanTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		final BoolType result = ops.logic().lessThan(5.0, (Comparable<Double>) 3.0);
+		final BoolType result = (BoolType) ops.run(ComparableLessThan.class, 5.0,
+			(Comparable<Double>) 3.0);
 		assertFalse(result.get());
 
-		final BoolType result2 =
-			ops.logic().lessThan(5.0, (Comparable<Double>) 6.0);
+		final BoolType result2 = (BoolType) ops.run(ComparableLessThan.class, 5.0,
+			(Comparable<Double>) 6.0);
 		assertTrue(result2.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/ConditionalTest.java
+++ b/src/test/java/net/imagej/ops/logic/ConditionalTest.java
@@ -49,20 +49,20 @@ public class ConditionalTest extends AbstractOpTest {
 	public void testIf() {
 		final ByteType ifTrueVal = new ByteType((byte) 10);
 		final ByteType ifFalseVal = new ByteType((byte) 100);
-		assertEquals(10, ops.logic().conditional(new BoolType(true), ifTrueVal,
-			ifFalseVal).get());
-		assertEquals(100, ops.logic().conditional(new BoolType(false), ifTrueVal,
-			ifFalseVal).get());
+		assertEquals(10, ((ByteType) ops.run(If.class, new BoolType(true),
+			ifTrueVal, ifFalseVal)).get());
+		assertEquals(100, ((ByteType) ops.run(If.class, new BoolType(false),
+			ifTrueVal, ifFalseVal)).get());
 	}
 
 	@Test
 	public void testDefault() {
 		final ByteType out = new ByteType((byte) 10);
 		final ByteType defaultVal = new ByteType((byte) 100);
-		assertEquals(10, ops.logic().conditional(out, new BoolType(true),
-			defaultVal).get());
-		assertEquals(100, ops.logic().conditional(out, new BoolType(false),
-			defaultVal).get());
+		assertEquals(10, ((ByteType) ops.run(Default.class, out, new BoolType(true),
+			defaultVal)).get());
+		assertEquals(100, ((ByteType) ops.run(Default.class, out, new BoolType(
+			false), defaultVal)).get());
 	}
 
 }

--- a/src/test/java/net/imagej/ops/logic/IntersectionConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/IntersectionConditionTest.java
@@ -48,20 +48,22 @@ public class IntersectionConditionTest extends AbstractOpTest {
 		final ArrayList<Condition<Double>> condition = new ArrayList<>();
 
 		@SuppressWarnings("unchecked")
-		final Condition<Double> c1 =
-			ops.op(ComparableGreaterThan.class, Double.class, 3.0);
+		final Condition<Double> c1 = ops.op(ComparableGreaterThan.class,
+			Double.class, 3.0);
 		@SuppressWarnings("unchecked")
-		final Condition<Double> c2 =
-			ops.op(ComparableLessThan.class, Double.class, 6.0);
+		final Condition<Double> c2 = ops.op(ComparableLessThan.class, Double.class,
+			6.0);
 
 		condition.add(c1);
 		condition.add(c2);
 
-		final BoolType result = ops.logic().and(2.0, condition);
+		final BoolType result = (BoolType) ops.run(IntersectionCondition.class, 2.0,
+			condition);
 		assertFalse(result.get());
 
 		condition.add(0, c2);
-		final BoolType result1 = ops.logic().and(4.0, condition);
+		final BoolType result1 = (BoolType) ops.run(IntersectionCondition.class,
+			4.0, condition);
 		assertTrue(result1.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/NotConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/NotConditionTest.java
@@ -46,10 +46,10 @@ public class NotConditionTest extends AbstractOpTest {
 		final Condition<?> c1 =
 			ops.op(ComparableGreaterThan.class, Double.class, 3.0);
 
-		final BoolType result = ops.logic().not(5.0, c1);
+		final BoolType result = (BoolType) ops.run(NotCondition.class, 5.0, c1);
 		assertFalse(result.get());
 
-		final BoolType result2 = ops.logic().not(2.0, c1);
+		final BoolType result2 = (BoolType) ops.run(NotCondition.class, 2.0, c1);
 		assertTrue(result2.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/ObjectsEqualTest.java
+++ b/src/test/java/net/imagej/ops/logic/ObjectsEqualTest.java
@@ -43,10 +43,12 @@ public class ObjectsEqualTest extends AbstractOpTest {
 
 	@Test
 	public void test() {
-		final BoolType result = ops.logic().equal(5.0, (Object) 5.0);
+		final BoolType result = (BoolType) ops.run(ObjectsEqual.class, 5.0,
+			(Object) 5.0);
 		assertTrue(result.get());
 
-		final BoolType result1 = ops.logic().equal(5.0, (Object) 6.0);
+		final BoolType result1 = (BoolType) ops.run(ObjectsEqual.class, 5.0,
+			(Object) 6.0);
 		assertFalse(result1.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/OrConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/OrConditionTest.java
@@ -52,16 +52,16 @@ public class OrConditionTest extends AbstractOpTest {
 		final Condition<Object> c3 =
 			ops.op(ObjectsEqual.class, Double.class, 13.0);
 
-		final BoolType result = ops.logic().or(5.0, c1, c2);
+		final BoolType result = (BoolType) ops.run(OrCondition.class, 5.0, c1, c2);
 		assertTrue(result.get());
 
-		final BoolType result2 = ops.logic().or(2.0, c1, c2);
+		final BoolType result2 = (BoolType) ops.run(OrCondition.class, 2.0, c1, c2);
 		assertTrue(result2.get());
 
-		final BoolType result3 = ops.logic().or(7.0, c1, c2);
+		final BoolType result3 = (BoolType) ops.run(OrCondition.class, 7.0, c1, c2);
 		assertTrue(result3.get());
 
-		final BoolType result4 = ops.logic().or(2.0, c1, c3);
+		final BoolType result4 = (BoolType) ops.run(OrCondition.class, 2.0, c1, c3);
 		assertFalse(result4.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/UnionConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/UnionConditionTest.java
@@ -57,14 +57,14 @@ public class UnionConditionTest extends AbstractOpTest {
 		condition.add(c1);
 		condition.add(c2);
 
-		final BoolType result = ops.logic().or(2.0, condition);
+		final BoolType result = (BoolType) ops.run(UnionCondition.class, 2.0, condition);
 		assertFalse(result.get());
 
 		condition.add(0, c2);
-		final BoolType result1 = ops.logic().or(4.0, condition);
+		final BoolType result1 = (BoolType) ops.run(UnionCondition.class, 4.0, condition);
 		assertTrue(result1.get());
 
-		final BoolType result2 = ops.logic().or(7.0, condition);
+		final BoolType result2 = (BoolType) ops.run(UnionCondition.class, 7.0, condition);
 		assertTrue(result2.get());
 	}
 

--- a/src/test/java/net/imagej/ops/logic/XorConditionTest.java
+++ b/src/test/java/net/imagej/ops/logic/XorConditionTest.java
@@ -44,22 +44,25 @@ public class XorConditionTest extends AbstractOpTest {
 	@Test
 	public void test() {
 		@SuppressWarnings("unchecked")
-		final Condition<Double> c1 =
-			ops.op(ComparableGreaterThan.class, Double.class, 3.0);
+		final Condition<Double> c1 = ops.op(ComparableGreaterThan.class,
+			Double.class, 3.0);
 		@SuppressWarnings("unchecked")
-		final Condition<Double> c2 =
-			ops.op(ComparableLessThan.class, Double.class, 6.0);
+		final Condition<Double> c2 = ops.op(ComparableLessThan.class, Double.class,
+			6.0);
 
-		final BoolType result = ops.logic().xor(5.0, c1, c2);
+		final BoolType result = (BoolType) ops.run(XorCondition.class, 5.0, c1, c2);
 		assertFalse(result.get());
 
-		final BoolType result2 = ops.logic().xor(2.0, c1, c2);
+		final BoolType result2 = (BoolType) ops.run(XorCondition.class, 2.0, c1,
+			c2);
 		assertTrue(result2.get());
 
-		final BoolType result3 = ops.logic().xor(7.0, c1, c2);
+		final BoolType result3 = (BoolType) ops.run(XorCondition.class, 7.0, c1,
+			c2);
 		assertTrue(result3.get());
 
-		final BoolType result4 = ops.logic().xor(Double.NaN, c1, c2);
+		final BoolType result4 = (BoolType) ops.run(XorCondition.class, Double.NaN,
+			c1, c2);
 		assertTrue(result4.get());
 	}
 

--- a/src/test/java/net/imagej/ops/loop/LoopTest.java
+++ b/src/test/java/net/imagej/ops/loop/LoopTest.java
@@ -72,7 +72,7 @@ public class LoopTest extends AbstractOpTest {
 
 	@Test
 	public void testInplace() {
-		ops.loop(in, inplaceOp, numIterations);
+		ops.run(DefaultLoopInplace.class, in, inplaceOp, numIterations);
 
 		// test
 		final Cursor<ByteType> c = in.cursor();
@@ -84,7 +84,8 @@ public class LoopTest extends AbstractOpTest {
 
 	@Test
 	public void testFunctionalEven() {
-		ops.loop(out, in, computerOp, new ImgImgSameTypeFactory<ByteType>(), numIterations);
+		ops.run(DefaultLoopComputer.class, out, in, computerOp,
+			new ImgImgSameTypeFactory<ByteType>(), numIterations);
 
 		// test
 		final Cursor<ByteType> c = out.cursor();
@@ -96,8 +97,8 @@ public class LoopTest extends AbstractOpTest {
 
 	@Test
 	public void testFunctionalOdd() {
-		ops.loop(out, in, computerOp, new ImgImgSameTypeFactory<ByteType>(),
-			numIterations - 1);
+		ops.run(DefaultLoopComputer.class, out, in, computerOp,
+			new ImgImgSameTypeFactory<ByteType>(), numIterations - 1);
 
 		// test
 		final Cursor<ByteType> c = out.cursor();

--- a/src/test/java/net/imagej/ops/math/UnaryRealTypeMathTest.java
+++ b/src/test/java/net/imagej/ops/math/UnaryRealTypeMathTest.java
@@ -33,6 +33,57 @@ package net.imagej.ops.math;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.math.UnaryRealTypeMath.Abs;
+import net.imagej.ops.math.UnaryRealTypeMath.Arccos;
+import net.imagej.ops.math.UnaryRealTypeMath.Arccosh;
+import net.imagej.ops.math.UnaryRealTypeMath.Arccot;
+import net.imagej.ops.math.UnaryRealTypeMath.Arccoth;
+import net.imagej.ops.math.UnaryRealTypeMath.Arccsc;
+import net.imagej.ops.math.UnaryRealTypeMath.Arccsch;
+import net.imagej.ops.math.UnaryRealTypeMath.Arcsec;
+import net.imagej.ops.math.UnaryRealTypeMath.Arcsech;
+import net.imagej.ops.math.UnaryRealTypeMath.Arcsin;
+import net.imagej.ops.math.UnaryRealTypeMath.Arcsinh;
+import net.imagej.ops.math.UnaryRealTypeMath.Arctan;
+import net.imagej.ops.math.UnaryRealTypeMath.Arctanh;
+import net.imagej.ops.math.UnaryRealTypeMath.Ceil;
+import net.imagej.ops.math.UnaryRealTypeMath.Cos;
+import net.imagej.ops.math.UnaryRealTypeMath.Cosh;
+import net.imagej.ops.math.UnaryRealTypeMath.Cot;
+import net.imagej.ops.math.UnaryRealTypeMath.Coth;
+import net.imagej.ops.math.UnaryRealTypeMath.Csc;
+import net.imagej.ops.math.UnaryRealTypeMath.Csch;
+import net.imagej.ops.math.UnaryRealTypeMath.CubeRoot;
+import net.imagej.ops.math.UnaryRealTypeMath.Exp;
+import net.imagej.ops.math.UnaryRealTypeMath.ExpMinusOne;
+import net.imagej.ops.math.UnaryRealTypeMath.Floor;
+import net.imagej.ops.math.UnaryRealTypeMath.Invert;
+import net.imagej.ops.math.UnaryRealTypeMath.Log;
+import net.imagej.ops.math.UnaryRealTypeMath.Log10;
+import net.imagej.ops.math.UnaryRealTypeMath.Log2;
+import net.imagej.ops.math.UnaryRealTypeMath.LogOnePlusX;
+import net.imagej.ops.math.UnaryRealTypeMath.MaxConstant;
+import net.imagej.ops.math.UnaryRealTypeMath.MinConstant;
+import net.imagej.ops.math.UnaryRealTypeMath.NearestInt;
+import net.imagej.ops.math.UnaryRealTypeMath.Negate;
+import net.imagej.ops.math.UnaryRealTypeMath.PowerConstant;
+import net.imagej.ops.math.UnaryRealTypeMath.RandomGaussian;
+import net.imagej.ops.math.UnaryRealTypeMath.RandomUniform;
+import net.imagej.ops.math.UnaryRealTypeMath.Reciprocal;
+import net.imagej.ops.math.UnaryRealTypeMath.Round;
+import net.imagej.ops.math.UnaryRealTypeMath.Sec;
+import net.imagej.ops.math.UnaryRealTypeMath.Sech;
+import net.imagej.ops.math.UnaryRealTypeMath.Signum;
+import net.imagej.ops.math.UnaryRealTypeMath.Sin;
+import net.imagej.ops.math.UnaryRealTypeMath.Sinc;
+import net.imagej.ops.math.UnaryRealTypeMath.SincPi;
+import net.imagej.ops.math.UnaryRealTypeMath.Sinh;
+import net.imagej.ops.math.UnaryRealTypeMath.Sqr;
+import net.imagej.ops.math.UnaryRealTypeMath.Sqrt;
+import net.imagej.ops.math.UnaryRealTypeMath.Step;
+import net.imagej.ops.math.UnaryRealTypeMath.Tan;
+import net.imagej.ops.math.UnaryRealTypeMath.Tanh;
+import net.imagej.ops.math.UnaryRealTypeMath.Ulp;
 import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -56,7 +107,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	@Test
 	public void testAbs() {
 		final LongType in = new LongType(-LARGE_NUM);
-		final LongType out = ops.math().abs(in.createVariable(), in);
+		final LongType out = (LongType) ops.run(Abs.class, in.createVariable(), in);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -64,7 +115,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccos() {
 		final FloatType in = new FloatType(0.5f);
 		final DoubleType out = new DoubleType();
-		ops.math().arccos(out, in);
+		ops.run(Arccos.class, out, in);
 		assertEquals(out.get(), Math.acos(0.5), 0.0);
 	}
 
@@ -72,7 +123,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccosh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arccosh(out, in);
+		ops.run(Arccosh.class, out, in);
 		final double delta = Math.sqrt(1234567890.0 * 1234567890.0 - 1);
 		assertEquals(out.get(), Math.log(1234567890 + delta), 0.0);
 	}
@@ -81,7 +132,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccot() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arccot(out, in);
+		ops.run(Arccot.class, out, in);
 		assertEquals(out.get(), Math.atan(1.0 / 1234567890), 0.0);
 	}
 
@@ -89,7 +140,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccoth() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arccoth(out, in);
+		ops.run(Arccoth.class, out, in);
 		final double result = 0.5 * Math.log(1234567891.0 / 1234567889.0);
 		assertEquals(out.get(), result, 0.0);
 	}
@@ -98,7 +149,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccsch() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arccsch(out, in);
+		ops.run(Arccsch.class, out, in);
 		final double delta = Math.sqrt(1 + 1 / (1234567890.0 * 1234567890.0));
 		assertEquals(out.get(), Math.log(1 / 1234567890.0 + delta), 0.0);
 	}
@@ -107,7 +158,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArcsech() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arcsech(out, in);
+		ops.run(Arcsech.class, out, in);
 		final double numer = 1 + Math.sqrt(1 - 1234567890.0 * 1234567890.0);
 		assertEquals(out.get(), Math.log(numer / 1234567890.0), 0.0);
 	}
@@ -116,7 +167,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArcsin() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arcsin(out, in);
+		ops.run(Arcsin.class, out, in);
 		assertEquals(out.get(), Math.asin(1234567890), 0.0);
 	}
 
@@ -124,7 +175,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArcsinh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arcsinh(out, in);
+		ops.run(Arcsinh.class, out, in);
 		final double delta = Math.sqrt(1234567890.0 * 1234567890.0 + 1);
 		assertEquals(out.get(), Math.log(1234567890 + delta), 0.0);
 	}
@@ -133,7 +184,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArctan() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arctan(out, in);
+		ops.run(Arctan.class, out, in);
 		assertEquals(out.get(), Math.atan(1234567890), 0.0);
 	}
 
@@ -141,14 +192,15 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArctanh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().arctanh(out, in);
+		ops.run(Arctanh.class, out, in);
 		assertEquals(out.get(), 0.5 * Math.log(1234567891.0 / -1234567889.0), 0.0);
 	}
 
 	@Test
 	public void testCeil() {
 		final LongType in = new LongType(LARGE_NUM);
-		final LongType out = ops.math().ceil(in.createVariable(), in);
+		final LongType out = (LongType) ops.run(Ceil.class, in.createVariable(),
+			in);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -156,7 +208,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCos() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().cos(out, in);
+		ops.run(Cos.class, out, in);
 		assertEquals(out.get(), Math.cos(1234567890), 0.0);
 	}
 
@@ -164,7 +216,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCosh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().cosh(out, in);
+		ops.run(Cosh.class, out, in);
 		assertEquals(out.get(), Math.cosh(1234567890), 0.0);
 	}
 
@@ -172,7 +224,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCot() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().cot(out, in);
+		ops.run(Cot.class, out, in);
 		assertEquals(out.get(), 1 / Math.tan(1234567890), 0.0);
 	}
 
@@ -180,7 +232,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCoth() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().coth(out, in);
+		ops.run(Coth.class, out, in);
 		assertEquals(out.get(), 1 / Math.tanh(1234567890), 0.0);
 	}
 
@@ -188,7 +240,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCsc() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().csc(out, in);
+		ops.run(Csc.class, out, in);
 		assertEquals(out.get(), 1 / Math.sin(1234567890), 0.0);
 	}
 
@@ -196,7 +248,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCsch() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().csch(out, in);
+		ops.run(Csch.class, out, in);
 		assertEquals(out.get(), 1 / Math.sinh(1234567890), 0.0);
 	}
 
@@ -204,7 +256,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCubeRoot() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().cubeRoot(out, in);
+		ops.run(CubeRoot.class, out, in);
 		assertEquals(out.get(), Math.cbrt(1234567890), 0.0);
 	}
 
@@ -212,7 +264,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testExp() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().exp(out, in);
+		ops.run(Exp.class, out, in);
 		assertEquals(out.get(), Math.exp(1234567890), 0.0);
 	}
 
@@ -220,22 +272,23 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testExpMinusOne() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().expMinusOne(out, in);
+		ops.run(ExpMinusOne.class, out, in);
 		assertEquals(out.get(), Math.exp(1234567890) - 1, 0.0);
 	}
 
 	@Test
 	public void testFloor() {
 		final LongType in = new LongType(LARGE_NUM);
-		final LongType out = ops.math().floor(in.createVariable(), in);
+		final LongType out = (LongType) ops.run(Floor.class, in.createVariable(),
+			in);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
 	@Test
 	public void testInvert() {
 		final LongType in = new LongType(LARGE_NUM);
-		final LongType out = ops.math().invert(in.createVariable(), in,
-			9007199254740992.0, 9007199254740994.0);
+		final LongType out = (LongType) ops.run(Invert.class, in.createVariable(),
+			in, 9007199254740992.0, 9007199254740994.0);
 		assertEquals(out.get(), LARGE_NUM + 1);
 	}
 
@@ -243,7 +296,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLog() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().log(out, in);
+		ops.run(Log.class, out, in);
 		assertEquals(out.get(), Math.log(1234567890), 0.0);
 	}
 
@@ -251,7 +304,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLog10() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().log10(out, in);
+		ops.run(Log10.class, out, in);
 		assertEquals(out.get(), Math.log10(1234567890), 0.0);
 	}
 
@@ -259,7 +312,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLog2() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().log2(out, in);
+		ops.run(Log2.class, out, in);
 		assertEquals(out.get(), Math.log(1234567890) / Math.log(2), 0.0);
 	}
 
@@ -267,37 +320,39 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLogOnePlusX() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().logOnePlusX(out, in);
+		ops.run(LogOnePlusX.class, out, in);
 		assertEquals(out.get(), Math.log1p(1234567890), 0.0);
 	}
 
 	@Test
 	public void testMax() {
 		final LongType in = new LongType(LARGE_NUM);
-		final LongType out = ops.math().max(in.createVariable(), in, LARGE_NUM +
-			1.0);
+		final LongType out = (LongType) ops.run(MaxConstant.class, in
+			.createVariable(), in, LARGE_NUM + 1.0);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
 	@Test
 	public void testMin() {
 		final LongType in = new LongType(LARGE_NUM);
-		final LongType out = ops.math().min(in.createVariable(), in, LARGE_NUM -
-			1.0);
+		final LongType out = (LongType) ops.run(MinConstant.class, in
+			.createVariable(), in, LARGE_NUM - 1.0);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
 	@Test
 	public void testNearestInt() {
 		final LongType in = new LongType(LARGE_NUM);
-		final LongType out = ops.math().nearestInt(in.createVariable(), in);
+		final LongType out = (LongType) ops.run(NearestInt.class, in
+			.createVariable(), in);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
 	@Test
 	public void testNegate() {
 		final LongType in = new LongType(-LARGE_NUM);
-		final LongType out = ops.math().negate(in.createVariable(), in);
+		final LongType out = (LongType) ops.run(Negate.class, in.createVariable(),
+			in);
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -305,7 +360,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testPower() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().power(out, in, 1.5);
+		ops.run(PowerConstant.class, out, in, 1.5);
 		assertEquals(out.get(), Math.pow(1234567890, 1.5), 0.0);
 	}
 
@@ -313,24 +368,22 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testReciprocal() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().reciprocal(out, in, 0.0);
+		ops.run(Reciprocal.class, out, in, 0.0);
 		assertEquals(out.get(), 1.0 / 1234567890, 0.0);
 	}
 
-	// NB: This tests always fails until this issue
-	// https://github.com/imglib/imglib2/issues/110 has been addressed.
-//	@Test
-//	public void testRound() {
-//		final LongType in = new LongType(LARGE_NUM);
-//		final LongType out = ops.math().round(in.createVariable(), in);
-//		assertEquals(out.get(), LARGE_NUM - 1);
-//	}
+	@Test
+	public void testRound() {
+		final LongType in = new LongType(LARGE_NUM);
+		final LongType out = (LongType) ops.run(Round.class, in.createVariable(), in);
+		assertEquals(out.get(), LARGE_NUM - 1);
+	}
 
 	@Test
 	public void testSec() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sec(out, in);
+		ops.run(Sec.class, out, in);
 		assertEquals(out.get(), 1 / Math.cos(1234567890), 0.0);
 	}
 
@@ -338,7 +391,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSech() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sech(out, in);
+		ops.run(Sech.class, out, in);
 		assertEquals(out.get(), 1 / Math.cosh(1234567890), 0.0);
 	}
 
@@ -346,7 +399,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSignum() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().signum(out, in);
+		ops.run(Signum.class, out, in);
 		assertEquals(out.get(), 1.0, 0.0);
 	}
 
@@ -354,7 +407,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSin() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sin(out, in);
+		ops.run(Sin.class, out, in);
 		assertEquals(out.get(), Math.sin(1234567890), 0.0);
 	}
 
@@ -362,7 +415,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSinc() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sinc(out, in);
+		ops.run(Sinc.class, out, in);
 		assertEquals(out.get(), Math.sin(1234567890) / 1234567890, 0.0);
 	}
 
@@ -370,7 +423,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSincPi() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sincPi(out, in);
+		ops.run(SincPi.class, out, in);
 		final double PI = Math.PI;
 		assertEquals(out.get(), Math.sin(PI * 1234567890) / (PI * 1234567890), 0.0);
 	}
@@ -379,14 +432,14 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSinh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sinh(out, in);
+		ops.run(Sinh.class, out, in);
 		assertEquals(out.get(), Math.sinh(1234567890), 0.0);
 	}
 
 	@Test
 	public void testSqr() {
 		final LongType in = new LongType(94906267L);
-		final LongType out = ops.math().sqr(in.createVariable(), in);
+		final LongType out = (LongType) ops.run(Sqr.class, in.createVariable(), in);
 		// NB: for any odd number greater than LARGE_NUM - 1, its double
 		// representation is not exact.
 		assertEquals(out.get(), 94906267L * 94906267L - 1);
@@ -396,7 +449,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSqrt() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().sqrt(out, in);
+		ops.run(Sqrt.class, out, in);
 		assertEquals(out.get(), Math.sqrt(1234567890), 0.0);
 	}
 
@@ -404,7 +457,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testStep() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().step(out, in);
+		ops.run(Step.class, out, in);
 		assertEquals(out.get(), 1.0, 0.0);
 	}
 
@@ -412,7 +465,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testTan() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().tan(out, in);
+		ops.run(Tan.class, out, in);
 		assertEquals(out.get(), Math.tan(1234567890), 0.0);
 	}
 
@@ -420,7 +473,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testTanh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		ops.math().tanh(out, in);
+		ops.run(Tanh.class, out, in);
 		assertEquals(out.get(), Math.tanh(1234567890), 0.0);
 	}
 
@@ -428,7 +481,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testUlp() {
 		final LongType in = new LongType(LARGE_NUM);
 		final DoubleType out = new DoubleType();
-		ops.math().ulp(out, in);
+		ops.run(Ulp.class, out, in);
 		assertEquals(out.get(), 2.0, 0.0);
 	}
 
@@ -489,19 +542,22 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 
 	private void assertArccsc(final double i, final double o) {
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out = ops.math().arccsc(in.createVariable(), in);
+		final DoubleType out = (DoubleType) ops.run(Arccsc.class, in
+			.createVariable(), in);
 		assertEquals(o, out.get(), 1e-15);
 	}
 
 	private void assertArcsec(final double i, final double o) {
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out = ops.math().arcsec(in.createVariable(), in);
+		final DoubleType out = (DoubleType) ops.run(Arcsec.class, in
+			.createVariable(), in);
 		assertEquals(o, out.get(), 1e-15);
 	}
 
 	private void assertRandomGaussian(final double i, final double o) {
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out = ops.math().randomGaussian(in.createVariable(), in);
+		final DoubleType out = (DoubleType) ops.run(RandomGaussian.class, in
+			.createVariable(), in);
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -509,8 +565,8 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 		final long seed)
 	{
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out = ops.math().randomGaussian(in.createVariable(), in,
-			seed);
+		final DoubleType out = (DoubleType) ops.run(RandomGaussian.class, in
+			.createVariable(), in, seed);
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -532,7 +588,8 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 
 	private void assertRandomUniform(final double i, final double o) {
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out = ops.math().randomUniform(in.createVariable(), in);
+		final DoubleType out = (DoubleType) ops.run(RandomUniform.class, in
+			.createVariable(), in);
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -540,8 +597,8 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 		final long seed)
 	{
 		final DoubleType in = new DoubleType(i);
-		final DoubleType out = ops.math().randomUniform(in.createVariable(), in,
-			seed);
+		final DoubleType out = (DoubleType) ops.run(RandomUniform.class, in
+			.createVariable(), in, seed);
 		assertEquals(o, out.get(), 0);
 	}
 

--- a/src/test/java/net/imagej/ops/stats/MeanTest.java
+++ b/src/test/java/net/imagej/ops/stats/MeanTest.java
@@ -51,7 +51,7 @@ public class MeanTest extends AbstractOpTest {
 	public void testMean() {
 		final Img<ByteType> image = generateByteArrayTestImg(true, 40, 50);
 		final DoubleType mean = new DoubleType();
-		ops.stats().mean(mean, image);
+		ops.run(IterableMean.class, mean, image);
 
 		assertEquals(1.0 / 15.625, mean.get(), 0.0);
 
@@ -63,7 +63,7 @@ public class MeanTest extends AbstractOpTest {
 			c.get().setReal(100.0);
 		}
 
-		ops.stats().mean(mean, image);
+		ops.run(IterableMean.class, mean, image);
 
 		// the mean should be 100
 		assertEquals(100.0, mean.get(), 0.0);

--- a/src/test/java/net/imagej/ops/stats/StatisticsTest.java
+++ b/src/test/java/net/imagej/ops/stats/StatisticsTest.java
@@ -98,12 +98,12 @@ public class StatisticsTest extends AbstractOpTest {
 		// calculate min using ops
 		FloatType min2 = new FloatType();
 		min2.setReal(Float.MAX_VALUE);
-		ops.stats().min(min2, img);
+		ops.run(IterableMin.class, min2, img);
 
 		// calculate max using ops
 		FloatType max2 = new FloatType();
 		max2.setReal(Float.MIN_VALUE);
-		ops.stats().max(max2, img);
+		ops.run(IterableMax.class, max2, img);
 
 		// check to see if everything matches
 		Assert.assertEquals(min1, min2.getRealFloat(), delta);
@@ -134,14 +134,14 @@ public class StatisticsTest extends AbstractOpTest {
 
 		// calculate mean using ops
 		final DoubleType mean2 = new DoubleType();
-		ops.stats().mean(mean2, img);
+		ops.run(IterableMean.class, mean2, img);
 
 		// check that the ratio between mean1 and mean2 is 1.0
 		Assert.assertEquals(1.0, mean1 / mean2.getRealFloat(), delta);
 
 		// calculate standard deviation using ops
 		final DoubleType std2 = new DoubleType();
-		ops.stats().stdDev(std2, img);
+		ops.run(IterableStandardDeviation.class, std2, img);
 
 		// check that the ratio between std1 and std2 is 1.0
 		Assert.assertEquals(1.0, std1 / std2.getRealFloat(), delta);
@@ -149,125 +149,138 @@ public class StatisticsTest extends AbstractOpTest {
 
 	@Test
 	public void testMax() {
-		Assert.assertEquals("Max", 254d, ops.stats().max(randomlyFilledImg)
-			.getRealDouble(), 0.00001d);
+		Assert.assertEquals("Max", 254d, ((DoubleType) ops.run(IterableMax.class,
+			randomlyFilledImg)).getRealDouble(), 0.00001d);
 
 		// NB: should work with negative numbers
-		Assert.assertEquals("Max", -1.0, ops.stats().max(ArrayImgs.bytes(new byte[] {
-			-1, -2, -4, -3 }, 2, 2)).getRealDouble(), 0.0);
+		Assert.assertEquals("Max", -1.0, ((DoubleType) ops.run(IterableMax.class,
+			ArrayImgs.bytes(new byte[] { -1, -2, -4, -3 }, 2, 2))).getRealDouble(),
+			0.0);
 	}
 
 	@Test
 	public void testMean() {
-		Assert.assertEquals("Mean", 127.7534, ops.stats().mean(randomlyFilledImg)
-			.getRealDouble(), 0.00001d);
+		Assert.assertEquals("Mean", 127.7534, ((DoubleType) ops.run(
+			IterableMean.class, randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testMedian() {
-		Assert.assertEquals("Median", 128d, ops.stats().median(randomlyFilledImg)
-			.getRealDouble(), 0.00001d);
+		Assert.assertEquals("Median", 128d, ((DoubleType) ops.run(
+			DefaultMedian.class, randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testMin() {
-		Assert.assertEquals("Min", 0, ops.stats().min(randomlyFilledImg)
-			.getRealDouble(), 0.00001d);
+		Assert.assertEquals("Min", 0, ((DoubleType) ops.run(IterableMin.class,
+			randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testStdDev() {
-		Assert.assertEquals("StdDev", 73.7460374274008, ops.stats().stdDev(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("StdDev", 73.7460374274008, ((DoubleType) ops.run(
+			IterableStandardDeviation.class, randomlyFilledImg)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testSum() {
-		Assert.assertEquals("Sum", 1277534.0, ops.stats().sum(randomlyFilledImg)
-			.getRealDouble(), 0.00001d);
+		Assert.assertEquals("Sum", 1277534.0, ((DoubleType) ops.run(
+			DefaultSum.class, randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testVariance() {
-		Assert.assertEquals("Variance", 5438.4780362436, ops.stats().variance(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Variance", 5438.4780362436, ((DoubleType) ops.run(
+			DefaultVariance.class, randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testGeometricMean() {
-		Assert.assertEquals("Geometric Mean", 0, ops.stats().geometricMean(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Geometric Mean", 0, ((DoubleType) ops.run(
+			IterableGeometricMean.class, randomlyFilledImg)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testHarmonicMean() {
-		Assert.assertEquals("Harmonic Mean", 0, ops.stats().harmonicMean(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Harmonic Mean", 0, ((DoubleType) ops.run(
+			IterableHarmonicMean.class, randomlyFilledImg)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testKurtosis() {
-		Assert.assertEquals("Kurtosis", 1.794289587623922, ops.stats().kurtosis(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Kurtosis", 1.794289587623922, ((DoubleType) ops.run(
+			DefaultKurtosis.class, randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testMoment1AboutMean() {
-		Assert.assertEquals("Moment 1 About Mean", 0, ops.stats().moment1AboutMean(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Moment 1 About Mean", 0, ((DoubleType) ops.run(
+			DefaultMoment1AboutMean.class, randomlyFilledImg)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testMoment2AboutMean() {
-		Assert.assertEquals("Moment 2 About Mean", 5437.93418843998, ops.stats()
-			.moment2AboutMean(randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Moment 2 About Mean", 5437.93418843998,
+			((DoubleType) ops.run(DefaultMoment2AboutMean.class, randomlyFilledImg))
+				.getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testMoment3AboutMean() {
-		Assert.assertEquals("Moment 3 About Mean", -507.810691261427, ops.stats()
-			.moment3AboutMean(randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Moment 3 About Mean", -507.810691261427,
+			((DoubleType) ops.run(DefaultMoment3AboutMean.class, randomlyFilledImg))
+				.getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testMoment4AboutMean() {
-		Assert.assertEquals("Moment 4 About Mean", 53069780.9168701, ops.stats()
-			.moment4AboutMean(randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Moment 4 About Mean", 53069780.9168701,
+			((DoubleType) ops.run(DefaultMoment4AboutMean.class, randomlyFilledImg))
+				.getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testPercentile() {
-		Assert.assertEquals("50-th Percentile", 128d, ops.stats().percentile(randomlyFilledImg, 50d)
-				.getRealDouble(), 0.00001d);
+		Assert.assertEquals("50-th Percentile", 128d, ((DoubleType) ops.run(
+			DefaultPercentile.class, randomlyFilledImg, 50d)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testQuantile() {
-		Assert.assertEquals("0.5-th Quantile", 128d, ops.stats().quantile(randomlyFilledImg, 0.5d)
-				.getRealDouble(), 0.00001d);
+		Assert.assertEquals("0.5-th Quantile", 128d, ((DoubleType) ops.run(
+			DefaultQuantile.class, randomlyFilledImg, 0.5d)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testSkewness() {
-		Assert.assertEquals("Skewness", -0.0012661517853476312, ops.stats()
-			.skewness(randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Skewness", -0.0012661517853476312, ((DoubleType) ops
+			.run(DefaultSkewness.class, randomlyFilledImg)).getRealDouble(),
+			0.00001d);
 	}
 
 	@Test
 	public void testSumOfInverses() {
-		Assert.assertEquals("Sum Of Inverses", Double.POSITIVE_INFINITY, ops.stats()
-			.sumOfInverses(randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Sum Of Inverses", Double.POSITIVE_INFINITY,
+			((DoubleType) ops.run(DefaultSumOfInverses.class, randomlyFilledImg))
+				.getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testSumOfLogs() {
-		Assert.assertEquals("Sum Of Logs", Double.NEGATIVE_INFINITY, ops.stats()
-			.sumOfLogs(randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Sum Of Logs", Double.NEGATIVE_INFINITY,
+			((DoubleType) ops.run(DefaultSumOfLogs.class, randomlyFilledImg))
+				.getRealDouble(), 0.00001d);
 	}
 
 	@Test
 	public void testSumOfSquares() {
-		Assert.assertEquals("Sum Of Squares", 217588654, ops.stats().sumOfSquares(
-			randomlyFilledImg).getRealDouble(), 0.00001d);
+		Assert.assertEquals("Sum Of Squares", 217588654, ((DoubleType) ops.run(
+			DefaultSumOfSquares.class, randomlyFilledImg)).getRealDouble(), 0.00001d);
 	}
 }

--- a/src/test/java/net/imagej/ops/threshold/apply/ApplyManualThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/ApplyManualThresholdTest.java
@@ -49,7 +49,7 @@ public class ApplyManualThresholdTest extends AbstractThresholdTest {
 	public void testApplyThreshold() throws IncompatibleTypeException {
 		final Img<BitType> out = bitmap();
 		final UnsignedShortType threshold = new UnsignedShortType(30000);
-		ops.threshold().apply(out, in, threshold);
+		ops.run(ApplyManualThreshold.class, out, in, threshold);
 		assertCount(out, 54);
 	}
 

--- a/src/test/templates/net/imagej/ops/convert/ConvertImagesTest.vm
+++ b/src/test/templates/net/imagej/ops/convert/ConvertImagesTest.vm
@@ -77,7 +77,9 @@ public class ConvertImagesTest extends AbstractOpTest {
 	@Test
 	public <C extends ComplexType<C>> void test$opType() {
 		final Img<DoubleType> in = ArrayImgs.doubles(VALUES, DIMS);
-		final Img<$imglibType> out = ops.convert().$methodName(in);
+		@SuppressWarnings("unchecked")
+		final Img<$imglibType> out = (Img<$imglibType>) ops.run(ConvertImages.${op.name}.class,
+			in);
 
 		final Cursor<DoubleType> ci = in.cursor();
 		final Cursor<$imglibType> co = out.cursor();

--- a/src/test/templates/net/imagej/ops/convert/TestConvertType.vm
+++ b/src/test/templates/net/imagej/ops/convert/TestConvertType.vm
@@ -68,7 +68,6 @@ public class TestConvertType extends AbstractOpTest{
 #end
 
 #foreach ($toType in $types)
-#set ($className = "ConvertTypes.ComplexTo$toType.op")
 #set ($methodName = "Types.$toType.outMethod")
 #set ($imgLibType = "$toType.imglibT" + "Type")
 #if ($toType.op.equals("Cfloat32"))
@@ -79,6 +78,11 @@ public class TestConvertType extends AbstractOpTest{
 #set ($getI = "getImaginaryDouble()")
 #end
 #foreach ($fromType in $types)
+#if ($fromType.built.contains("float") || $toType.built.contains("float"))
+#set ($className = "ConvertTypes.ComplexTo$toType.op")
+#else
+#set ($className = "ConvertTypes.IntegerTo$toType.op")
+#end
 #set ($imgLibType2 = "$fromType.imglibT" + "Type")
 #set ($first = "true")
 	/** Tests {@link $className}. */
@@ -88,7 +92,7 @@ public class TestConvertType extends AbstractOpTest{
 #foreach ($value in ${fromType.values})
 #if ($first.equals("true"))
 		final $imgLibType2 b = new $imgLibType2($value.v);
-		final Object result = ops.convert().${toType.built}(b);
+		final Object result = ops.run(${className}.class, b);
 		assertTrue(result instanceof $imgLibType);
 #if($toType.op.contains("C"))
 		assertEquals($methodName($value.r), (($imgLibType) result).$getR, 0);
@@ -104,16 +108,16 @@ public class TestConvertType extends AbstractOpTest{
 #else
 		b.set($value.v);
 #if($toType.op.contains("C"))
-		assertEquals($methodName($value.r), ops.convert().${toType.built}(b).$getR, 0);
-		assertEquals($methodName($value.i), ops.convert().${toType.built}(b).$getI, 0);
+		assertEquals($methodName($value.r), (($imgLibType) ops.run(${className}.class, b)).$getR, 0);
+		assertEquals($methodName($value.i), (($imgLibType) ops.run(${className}.class, b)).$getI, 0);
 #elseif ($toType.op.contains("Float"))
-		assertEquals($methodName($value.r), ops.convert().${toType.built}(b).get(), 0);
+		assertEquals($methodName($value.r), (($imgLibType) ops.run(${className}.class, b)).get(), 0);
 #elseif ($toType.op.equals("Uint64"))
-		assertEquals($methodName($value.r), ops.convert().${toType.built}(b).getBigInteger());
+		assertEquals($methodName($value.r), (($imgLibType) ops.run(${className}.class, b)).getBigInteger());
 #elseif ($toType.op.equals("Uint128") && $fromType.op.equals("Uint64") && $value.s)
-		assertEquals(Types.uint64Uint128($value.r), ops.convert().${toType.built}(b).getBigInteger());
+		assertEquals(Types.uint64Uint128($value.r), (($imgLibType) ops.run(${className}.class, b)).getBigInteger());
 #else
-		assertEquals($methodName($value.r), ops.convert().${toType.built}(b).get());
+		assertEquals($methodName($value.r), (($imgLibType) ops.run(${className}.class, b)).get());
 #end
 #end
 

--- a/src/test/templates/net/imagej/ops/features/haralick/HaralickFeaturesTest.vm
+++ b/src/test/templates/net/imagej/ops/features/haralick/HaralickFeaturesTest.vm
@@ -38,6 +38,7 @@ import org.junit.Test;
 import net.imagej.ops.features.AbstractFeatureTest;
 import net.imagej.ops.image.cooccurrenceMatrix.MatrixOrientation2D;
 import net.imagej.ops.image.cooccurrenceMatrix.MatrixOrientation3D;
+import net.imglib2.type.numeric.real.DoubleType;
 
 /**
  * Testing implementations of {@link HaralickFeature}
@@ -50,22 +51,22 @@ public class HaralickFeaturesTest extends AbstractFeatureTest {
 	@Test
 	public void test${op.iface}() {
 		// empty
-		assertEquals("${op.label} empty 2d", ${op.empty2d}, this.ops.haralick().${op.label}(this.empty, 8, 1,
-			MatrixOrientation2D.HORIZONTAL).get(), SMALL_DELTA);
-		assertEquals("${op.label} empty 3d", ${op.empty3d}, this.ops.haralick().${op.label}(this.empty3d, 8, 1,
-			MatrixOrientation3D.HORIZONTAL_DIAGONAL).get(), SMALL_DELTA);
+		assertEquals("${op.label} empty 2d", ${op.empty2d}, ((DoubleType) this.ops.run(Default${op.iface}.class, this.empty, 8, 1,
+			MatrixOrientation2D.HORIZONTAL)).get(), SMALL_DELTA);
+		assertEquals("${op.label} empty 3d", ${op.empty3d}, ((DoubleType) this.ops.run(Default${op.iface}.class, this.empty3d, 8, 1,
+			MatrixOrientation3D.HORIZONTAL_DIAGONAL)).get(), SMALL_DELTA);
 
 		// constant
-		assertEquals("${op.label} constant 2d", ${op.constant2d}, this.ops.haralick().${op.label}(this.constant,
-			8, 1, MatrixOrientation2D.HORIZONTAL).get(), SMALL_DELTA);
-		assertEquals("${op.label} constant 3d", ${op.constant3d}, this.ops.haralick().${op.label}(this.constant3d,
-			8, 1, MatrixOrientation3D.HORIZONTAL_DIAGONAL).get(), SMALL_DELTA);
+		assertEquals("${op.label} constant 2d", ${op.constant2d}, ((DoubleType) this.ops.run(Default${op.iface}.class, this.constant,
+			8, 1, MatrixOrientation2D.HORIZONTAL)).get(), SMALL_DELTA);
+		assertEquals("${op.label} constant 3d", ${op.constant3d}, ((DoubleType) this.ops.run(Default${op.iface}.class, this.constant3d,
+			8, 1, MatrixOrientation3D.HORIZONTAL_DIAGONAL)).get(), SMALL_DELTA);
 
 		// random
-		assertEquals("${op.label} random 2d", ${op.random2d}, this.ops.haralick().${op.label}(
-			this.random, 8, 1, MatrixOrientation2D.HORIZONTAL).get(), SMALL_DELTA);
-		assertEquals("${op.label} random 3d", ${op.random3d}, this.ops.haralick().${op.label}(
-			this.random3d, 8, 1, MatrixOrientation3D.HORIZONTAL_DIAGONAL).get(),
+		assertEquals("${op.label} random 2d", ${op.random2d}, ((DoubleType) this.ops.run(Default${op.iface}.class, 
+			this.random, 8, 1, MatrixOrientation2D.HORIZONTAL)).get(), SMALL_DELTA);
+		assertEquals("${op.label} random 3d", ${op.random3d}, ((DoubleType) this.ops.run(Default${op.iface}.class, 
+			this.random3d, 8, 1, MatrixOrientation3D.HORIZONTAL_DIAGONAL)).get(),
 			SMALL_DELTA);
 	}
 #end

--- a/src/test/templates/net/imagej/ops/math/NumericTypeBinaryMathTest.vm
+++ b/src/test/templates/net/imagej/ops/math/NumericTypeBinaryMathTest.vm
@@ -73,7 +73,7 @@ public class NumericTypeBinaryMathTest extends AbstractOpTest {
 		final $type expected = new ${type}();
 		expected.set(a);
 		expected.${test.function}(b);
-		final Object result = ops.math().$methodName(a, b);
+		final Object result = ops.run(${className}.class, a, b);
 		final $type actual = ($type) result;
 ## NB: Compare values, until all types implement equals properly.
 ##		assertEquals(expected, actual);

--- a/src/test/templates/net/imagej/ops/math/PrimitiveMathTest.vm
+++ b/src/test/templates/net/imagej/ops/math/PrimitiveMathTest.vm
@@ -51,7 +51,7 @@ public class PrimitiveMathTest extends AbstractOpTest {
 	/** Tests {@link PrimitiveMath.$className}. */
 	@Test
 	public void test$className() {
-		final Object result = ops.math().$methodName($test.args);
+		final Object result = ops.run(PrimitiveMath.${className}.class, $test.args);
 		assertTrue(result instanceof $type.name);
 		final $type.primitive value = ($type.name) result;
 #if ($type.delta)

--- a/src/test/templates/net/imagej/ops/threshold/ComputeThresholdTest.vm
+++ b/src/test/templates/net/imagej/ops/threshold/ComputeThresholdTest.vm
@@ -40,11 +40,12 @@ import org.junit.Test;
  */
 public class ComputeThresholdTest extends AbstractThresholdTest {
 #foreach ($method in $methods)
+#set ($className = "net.imagej.ops.threshold.${method.name}.Compute${method.iface}Threshold") 
 
-	/** Tests {@link net.imagej.ops.threshold.${method.name}.Compute${method.iface}Threshold}. */
+	/** Tests {@link $className}. */
 	@Test
 	public void test${method.iface}() {
-		final Object actual = ops.threshold().${method.name}(histogram());
+		final Object actual = ops.run(${className}.class, histogram());
 		assertThreshold($method.expected, actual);
 	}
 #end


### PR DESCRIPTION
Since the OpMethods in the namespaces no longer match the exact op class as indicated in its annotation, testing should not rely on OpMethods, except the method is called as a helper and is not intended to be tested, i.e. when using ops.stats().sum() to calculate the sum of a filtered image, or there is a dedicated test for checking if the OpMethods are working correctly.