### PR TITLE
Multipass matching

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpMatchingService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpMatchingService.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import net.imagej.ops.OpCandidate.StatusCode;
 
@@ -126,23 +127,21 @@ public class DefaultOpMatchingService extends AbstractService implements
 	public List<OpCandidate<?>> filterMatches(
 		final List<OpCandidate<?>> candidates)
 	{
-		final ArrayList<OpCandidate<?>> matches = new ArrayList<>();
+		final List<OpCandidate<?>> validCandidates = validCandidates(candidates);
 
-		double priority = Double.NaN;
-		for (final OpCandidate<?> candidate : candidates) {
-			final ModuleInfo info = candidate.cInfo();
-			final double p = info.getPriority();
-			if (p != priority && !matches.isEmpty()) {
-				// NB: Lower priority was reached; stop looking for any more matches.
-				break;
-			}
-			priority = p;
+		List<OpCandidate<?>> matches;
 
-			final Module module = match(candidate);
+		matches = filterMatches(validCandidates, (cand) -> typesPerfectMatch(cand));
+		if (!matches.isEmpty()) return matches;
 
-			if (module != null) matches.add(candidate);
-		}
+		matches = castMatches(validCandidates);
+		if (!matches.isEmpty()) return matches;
 
+		// NB: Not implemented yet
+//		matches = filterMatches(validCandidates, (cand) -> losslessMatch(cand));
+//		if (!matches.isEmpty()) return matches;
+
+		matches = filterMatches(validCandidates, (cand) -> typesMatch(cand));
 		return matches;
 	}
 
@@ -246,6 +245,165 @@ public class DefaultOpMatchingService extends AbstractService implements
 	}
 
 	/**
+	 * Gets a list of valid candidates injected with padded arguments.
+	 * <p>
+	 * Helper method of {@link #filterMatches}.
+	 * </p>
+	 * 
+	 * @param candidates list of candidates
+	 * @return a list of valid candidates with arguments injected
+	 */
+	private List<OpCandidate<?>> validCandidates(
+		final List<OpCandidate<?>> candidates)
+	{
+		final ArrayList<OpCandidate<?>> validCandidates = new ArrayList<>();
+		for (final OpCandidate<?> candidate : candidates) {
+			if (!valid(candidate) || !outputsMatch(candidate)) continue;
+			final Object[] args = padArgs(candidate);
+			if (args == null) continue;
+			candidate.setArgs(args);
+			if (missArgs(candidate)) continue;
+			validCandidates.add(candidate);
+		}
+		return validCandidates;
+	}
+
+	/**
+	 * Determines if the candidate arguments match with lossless conversion. Needs
+	 * support from the conversion in the future.
+	 */
+	@SuppressWarnings("unused")
+	private boolean losslessMatch(final OpCandidate<?> candidate) {
+		// NB: Not yet implemented
+		return false;
+	}
+
+	/**
+	 * Filters out candidates that pass the given filter.
+	 * <p>
+	 * Helper method of {@link #filterMatches(List)}.
+	 * </p>
+	 */
+	private List<OpCandidate<?>> filterMatches(
+		final List<OpCandidate<?>> candidates,
+		final Predicate<OpCandidate<?>> filter)
+	{
+		final ArrayList<OpCandidate<?>> matches = new ArrayList<>();
+		double priority = Double.NaN;
+		for (final OpCandidate<?> candidate : candidates) {
+			final ModuleInfo info = candidate.cInfo();
+			final double p = info.getPriority();
+			if (p != priority && !matches.isEmpty()) {
+				// NB: Lower priority was reached; stop looking for any more matches.
+				break;
+			}
+			priority = p;
+
+			if (filter.test(candidate) && moduleConforms(candidate)) matches.add(
+				candidate);
+		}
+		return matches;
+	}
+
+	/**
+	 * Determines if the candidate has some arguments missing.
+	 * <p>
+	 * Helper method of {@link #filterMatches(List)}.
+	 * </p>
+	 */
+	private boolean missArgs(final OpCandidate<?> candidate) {
+		int i = 0;
+		for (final ModuleItem<?> item : candidate.cInfo().inputs()) {
+			if (candidate.getArgs()[i++] == null && item.isRequired()) {
+				candidate.setStatus(StatusCode.REQUIRED_ARG_IS_NULL, null, item);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the arguments of the candidate perfectly match with the
+	 * reference.
+	 * <p>
+	 * Helper method of {@link #filterMatches(List)}.
+	 * </p>
+	 */
+	private boolean typesPerfectMatch(final OpCandidate<?> candidate) {
+		int i = 0;
+		final Object[] args = candidate.getArgs();
+		for (final ModuleItem<?> item : candidate.cInfo().inputs()) {
+			if (args[i] != null) {
+				final Class<?> typeClass = OpMatchingUtil.getClass(item.getType());
+				final Class<?> argClass = OpMatchingUtil.getClass(args[i]);
+				if (!typeClass.equals(argClass)) return false;
+			}
+			i++;
+		}
+		return true;
+	}
+
+	/**
+	 * Extracts a list of candidates that requires casting to match with the
+	 * reference.
+	 * <p>
+	 * Helper method of {@link #filterMatches(List)}.
+	 * </p>
+	 */
+	private List<OpCandidate<?>> castMatches(
+		final List<OpCandidate<?>> candidates)
+	{
+		final ArrayList<OpCandidate<?>> matches = new ArrayList<>();
+		int minLevels = Integer.MAX_VALUE;
+		double priority = Double.NaN;
+		for (final OpCandidate<?> candidate : candidates) {
+
+			final ModuleInfo info = candidate.cInfo();
+			final double p = info.getPriority();
+			if (p != priority && !matches.isEmpty()) {
+				// NB: Lower priority was reached; stop looking for any more matches.
+				break;
+			}
+			priority = p;
+
+			final int nextLevels = findCastLevels(candidate);
+			if (nextLevels < 0 || nextLevels > minLevels) continue;
+
+			if (!moduleConforms(candidate)) continue;
+
+			if (nextLevels < minLevels) {
+				matches.clear();
+				minLevels = nextLevels;
+			}
+			matches.add(candidate);
+		}
+		return matches;
+	}
+
+	/**
+	 * Find the total levels of casting needed for the candidate to match with the
+	 * reference.
+	 * <p>
+	 * Helper method of {@link #filterMatches(List)}.
+	 * </p>
+	 */
+	private <OP extends Op> int findCastLevels(final OpCandidate<OP> candidate) {
+		int level = 0, i = 0;
+		final Object[] args = candidate.getArgs();
+		for (final ModuleItem<?> item : candidate.cInfo().inputs()) {
+			final Class<?> type = item.getType();
+			if (args[i] != null) {
+				final int currLevel = OpMatchingUtil.findCastLevels(type, OpMatchingUtil
+					.getClass(args[i]));
+				if (currLevel < 0) return -1;
+				level += currLevel;
+			}
+			i++;
+		}
+		return level;
+	}
+
+	/**
 	 * Extracts and returns the single match from the given list of matches,
 	 * executing the linked {@link Module}'s initializer if applicable. If there
 	 * is not exactly one match, an {@link IllegalArgumentException} is thrown
@@ -319,6 +477,33 @@ public class DefaultOpMatchingService extends AbstractService implements
 				return false;
 			}
 		}
+		return true;
+	}
+
+	/**
+	 * Verifies that the given candidate's module conforms.
+	 * <p>
+	 * Helper method of {@link #filterMatches(List)}.
+	 * </p>
+	 */
+	private <OP extends Op> boolean moduleConforms(
+		final OpCandidate<OP> candidate)
+	{
+		// create module and assign the inputs
+		final Module module = createModule(candidate, candidate.getArgs());
+		candidate.setModule(module);
+
+		// make sure the op itself is happy with these arguments
+		final Object op = module.getDelegateObject();
+		if (op instanceof Contingent) {
+			final Contingent c = (Contingent) op;
+			if (!c.conforms()) {
+				candidate.setStatus(StatusCode.DOES_NOT_CONFORM);
+				return false;
+			}
+		}
+
+		// found a match!
 		return true;
 	}
 

--- a/src/main/java/net/imagej/ops/DefaultOpMatchingService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpMatchingService.java
@@ -108,8 +108,8 @@ public class DefaultOpMatchingService extends AbstractService implements
 	}
 
 	@Override
-	public List<OpCandidate<?>> findCandidates(
-		final OpEnvironment ops, final List<OpRef<?>> refs)
+	public List<OpCandidate<?>> findCandidates(final OpEnvironment ops,
+		final List<OpRef<?>> refs)
 	{
 		final ArrayList<OpCandidate<?>> candidates = new ArrayList<>();
 		for (final OpInfo info : ops.infos()) {
@@ -184,14 +184,14 @@ public class DefaultOpMatchingService extends AbstractService implements
 		}
 		if (args.length > inputCount) {
 			// too many arguments
-			candidate.setStatus(StatusCode.TOO_MANY_ARGS,
-				args.length + " > " + inputCount);
+			candidate.setStatus(StatusCode.TOO_MANY_ARGS, args.length + " > " +
+				inputCount);
 			return null;
 		}
 		if (args.length < requiredCount) {
 			// too few arguments
-			candidate.setStatus(StatusCode.TOO_FEW_ARGS,
-				args.length + " < " + requiredCount);
+			candidate.setStatus(StatusCode.TOO_FEW_ARGS, args.length + " < " +
+				requiredCount);
 			return null;
 		}
 
@@ -261,8 +261,7 @@ public class DefaultOpMatchingService extends AbstractService implements
 	 * @throws IllegalArgumentException If there is not exactly one matching
 	 *           candidate.
 	 */
-	private OpCandidate<?> singleMatch(
-		final List<OpCandidate<?>> candidates,
+	private OpCandidate<?> singleMatch(final List<OpCandidate<?>> candidates,
 		final List<OpCandidate<?>> matches)
 	{
 		if (matches.size() == 1) {
@@ -304,12 +303,12 @@ public class DefaultOpMatchingService extends AbstractService implements
 	 * </p>
 	 */
 	private boolean outputsMatch(final OpCandidate<?> candidate) {
-		final Collection<? extends Class<?>> outTypes =
-			candidate.getRef().getOutTypes();
+		final Collection<? extends Class<?>> outTypes = candidate.getRef()
+			.getOutTypes();
 		if (outTypes == null) return true; // no constraints on output types
 
-		final Iterator<ModuleItem<?>> outItems =
-			candidate.cInfo().outputs().iterator();
+		final Iterator<ModuleItem<?>> outItems = candidate.cInfo().outputs()
+			.iterator();
 		for (final Class<?> outType : outTypes) {
 			if (!outItems.hasNext()) {
 				candidate.setStatus(StatusCode.TOO_FEW_OUTPUTS);
@@ -418,8 +417,8 @@ public class DefaultOpMatchingService extends AbstractService implements
 
 		final Type type = item.getGenericType();
 		if (!canConvert(arg, type)) {
-			candidate.setStatus(StatusCode.CANNOT_CONVERT,
-				arg.getClass().getName() + " => " + type, item);
+			candidate.setStatus(StatusCode.CANNOT_CONVERT, arg.getClass().getName() +
+				" => " + type, item);
 			return false;
 		}
 
@@ -458,8 +457,8 @@ public class DefaultOpMatchingService extends AbstractService implements
 
 	/** Determines whether the argument is a matching class instance. */
 	private boolean isMatchingClass(final Object arg, final Type type) {
-		return arg instanceof Class &&
-			convertService.supports((Class<?>) arg, type);
+		return arg instanceof Class && convertService.supports((Class<?>) arg,
+			type);
 	}
 
 	// -- Deprecated methods --

--- a/src/main/java/net/imagej/ops/OpCandidate.java
+++ b/src/main/java/net/imagej/ops/OpCandidate.java
@@ -69,6 +69,7 @@ public class OpCandidate<OP extends Op> {
 	private StatusCode code;
 	private String message;
 	private ModuleItem<?> item;
+	private Object[] args;
 
 	public OpCandidate(final OpEnvironment ops, final OpRef<OP> ref,
 		final OpInfo info)
@@ -203,6 +204,14 @@ public class OpCandidate<OP extends Op> {
 		if (msg != null) sb.append(": " + msg);
 
 		return sb.toString();
+	}
+	
+	public Object[] getArgs() {
+		return args;
+	}
+	
+	public void setArgs(final Object[] args) {
+		this.args = args;
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/OpMatchingUtil.java
+++ b/src/main/java/net/imagej/ops/OpMatchingUtil.java
@@ -1,0 +1,107 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+
+/**
+ * Utility class for {@link OpMatchingService}.
+ * 
+ * @author Leon Yang
+ */
+public class OpMatchingUtil {
+
+	private OpMatchingUtil() {
+		// NB: prevent instantiation of utility class.
+	}
+
+	/**
+	 * Gets the "useful" class information carries on the given object, which
+	 * depends on the actual type of the object.
+	 */
+	public static Class<?> getClass(final Object obj) {
+		if (obj == null) return null;
+		if (obj instanceof Class) return (Class<?>) obj;
+		if (obj instanceof ParameterizedType)
+			return (Class<?>) ((ParameterizedType) obj).getRawType();
+		return obj.getClass();
+	}
+
+	/**
+	 * Finds the levels of casting between <code>origin</code> and
+	 * <code>dest</code>. Returns 0 if dest and origin are the same. Returns -1 if
+	 * dest is not assignable from origin.
+	 */
+	public static int findCastLevels(final Class<?> dest, final Class<?> origin) {
+		if (dest.equals(origin)) return 0;
+
+		int level = 1;
+		Class<?> currType = origin;
+		// BFS if dest is an interface
+		if (dest.isInterface()) {
+			final HashSet<String> seen = new HashSet<>();
+			final ArrayList<Type> currIfaces = new ArrayList<>(Arrays.asList(currType
+				.getGenericInterfaces()));
+			do {
+				final ArrayList<Type> nextIfaces = new ArrayList<>();
+				for (final Type iface : currIfaces) {
+					if (seen.contains(iface.getTypeName())) continue;
+
+					final Class<?> cls = getClass(iface);
+					if (cls.equals(dest)) return level;
+					seen.add(iface.getTypeName());
+					nextIfaces.addAll(Arrays.asList(cls.getGenericInterfaces()));
+				}
+				currIfaces.clear();
+				currIfaces.addAll(nextIfaces);
+				if (currType.getSuperclass() != null) {
+					currType = currType.getSuperclass();
+					currIfaces.addAll(Arrays.asList(currType.getGenericInterfaces()));
+				}
+				level++;
+			}
+			while (!currIfaces.isEmpty() || currType.getSuperclass() != null);
+		}
+		// otherwise dest is a class, so search the list of ancestors
+		else {
+			while (currType.getSuperclass() != null) {
+				currType = currType.getSuperclass();
+				if (currType.equals(dest)) return level;
+				level++;
+			}
+		}
+		return -1;
+	}
+}

--- a/src/test/java/net/imagej/ops/OpMatchingServiceTest.java
+++ b/src/test/java/net/imagej/ops/OpMatchingServiceTest.java
@@ -59,8 +59,8 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 	public void testFindMatch() {
 		final DoubleType value = new DoubleType(123.456);
 
-		final Module moduleByName =
-			matcher.findMatch(ops, OpRef.create("test.nan", value)).getModule();
+		final Module moduleByName = matcher.findMatch(ops, OpRef.create("test.nan",
+			value)).getModule();
 		assertSame(value, moduleByName.getInput("arg"));
 
 		assertFalse(Double.isNaN(value.get()));
@@ -68,8 +68,8 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 		assertTrue(Double.isNaN(value.get()));
 
 		value.set(987.654);
-		final Module moduleByType =
-			matcher.findMatch(ops, OpRef.create(NaNOp.class, value)).getModule();
+		final Module moduleByType = matcher.findMatch(ops, OpRef.create(NaNOp.class,
+			value)).getModule();
 		assertSame(value, moduleByType.getInput("arg"));
 
 		assertFalse(Double.isNaN(value.get()));
@@ -117,7 +117,8 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 		assertMatches("dessert.vanillaIceCream", VanillaIceCream.class);
 		assertMatches("dessert.chocolateIceCream", ChocolateIceCream.class);
 		assertMatches("dessert.sorbet", YummySorbet.class);
-		assertMatches("dessert.sherbet", GenericSherbet.class, RainbowSherbet.class);
+		assertMatches("dessert.sherbet", GenericSherbet.class,
+			RainbowSherbet.class);
 		assertMatches("dessert.americanSherbet", GenericSherbet.class);
 		assertMatches("dessert.rainbowSherbet", RainbowSherbet.class);
 		assertMatches("dessert.gelato", RichGelato.class);
@@ -125,10 +126,46 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 		assertMatches("dessert.italianIceCream", RichGelato.class);
 	}
 
+	/** Tests if the perfect match will be selected if no priority given. */
+	@Test
+	public void testPerfectMatch() {
+		assertEquals(ops.op(Foo.class, AppleIface2.class).getClass(),
+			AppleIface2Foo.class);
+		assertEquals(ops.op(Foo.class, AppleClass2.class).getClass(),
+			AppleClass2Foo.class);
+	}
+
+	/**
+	 * Tests if the match with fewer levels of casting will be selected if no
+	 * priority given.
+	 */
+	@Test
+	public void testCastMatch() {
+		assertEquals(ops.op(Foo.class, OrangeIface2.class).getClass(),
+			OrangeIfaceFoo.class);
+		assertEquals(ops.op(Foo.class, OrangeClass2.class).getClass(),
+			OrangeClassFoo.class);
+
+		try {
+			// both AppleIface1 and AppleClass have same levels of casting.
+			ops.op(Foo.class, AppleClass1.class);
+			assertTrue(false);
+		}
+		catch (final IllegalArgumentException ex) {
+			// expected
+		}
+	}
+	
+	@Test
+	public void testLosslessMatch() {
+		// Not implemented yet
+	}
+
 	// -- Helper methods --
 
 	private Module optionalParamsModule(Object... args) {
-		return matcher.findMatch(ops, OpRef.create(OptionalParams.class, args)).getModule();
+		return matcher.findMatch(ops, OpRef.create(OptionalParams.class, args))
+			.getModule();
 	}
 
 	private void assertValues(final Module m, final int a, final int b,
@@ -148,12 +185,13 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 	}
 
 	private void assertMatches(final String name, Class<?>... opTypes) {
-		final List<OpCandidate<Op>> candidates =
-			matcher.findCandidates(ops, OpRef.create(name));
+		final List<OpCandidate<Op>> candidates = matcher.findCandidates(ops, OpRef
+			.create(name));
 		@SuppressWarnings({ "unchecked", "rawtypes" })
-		final List<OpCandidate<?>> matches = matcher.filterMatches((List) candidates);
+		final List<OpCandidate<?>> matches = matcher.filterMatches(
+			(List) candidates);
 		assertEquals(opTypes.length, matches.size());
-		for (int i=0; i<opTypes.length; i++) {
+		for (int i = 0; i < opTypes.length; i++) {
 			final Module m = matches.get(i).getModule();
 			assertSame(opTypes[i], m.getDelegateObject().getClass());
 		}
@@ -204,19 +242,23 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 	}
 
 	public static interface IceCream extends Dessert {
+
 		String NAME = "dessert.iceCream";
 	}
 
 	public static interface Sorbet extends IceCream {
+
 		String NAME = "dessert.sorbet";
 	}
 
 	public static interface Sherbet extends IceCream {
+
 		String NAME = "dessert.sherbet";
 		String ALIAS = "dessert.americanSherbet";
 	}
 
 	public static interface Gelato extends IceCream {
+
 		String NAME = "dessert.gelato";
 		String ALIASES = "dessert.gelati, dessert.italianIceCream";
 	}
@@ -255,6 +297,109 @@ public class OpMatchingServiceTest extends AbstractOpTest {
 	@Plugin(type = Gelato.class)
 	public static class RichGelato extends NoOp implements Gelato {
 		// NB: No implementation needed.
+	}
+
+	public static interface Foo extends Op {
+		// NB: No implementation needed.
+	}
+
+	public static interface AppleIface {
+		// NB: No implementation needed.
+	}
+
+	public static interface AppleIface1 extends AppleIface {
+		// NB: No implementation needed.
+	}
+
+	public static interface AppleIface2 extends AppleIface1 {
+		// NB: No implementation needed.
+	}
+
+	public static class AppleClass implements AppleIface{
+		// NB: No implementation needed.
+	}
+
+	public static class AppleClass1 extends AppleClass implements AppleIface1 {
+		// NB: No implementation needed.
+	}
+
+	public static class AppleClass2 extends AppleClass1 implements AppleIface2 {
+		// NB: No implementation needed.
+	}
+
+	public static interface OrangeIface {
+		// NB: No implementation needed.
+	}
+
+	public static interface OrangeIface1 extends OrangeIface {
+		// NB: No implementation needed.
+	}
+
+	public static interface OrangeIface2 extends OrangeIface1 {
+		// NB: No implementation needed.
+	}
+
+	public static class OrangeClass implements OrangeIface {
+		// NB: No implementation needed.
+	}
+
+	public static class OrangeClass1 extends OrangeClass implements OrangeIface1 {
+		// NB: No implementation needed.
+	}
+
+	public static class OrangeClass2 extends OrangeClass1 implements
+		OrangeIface2
+	{
+		// NB: No implementation needed.
+	}
+
+	@Plugin(type = Foo.class)
+	public static class AppleIface2Foo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private AppleIface2 in;
+	}
+
+	@Plugin(type = Foo.class)
+	public static class AppleIface1Foo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private AppleIface1 in;
+	}
+
+	@Plugin(type = Foo.class)
+	public static class AppleIfaceFoo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private AppleIface in;
+	}
+
+	@Plugin(type = Foo.class)
+	public static class AppleClass2Foo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private AppleClass2 in;
+	}
+
+	@Plugin(type = Foo.class)
+	public static class AppleClassFoo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private AppleClass in;
+	}
+
+	@Plugin(type = Foo.class)
+	public static class OrangeIfaceFoo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private OrangeIface in;
+	}
+
+	@Plugin(type = Foo.class)
+	public static class OrangeClassFoo extends NoOp implements Foo {
+
+		@Parameter(type = ItemIO.INPUT)
+		private OrangeClass in;
 	}
 
 }


### PR DESCRIPTION
DefaultOpMatchingService now do a multi-pass matching instead of a
single pass.

First it search for Ops whose arguments match exactly with the
references.

If fails, it search for Ops whose arguments match by casting. Ops with
fewest total levels of casting will be returned.

If fails, it then search for Ops whose arguments match by lossless
conversion. This functionality is not yet implemented, because it needs
support from the conversion service to tell if a conversion is lossy.

If still no match is found, it does the regular search.