### PR TITLE
Add new equation ops

### DIFF
--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -30,17 +30,21 @@
 
 package net.imagej.ops.image;
 
+import java.util.function.DoubleBinaryOperator;
+
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops;
 import net.imagej.ops.image.cooccurrenceMatrix.MatrixOrientation;
+import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
 
 import org.scijava.plugin.Plugin;
 
@@ -58,7 +62,7 @@ public class ImageNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.image.ascii.DefaultASCII.class)
 	public <T extends RealType<T>> String ascii(final IterableInterval<T> image) {
 		final String result = (String) ops().run(
-				net.imagej.ops.Ops.Image.ASCII.class, image);
+			net.imagej.ops.Ops.Image.ASCII.class, image);
 		return result;
 	}
 
@@ -68,7 +72,7 @@ public class ImageNamespace extends AbstractNamespace {
 		final T min)
 	{
 		final String result = (String) ops().run(
-				net.imagej.ops.Ops.Image.ASCII.class, image, min);
+			net.imagej.ops.Ops.Image.ASCII.class, image, min);
 		return result;
 	}
 
@@ -78,47 +82,57 @@ public class ImageNamespace extends AbstractNamespace {
 		final T min, final T max)
 	{
 		final String result = (String) ops().run(
-				net.imagej.ops.Ops.Image.ASCII.class, image, min, max);
+			net.imagej.ops.Ops.Image.ASCII.class, image, min, max);
 		return result;
 	}
 
 	// -- cooccurrence matrix --
 
 	@OpMethod(ops = {
-			net.imagej.ops.image.cooccurrenceMatrix.CooccurrenceMatrix3D.class,
-			net.imagej.ops.image.cooccurrenceMatrix.CooccurrenceMatrix2D.class })
+		net.imagej.ops.image.cooccurrenceMatrix.CooccurrenceMatrix3D.class,
+		net.imagej.ops.image.cooccurrenceMatrix.CooccurrenceMatrix2D.class })
 	public <T extends RealType<T>> double[][] cooccurrenceMatrix(
-			final IterableInterval<T> in, final int nrGreyLevels,
-			final int distance, final MatrixOrientation orientation) {
+		final IterableInterval<T> in, final int nrGreyLevels, final int distance,
+		final MatrixOrientation orientation)
+	{
 		final double[][] result = (double[][]) ops().run(
-				Ops.Image.CooccurrenceMatrix.class, in, nrGreyLevels, distance,
-				orientation);
+			Ops.Image.CooccurrenceMatrix.class, in, nrGreyLevels, distance,
+			orientation);
 		return result;
 	}
 
 	// -- distance transform --
 
 	/** Executes the "distancetransform" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.image.distancetransform.DefaultDistanceTransform.class,
-			net.imagej.ops.image.distancetransform.DistanceTransform2D.class,
-			net.imagej.ops.image.distancetransform.DistanceTransform3D.class })
-	public <B extends BooleanType<B>, T extends RealType<T>> RandomAccessibleInterval<T> distancetransform(
-			final RandomAccessibleInterval<B> in, final RandomAccessibleInterval<T> out) {
+	@OpMethod(ops = {
+		net.imagej.ops.image.distancetransform.DefaultDistanceTransform.class,
+		net.imagej.ops.image.distancetransform.DistanceTransform2D.class,
+		net.imagej.ops.image.distancetransform.DistanceTransform3D.class })
+	public <B extends BooleanType<B>, T extends RealType<T>>
+		RandomAccessibleInterval<T> distancetransform(
+			final RandomAccessibleInterval<B> in,
+			final RandomAccessibleInterval<T> out)
+	{
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(Ops.Image.DistanceTransform.class, in, out);
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(Ops.Image.DistanceTransform.class,
+				in, out);
 		return result;
 	}
-	
+
 	/** Executes the "distancetransform" operation on the given arguments. */
-	@OpMethod(ops = { net.imagej.ops.image.distancetransform.DefaultDistanceTransform.class,
-			net.imagej.ops.image.distancetransform.DistanceTransform2D.class,
-			net.imagej.ops.image.distancetransform.DistanceTransform3D.class })
-	public <B extends BooleanType<B>, T extends RealType<T>> RandomAccessibleInterval<T> distancetransform(
-			final RandomAccessibleInterval<B> in) {
+	@OpMethod(ops = {
+		net.imagej.ops.image.distancetransform.DefaultDistanceTransform.class,
+		net.imagej.ops.image.distancetransform.DistanceTransform2D.class,
+		net.imagej.ops.image.distancetransform.DistanceTransform3D.class })
+	public <B extends BooleanType<B>, T extends RealType<T>>
+		RandomAccessibleInterval<T> distancetransform(
+			final RandomAccessibleInterval<B> in)
+	{
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
-				.run(Ops.Image.DistanceTransform.class, in);
+		final RandomAccessibleInterval<T> result =
+			(RandomAccessibleInterval<T>) ops().run(Ops.Image.DistanceTransform.class,
+				in);
 		return result;
 	}
 
@@ -129,17 +143,18 @@ public class ImageNamespace extends AbstractNamespace {
 	public <T extends RealType<T>> IterableInterval<T> equation(final String in) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Equation.class, in);
+			net.imagej.ops.Ops.Image.Equation.class, in);
 		return result;
 	}
 
 	/** Executes the "equation" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.equation.DefaultEquation.class)
 	public <T extends RealType<T>> IterableInterval<T> equation(
-			final IterableInterval<T> out, final String in) {
+		final IterableInterval<T> out, final String in)
+	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Equation.class, out, in);
+			net.imagej.ops.Ops.Image.Equation.class, out, in);
 		return result;
 	}
 
@@ -160,25 +175,27 @@ public class ImageNamespace extends AbstractNamespace {
 
 	/** Executes the "histogram" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.histogram.HistogramCreate.class)
-	public <T extends RealType<T>> Histogram1d<T> histogram(final Iterable<T> in) {
+	public <T extends RealType<T>> Histogram1d<T> histogram(
+		final Iterable<T> in)
+	{
 		@SuppressWarnings("unchecked")
 		final Histogram1d<T> result = (Histogram1d<T>) ops().run(
-				net.imagej.ops.Ops.Image.Histogram.class, in);
+			net.imagej.ops.Ops.Image.Histogram.class, in);
 		return result;
 	}
 
 	/** Executes the "histogram" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.histogram.HistogramCreate.class)
-	public <T extends RealType<T>> Histogram1d<T> histogram(
-			final Iterable<T> in, final int numBins) {
+	public <T extends RealType<T>> Histogram1d<T> histogram(final Iterable<T> in,
+		final int numBins)
+	{
 		@SuppressWarnings("unchecked")
 		final Histogram1d<T> result = (Histogram1d<T>) ops().run(
-				net.imagej.ops.Ops.Image.Histogram.class, in,
-				numBins);
+			net.imagej.ops.Ops.Image.Histogram.class, in, numBins);
 		return result;
 	}
 
-	//-- integral --
+	// -- integral --
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@OpMethod(op = net.imagej.ops.image.integral.DefaultIntegralImg.class)
@@ -199,8 +216,7 @@ public class ImageNamespace extends AbstractNamespace {
 		final RandomAccessibleInterval<T> in)
 	{
 		final RandomAccessibleInterval<RealType> result =
-			(RandomAccessibleInterval) ops().run(
-				Ops.Image.Integral.class, in);
+			(RandomAccessibleInterval) ops().run(Ops.Image.Integral.class, in);
 		return result;
 	}
 
@@ -230,171 +246,209 @@ public class ImageNamespace extends AbstractNamespace {
 
 	/** Executes the "invert" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
-			final IterableInterval<O> out, final IterableInterval<I> in) {
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O>
+		invert(final IterableInterval<O> out, final IterableInterval<I> in)
+	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.Ops.Image.Invert.class, out,
-				in);
+			net.imagej.ops.Ops.Image.Invert.class, out, in);
 		return result;
 	}
 
 	// -- normalize --
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> out, final IterableInterval<T> in)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> out, final IterableInterval<T> in)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops()
-				.run(net.imagej.ops.Ops.Image.Normalize.class,
-					out, in);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, out, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> out, final IterableInterval<T> in,
-			final T sourceMin)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T sourceMin)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class, out,
-				in, sourceMin);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, out, in, sourceMin);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> out, final IterableInterval<T> in,
-			final T sourceMin, final T sourceMax)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T sourceMin, final T sourceMax)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class, out,
-				in, sourceMin, sourceMax);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, out, in, sourceMin, sourceMax);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> out, final IterableInterval<T> in,
-			final T sourceMin, final T sourceMax, final T targetMin)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T sourceMin, final T sourceMax, final T targetMin)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class, out,
-				in, sourceMin, sourceMax, targetMin);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, out, in, sourceMin, sourceMax,
+			targetMin);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)
-	public
-		<T extends RealType<T>>
-		IterableInterval<T>
-		normalize(final IterableInterval<T> out, final IterableInterval<T> in,
-			final T sourceMin, final T sourceMax, final T targetMin, final T targetMax)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final T sourceMin, final T sourceMax, final T targetMin,
+		final T targetMax)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class, out,
-				in, sourceMin, sourceMax, targetMin, targetMax);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, out, in, sourceMin, sourceMax,
+			targetMin, targetMax);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> in)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> in, final T sourceMin)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, in, sourceMin);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> in, final T sourceMin, final T sourceMax)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, in, sourceMin, sourceMax);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> in, final T sourceMin, final T sourceMax,
+		final T targetMin)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, in, sourceMin, sourceMax,
+			targetMin);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> in, final T sourceMin, final T sourceMax,
+		final T targetMin, final T targetMax)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, in, sourceMin, sourceMax,
+			targetMin, targetMax);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
+	public <T extends RealType<T>> IterableInterval<T> normalize(
+		final IterableInterval<T> in, final T sourceMin, final T sourceMax,
+		final T targetMin, final T targetMax, final boolean isLazy)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Normalize.class, in, sourceMin, sourceMax,
+			targetMin, targetMax, isLazy);
+		return result;
+	}
+
+	// -- calibrated equation --
+	@OpMethod(op = net.imagej.ops.image.equation.DefaultCalibratedEquation.class)
+	public <T extends RealType<T>> IterableInterval<T> equation(
+		final IterableInterval<T> out, final UnaryFunctionOp<double[], Double> in)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.image.equation.DefaultCalibratedEquation.class, out, in);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.equation.DefaultCalibratedEquation.class)
+	public <T extends RealType<T>> IterableInterval<T> equation(
+		final IterableInterval<T> out, final UnaryFunctionOp<double[], Double> in,
+		final double... origin)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.image.equation.DefaultCalibratedEquation.class, out, in,
+			origin);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.image.equation.DefaultCalibratedEquation.class)
+	public <T extends RealType<T>> IterableInterval<T> equation(
+		final IterableInterval<T> out, final UnaryFunctionOp<double[], Double> in,
+		final double[] origin, final double... calibration)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.image.equation.DefaultCalibratedEquation.class, out, in,
+			origin, calibration);
 		return result;
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> in)
+		op = net.imagej.ops.image.equation.DefaultXYCalibratedEquation.class)
+	public <T extends RealType<T>> IterableInterval<T> equation(
+		final IterableInterval<T> out, final DoubleBinaryOperator in)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class,
-				in);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.image.equation.DefaultXYCalibratedEquation.class, out, in);
 		return result;
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> in, final T sourceMin)
+		op = net.imagej.ops.image.equation.DefaultXYCalibratedEquation.class)
+	public <T extends RealType<T>> IterableInterval<T> equation(
+		final IterableInterval<T> out, final DoubleBinaryOperator in,
+		final double... origin)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class,
-				in, sourceMin);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.image.equation.DefaultXYCalibratedEquation.class, out, in,
+			origin);
 		return result;
 	}
 
 	@OpMethod(
-		op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> in, final T sourceMin, final T sourceMax)
+		op = net.imagej.ops.image.equation.DefaultXYCalibratedEquation.class)
+	public <T extends RealType<T>> IterableInterval<T> equation(
+		final IterableInterval<T> out, final DoubleBinaryOperator in,
+		final double[] origin, final double... calibration)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class,
-				in, sourceMin, sourceMax);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> in, final T sourceMin, final T sourceMax,
-			final T targetMin)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class,
-				in, sourceMin, sourceMax, targetMin);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> in, final T sourceMin, final T sourceMax,
-			final T targetMin, final T targetMax)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class,
-				in, sourceMin, sourceMax, targetMin, targetMax);
-		return result;
-	}
-
-	@OpMethod(
-		op = net.imagej.ops.image.normalize.NormalizeIIFunction.class)
-	public
-		<T extends RealType<T>> IterableInterval<T> normalize(
-			final IterableInterval<T> in, final T sourceMin, final T sourceMax,
-			final T targetMin, final T targetMax, final boolean isLazy)
-	{
-		@SuppressWarnings("unchecked")
-		final IterableInterval<T> result =
-			(IterableInterval<T>) ops().run(
-				net.imagej.ops.Ops.Image.Normalize.class,
-				in, sourceMin, sourceMax, targetMin, targetMax, isLazy);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.image.equation.DefaultXYCalibratedEquation.class, out, in,
+			origin, calibration);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/image/equation/AbstractCalibratedEquation.java
+++ b/src/main/java/net/imagej/ops/image/equation/AbstractCalibratedEquation.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.equation;
+
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * A "calibrated equation" operation which computes image values based on
+ * calibrated coordinates.
+ * 
+ * @author Brian Northan
+ */
+public abstract class AbstractCalibratedEquation<F, T extends RealType<T>>
+	extends AbstractUnaryComputerOp<F, IterableInterval<T>>
+{
+
+	@Parameter(required = false)
+	private double[] origin;
+
+	@Parameter(required = false)
+	private double[] calibration;
+
+	public double[] getOrigin() {
+		if (origin == null) {
+			if (out() != null) {
+				origin = new double[out().numDimensions()];
+
+				for (int d = 0; d < out().numDimensions(); d++) {
+					origin[d] = 0;
+				}
+			}
+		}
+		return origin;
+	}
+
+	public double[] getCalibration() {
+		if (calibration == null) {
+			if (out() != null) {
+				calibration = new double[out().numDimensions()];
+
+				for (int d = 0; d < out().numDimensions(); d++) {
+					calibration[d] = 1;
+				}
+
+			}
+
+		}
+
+		return calibration;
+	}
+}

--- a/src/main/java/net/imagej/ops/image/equation/CalibratedEquationOp.java
+++ b/src/main/java/net/imagej/ops/image/equation/CalibratedEquationOp.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.equation;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.IterableInterval;
+
+/**
+ * A "calibrated equation" operation which computes image values based on
+ * calibrated coordinates.
+ * 
+ * @author Brian Northan
+ */
+public interface CalibratedEquationOp<T> extends Ops.Image.Equation,
+	UnaryComputerOp<UnaryFunctionOp<double[], Double>, IterableInterval<T>>
+{
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ops/image/equation/DefaultCalibratedEquation.java
+++ b/src/main/java/net/imagej/ops/image/equation/DefaultCalibratedEquation.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.equation;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * An "calibrated equation" operation which computes image values from real
+ * coordinates using an op.
+ * 
+ * @author Brian Northan
+ */
+@Plugin(type = Ops.Image.Equation.class)
+public class DefaultCalibratedEquation<T extends RealType<T>> extends
+	AbstractCalibratedEquation<UnaryFunctionOp<double[], Double>, T> implements
+	CalibratedEquationOp<T>
+{
+
+	@Override
+	public void compute1(final UnaryFunctionOp<double[], Double> op,
+		final IterableInterval<T> output)
+	{
+
+		final Cursor<T> c = output.localizingCursor();
+		final long[] pos = new long[output.numDimensions()];
+		final double[] realCoordinates = new double[output.numDimensions()];
+
+		while (c.hasNext()) {
+			c.fwd();
+			c.localize(pos);
+
+			for (int i = 0; i < output.numDimensions(); i++) {
+				realCoordinates[i] = getOrigin()[i] + getCalibration()[i] * pos[i];
+
+				c.get().setReal(op.compute1(realCoordinates));
+
+			}
+
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/image/equation/DefaultXYCalibratedEquation.java
+++ b/src/main/java/net/imagej/ops/image/equation/DefaultXYCalibratedEquation.java
@@ -1,0 +1,58 @@
+
+package net.imagej.ops.image.equation;
+
+import java.util.function.DoubleBinaryOperator;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * A "calibrated equation" operation which computes image values from x and y
+ * coordinates using a binary lambda.
+ * 
+ * @author Brian Northan
+ */
+@Plugin(type = Ops.Image.Equation.class)
+public class DefaultXYCalibratedEquation<T extends RealType<T>> extends
+	AbstractCalibratedEquation<DoubleBinaryOperator, T> implements
+	XYCalibratedEquationOp<T>
+{
+
+	private UnaryComputerOp<UnaryFunctionOp<double[], Double>, IterableInterval<T>> equation;
+
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void initialize() {
+		super.initialize();
+		equation = (UnaryComputerOp) Computers.unary(ops(),
+			DefaultCalibratedEquation.class, IterableInterval.class,
+			UnaryFunctionOp.class, getOrigin(), getCalibration());
+	}
+
+	@Override
+	public void compute1(DoubleBinaryOperator lambda,
+		final IterableInterval<T> output)
+	{
+
+		UnaryFunctionOp<double[], Double> op =
+			new AbstractUnaryFunctionOp<double[], Double>()
+		{
+
+				@Override
+				public Double compute1(double[] coords) {
+					return lambda.applyAsDouble(coords[0], coords[1]);
+				}
+
+			};
+
+		equation.compute1(op, output);
+
+	}
+}

--- a/src/main/java/net/imagej/ops/image/equation/XYCalibratedEquationOp.java
+++ b/src/main/java/net/imagej/ops/image/equation/XYCalibratedEquationOp.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.equation;
+
+import java.util.function.DoubleBinaryOperator;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imglib2.IterableInterval;
+
+/**
+ * An "calibrated equation" operation which computes image values from real
+ * interval coordinates using a binary lambda.
+ * 
+ * @author Brian Northan
+ */
+public interface XYCalibratedEquationOp<T> extends Ops.Image.Equation,
+	UnaryComputerOp<DoubleBinaryOperator, IterableInterval<T>>
+{
+	// NB: Marker interface.
+}

--- a/src/test/java/net/imagej/ops/image/equation/CalibratedEquationTest.java
+++ b/src/test/java/net/imagej/ops/image/equation/CalibratedEquationTest.java
@@ -1,0 +1,115 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.equation;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
+import net.imglib2.IterableInterval;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Test;
+
+public class CalibratedEquationTest extends AbstractOpTest {
+
+	long[] size = new long[] { 100, 100 };
+
+	// define start and end
+	double[] start = new double[] { -1., -1. };
+	double[] end = new double[] { 1., 1. };
+
+	// calculate spacing based on size and starting point
+	double[] spacing = new double[] { (end[0] - start[0]) / (size[0] - 1),
+		(end[1] - start[1]) / (size[1] - 1) };
+
+	Dimensions dimensions = new FinalDimensions(size[0], size[1]);
+
+	@Test
+	public void testEquationXY() {
+		IterableInterval<DoubleType> image = ops.create().img(dimensions,
+			new DoubleType());
+
+		ops.image().equation(image, (x, y) -> 10 * (Math.cos(0.3 * x) + Math.sin(
+			0.3 * y)));
+		
+		// assert against value determined by running string version of equation in jython
+		assertEquals(ops.stats().sum(image).getRealDouble(), 446.1755977585166, 0.000000001);
+
+	}
+
+	@Test
+	public void testCalibratedEquationXY() {
+
+		IterableInterval<DoubleType> image = ops.create().img(dimensions,
+			new DoubleType());
+
+		ops.image().equation(image, (x, y) -> Math.pow(x, 2) + Math.pow(y, 2),
+			start, spacing);
+
+		assertEquals(6801.346801346799, ops.stats().sum(image).getRealDouble(),
+			0.0000001);
+
+	}
+
+	@Test
+	public void testCalibratedEquation() {
+
+		IterableInterval<DoubleType> image = ops.create().img(dimensions,
+			new DoubleType());
+
+		// implement x^2+y^2
+		UnaryFunctionOp<double[], Double> op =
+			new AbstractUnaryFunctionOp<double[], Double>()
+		{
+
+				@Override
+				public Double compute1(double[] coords) {
+					double result = 0;
+					for (double d : coords) {
+						result += Math.pow(d, 2);
+					}
+
+					return result;
+				}
+			};
+
+		ops.image().equation(image, op, start, spacing);
+
+		assertEquals(6801.346801346799, ops.stats().sum(image).getRealDouble(),
+			0.0000001);
+
+	}
+
+}


### PR DESCRIPTION
Add ops for calibrated equations (AbstractCalibratedEquation.java), equations passed in using an op (DefaultCalibratedEquation.java), and equations passed in using a binary lambda
(DefaultXYCalibratedEquation.java).

This allows me to implement equations fairly easily.  For example:

```
// define origin and calibration
double[] origin = new double[] { -1., -1. };
double[] calibration = new double[]{0.1,0.1};

ops.image().equation(image, (x, y) -> Math.pow(x, 2) + Math.pow(y, 2),
            origin, calibration);
```

or (since origin and calibration are optional)

```
ops.image().equation(image, (x, y) -> 10 * (Math.cos(0.3 * x) + Math.sin(
            0.3 * y)));
```
