### PR TITLE
feature sets table

### DIFF
--- a/src/main/java/net/imagej/ops/features/sets/AbstractComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/AbstractComputerSet.java
@@ -1,0 +1,201 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.sets;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import net.imagej.ops.CustomOpEnvironment;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpEnvironment;
+import net.imagej.ops.OpInfo;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imglib2.type.Type;
+
+/**
+ * The abstract implementation of {@link ComputerSet}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            type of the common input
+ * @param <O>
+ *            type of the common output
+ */
+public abstract class AbstractComputerSet<I, O extends Type<O>> extends AbstractUnaryFunctionOp<I, Map<String, O>>
+		implements ComputerSet<I, O> {
+
+	/**
+	 * The computers of this {@link ComputerSet}.
+	 */
+	protected final Map<Class<? extends Op>, UnaryComputerOp<I, O>> computers;
+
+	/**
+	 * The outputs by name of all computers.
+	 */
+	protected final Map<String, O> namedOutputs;
+
+	/**
+	 * An instance of the output type.
+	 */
+	protected final O outputTypeInstance;
+
+	/**
+	 * The input type.
+	 */
+	private final Class<I> inType;
+
+	/**
+	 * Create a new {@link AbstractComputerSet} with the default
+	 * {@link OpEnvironment}.
+	 *
+	 * @param outputTypeInstance
+	 *            object of the output type
+	 * @param inType
+	 *            the input type
+	 */
+	public AbstractComputerSet(final O outputTypeInstance, final Class<I> inType) {
+		this(null, outputTypeInstance, inType);
+	}
+
+	/**
+	 * Create a new {@link AbstractComputerSet} with a custom
+	 * {@link OpEnvironment}.
+	 *
+	 * @param opEnv
+	 *            the custom {@link OpEnvironment}
+	 * @param outputTypeInstance
+	 *            object of the output type
+	 * @param inType
+	 *            the input type
+	 */
+	public AbstractComputerSet(final OpEnvironment opEnv, final O outputTypeInstance, final Class<I> inType) {
+		if (opEnv != null) {
+			setEnvironment(opEnv);
+		}
+
+		this.outputTypeInstance = outputTypeInstance;
+		this.inType = inType;
+		this.computers = new HashMap<>();
+		this.namedOutputs = new HashMap<>();
+	}
+
+	/**
+	 * TEMP
+	 *
+	 * A fake input is need for the matching of Ops. This can be removed if the
+	 * matcher gets improved.
+	 *
+	 * @return an empty input object.
+	 */
+	protected abstract I getFakeInput();
+
+	@Override
+	public void initialize() {
+		setInput(getFakeInput());
+		initialize(null);
+	}
+
+	/**
+	 * Set {@link CustomOpEnvironment} and create all computers of this
+	 * featureset.
+	 *
+	 * @param infos
+	 *            for the {@link CustomOpEnvironment}
+	 */
+	protected void initialize(final Collection<OpInfo> infos) {
+		if (infos != null) {
+			setEnvironment(new CustomOpEnvironment(ops(), infos));
+		}
+		for (final Class<? extends Op> feature : getFeatures()) {
+			addComputer(feature);
+		}
+	}
+
+	/**
+	 * Create computer and output object for the computer. Add both to the
+	 * datastructures.
+	 *
+	 * @param clazz
+	 *            the class of the computer
+	 */
+	protected void addComputer(final Class<? extends Op> clazz) {
+		@SuppressWarnings("unchecked")
+		final UnaryComputerOp<I, O> computer = Computers.unary(ops(), clazz, (Class<O>) outputTypeInstance.getClass(),
+				in());
+		final O output = outputTypeInstance.createVariable();
+		namedOutputs.put(clazz.getSimpleName(), output);
+		computer.setOutput(output);
+		computers.put(clazz, computer);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Map<String, O> compute1(final I input) {
+		for (final UnaryComputerOp<I, O> computer : computers.values()) {
+			computer.compute1(input, computer.out());
+		}
+
+		return namedOutputs;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Class<? extends Op>[] getComputedFeatures() {
+		return getFeatures();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String[] getComputerNames() {
+		return Arrays.asList(getFeatures()).stream().map(a -> a.getSimpleName()).collect(Collectors.toList())
+				.toArray(new String[computers.size()]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Class<I> getInType() {
+		return inType;
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/AbstractConfigurableComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/AbstractConfigurableComputerSet.java
@@ -1,0 +1,196 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.sets;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import net.imagej.ops.CustomOpEnvironment;
+import net.imagej.ops.Op;
+import net.imagej.ops.OpEnvironment;
+import net.imagej.ops.OpInfo;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Parameter;
+
+/**
+ * An abstract implementation of {@link ComputerSet} which is configurable.
+ *
+ * {@link Computers} passed by construction will be activated and all remaining
+ * will be deactivated. If no {@link Computers} is passed, all {@link Computers}
+ * will be activated by default.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            type of the common input
+ * @param <O>
+ *            type of the common output
+ */
+public abstract class AbstractConfigurableComputerSet<I, O extends Type<O>> extends AbstractComputerSet<I, O>
+		implements ConfigurableComputerSet<I, O> {
+
+	@Parameter(required = false)
+	private List<Class<? extends Op>> active;
+
+	/**
+	 * The activated {@link Computers}.
+	 */
+	private final Map<Class<? extends Op>, Boolean> activated;
+
+	/**
+	 * Create a new {@link AbstractConfigurableComputerSet} with the default
+	 * {@link OpEnvironment}.
+	 *
+	 * @param outputTypeInstance
+	 *            object of the output type
+	 * @param inType
+	 *            the input type
+	 */
+	public AbstractConfigurableComputerSet(final O outputTypeInstance, final Class<I> inType) {
+		super(null, outputTypeInstance, inType);
+		active = new ArrayList<>();
+		activated = new HashMap<>();
+	}
+
+	/**
+	 * Create a new {@link AbstractConfigurableComputerSet} with a custom
+	 * {@link OpEnvironment}.
+	 *
+	 * @param opEnv
+	 *            the custom {@link OpEnvironment}
+	 * @param outputTypeInstance
+	 *            object of the output type
+	 * @param inType
+	 *            the input type
+	 */
+	public AbstractConfigurableComputerSet(final OpEnvironment opEnv, final O outputTypeInstance,
+			final Class<I> inType) {
+		super(opEnv, outputTypeInstance, inType);
+		active = new ArrayList<>();
+		activated = new HashMap<>();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void initialize() {
+		if (active.isEmpty()) {
+			active.addAll(Arrays.asList(getFeatures()));
+		}
+		super.initialize();
+	}
+
+	/**
+	 * Set {@link CustomOpEnvironment} and create all computers of this
+	 * featureset and activate passed {@link Computers}.
+	 *
+	 * @param infos
+	 *            for the {@link CustomOpEnvironment}
+	 */
+	@Override
+	protected void initialize(final Collection<OpInfo> infos) {
+		if (infos != null) {
+			setEnvironment(new CustomOpEnvironment(ops(), infos));
+		}
+
+		for (final Class<? extends Op> feature : getFeatures()) {
+			if (active.contains(feature)) {
+				activated.put(feature, true);
+				addComputer(feature);
+			} else {
+				activated.put(feature, false);
+			}
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Map<String, O> compute1(final I input) {
+		for (final UnaryComputerOp<I, O> computer : activated.entrySet().stream().filter(a -> a.getValue())
+				.map(a -> computers.get(a.getKey())).collect(Collectors.toList())) {
+			computer.compute1(input, computer.out());
+		}
+
+		return namedOutputs;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isActive(final Class<? extends Op> feature) {
+		return activated.get(feature);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<Class<? extends Op>> getActive() {
+		return activated.entrySet().stream().filter(e -> e.getValue()).map(e -> e.getKey())
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends Op>[] getComputedFeatures() {
+		return getActive().toArray(new Class[(int) activated.values().stream().filter(a -> a.booleanValue()).count()]);
+	}
+
+	@Override
+	public String[] getComputerNames() {
+		return getActive().stream().map(a -> a.getSimpleName()).collect(Collectors.toList())
+				.toArray(new String[computers.size()]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<Class<? extends Op>> getInactive() {
+		return activated.entrySet().stream().filter(e -> !e.getValue()).map(e -> e.getKey())
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/ComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/ComputerSet.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.sets;
+
+import java.util.Map;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+
+/**
+ * An {@link ComputerSet} holds different {@link Computers} which can be
+ * computed on the same input and generate outputs of the same type.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            type of the common input
+ * @param <O>
+ *            type of the common output
+ */
+public interface ComputerSet<I, O> extends UnaryFunctionOp<I, Map<String, O>> {
+
+	/**
+	 * The {@link Computers} which define this {@link ComputerSet}.
+	 *
+	 * @return all {@link Computers} of this {@link ComputerSet}
+	 */
+	Class<? extends Op>[] getFeatures();
+
+	/**
+	 * The {@link Computers} which were computed by this {@link ComputerSet}.
+	 *
+	 * @return the computed {@link Computers} of this {@link ComputerSet}.
+	 */
+	Class<? extends Op>[] getComputedFeatures();
+
+	/**
+	 * The input type of the {@link Computers} of this {@link ComputerSet}.
+	 *
+	 * @return the input type
+	 */
+	Class<I> getInType();
+
+	/**
+	 * An array of the names of all computers which will be executed.
+	 *
+	 * @return the names of all active computers.
+	 */
+	String[] getComputerNames();
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/ConfigurableComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/ConfigurableComputerSet.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import java.util.List;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.special.function.Functions;
+
+/**
+ * A {@link ConfigurableComputerSet} can be initialized with only a subset of
+ * activated {@link Functions}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            type of the common input
+ * @param <O>
+ *            type of the common output
+ */
+public interface ConfigurableComputerSet<I, O> extends ComputerSet<I, O> {
+
+	/**
+	 * Get the activation state of a {@link Functions} of this
+	 * {@link ConfigurableComputerSet}.
+	 *
+	 * @param function
+	 *            the {@link Functions} to check.
+	 * @return the activation state of this {@link Functions}
+	 */
+	boolean isActive(final Class<? extends Op> function);
+
+	/**
+	 * Get all active {@link Functions} of this {@link ConfigurableComputerSet}.
+	 *
+	 * @return the active {@link Functions}
+	 */
+	List<Class<? extends Op>> getActive();
+
+	/**
+	 * Get all inactive {@link Functions} of this
+	 * {@link ConfigurableComputerSet}.
+	 *
+	 * @return the inactive {@link Functions}
+	 */
+	List<Class<? extends Op>> getInactive();
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/DefaultFirstOrderStatsComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/DefaultFirstOrderStatsComputerSet.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.sets;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.Stats.GeometricMean;
+import net.imagej.ops.Ops.Stats.HarmonicMean;
+import net.imagej.ops.Ops.Stats.Kurtosis;
+import net.imagej.ops.Ops.Stats.Max;
+import net.imagej.ops.Ops.Stats.Mean;
+import net.imagej.ops.Ops.Stats.Median;
+import net.imagej.ops.Ops.Stats.Min;
+import net.imagej.ops.Ops.Stats.Moment1AboutMean;
+import net.imagej.ops.Ops.Stats.Moment2AboutMean;
+import net.imagej.ops.Ops.Stats.Moment3AboutMean;
+import net.imagej.ops.Ops.Stats.Moment4AboutMean;
+import net.imagej.ops.Ops.Stats.Size;
+import net.imagej.ops.Ops.Stats.Skewness;
+import net.imagej.ops.Ops.Stats.StdDev;
+import net.imagej.ops.Ops.Stats.Sum;
+import net.imagej.ops.Ops.Stats.SumOfInverses;
+import net.imagej.ops.Ops.Stats.SumOfLogs;
+import net.imagej.ops.Ops.Stats.SumOfSquares;
+import net.imagej.ops.Ops.Stats.Variance;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessorUtils;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Default implementation of {@link FirstOrderStatsComputerSet}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+@Plugin(type = ComputerSet.class, label = "First Order Statistic Computers")
+@SuppressWarnings("rawtypes")
+public class DefaultFirstOrderStatsComputerSet extends AbstractConfigurableComputerSet<Iterable, DoubleType>
+		implements FirstOrderStatsComputerSet<Iterable, DoubleType> {
+
+	public DefaultFirstOrderStatsComputerSet() {
+		super(new DoubleType(), Iterable.class);
+	}
+
+	@SuppressWarnings("unused")
+	@Override
+	public void initialize() {
+		if (false) {
+			// Add special implementations if needed.
+			// initialize(Arrays.asList(MinBasedOnMinMax.class,
+			// MaxBasedOnMinMax.class));
+		} else {
+			super.initialize();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends Op>[] getFeatures() {
+		return new Class[] { GeometricMean.class, HarmonicMean.class, Kurtosis.class, Mean.class, Median.class,
+				Min.class, Max.class, Moment1AboutMean.class, Moment2AboutMean.class, Moment3AboutMean.class,
+				Moment4AboutMean.class, Size.class, Skewness.class, StdDev.class, Sum.class, SumOfInverses.class,
+				SumOfLogs.class, SumOfSquares.class, Variance.class };
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Iterable getFakeInput() {
+		return ComputerSetProcessorUtils.getIterable();
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/DefaultGeometric2DComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/DefaultGeometric2DComputerSet.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.Geometric.BoundarySize;
+import net.imagej.ops.Ops.Geometric.Boxivity;
+import net.imagej.ops.Ops.Geometric.Circularity;
+import net.imagej.ops.Ops.Geometric.Convexity;
+import net.imagej.ops.Ops.Geometric.Eccentricity;
+import net.imagej.ops.Ops.Geometric.FeretsAngle;
+import net.imagej.ops.Ops.Geometric.FeretsDiameter;
+import net.imagej.ops.Ops.Geometric.MainElongation;
+import net.imagej.ops.Ops.Geometric.MajorAxis;
+import net.imagej.ops.Ops.Geometric.MinorAxis;
+import net.imagej.ops.Ops.Geometric.Roundness;
+import net.imagej.ops.Ops.Geometric.Rugosity;
+import net.imagej.ops.Ops.Geometric.Size;
+import net.imagej.ops.Ops.Geometric.Solidity;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessorUtils;
+import net.imglib2.roi.geometric.Polygon;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Default implementation of {@link Geometric2DComputerSet}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+@Plugin(type = ComputerSet.class, label = "Geometric 2D Computers")
+public class DefaultGeometric2DComputerSet extends AbstractConfigurableComputerSet<Polygon, DoubleType>
+		implements Geometric2DComputerSet<Polygon, DoubleType> {
+
+	public DefaultGeometric2DComputerSet() {
+		super(new DoubleType(), Polygon.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends Op>[] getFeatures() {
+		return new Class[] { Boxivity.class, Convexity.class, Circularity.class, Eccentricity.class,
+				MainElongation.class, FeretsAngle.class, FeretsDiameter.class, MajorAxis.class, MinorAxis.class,
+				BoundarySize.class, Roundness.class, Rugosity.class, Solidity.class, Size.class };
+	}
+
+	@Override
+	protected Polygon getFakeInput() {
+		return ComputerSetProcessorUtils.get2DPolygon();
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/DefaultHistogramComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/DefaultHistogramComputerSet.java
@@ -1,0 +1,115 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessorUtils;
+import net.imagej.ops.image.histogram.HistogramCreate;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.histogram.Histogram1d;
+import net.imglib2.type.numeric.integer.LongType;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Default implementation of {@link HistogramComputerSet}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ */
+@Plugin(type = ComputerSet.class, label = "Histogram Computerset")
+@SuppressWarnings("rawtypes")
+public class DefaultHistogramComputerSet extends AbstractComputerSet<Iterable, LongType>
+		implements HistogramComputerSet<Iterable, LongType> {
+
+	@Parameter(type = ItemIO.INPUT, label = "Number of Bins", description = "The number of bins of the histogram", min = "1", max = "2147483647", stepSize = "1")
+	private int numBins = 256;
+
+	private UnaryFunctionOp<Iterable, Histogram1d> histogramFunc;
+
+	public DefaultHistogramComputerSet() {
+		super(new LongType(), Iterable.class);
+	}
+
+	@Override
+	public void initialize() {
+		super.initialize();
+		histogramFunc = Functions.unary(ops(), HistogramCreate.class, Histogram1d.class, in(), numBins);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends Op>[] getFeatures() {
+		return new Class[] { HistogramCreate.class };
+	}
+
+	@Override
+	protected Iterable getFakeInput() {
+		return ComputerSetProcessorUtils.getIterable();
+	}
+
+	@Override
+	protected void addComputer(final Class<? extends Op> clazz) {
+		for (int i = 0; i < numBins; i++) {
+			final LongType output = outputTypeInstance.createVariable();
+			namedOutputs.put(getKey(i), output);
+		}
+	}
+
+	@Override
+	public Map<String, LongType> compute1(final Iterable input) {
+		final Histogram1d histogram = histogramFunc.compute1(input);
+		final Map<String, LongType> result = new HashMap<>();
+		for (int i = 0; i < numBins; i++) {
+			result.put(getKey(i), new LongType(histogram.frequency(i)));
+		}
+		return result;
+	}
+
+	private String getKey(final int bin) {
+		return "Histogram Bin[" + bin + "]";
+	}
+
+	@Override
+	public String[] getComputerNames() {
+		final List<String> names = new ArrayList<>();
+		for (int i = 0; i < numBins; i++) {
+			names.add(getKey(i));
+		}
+		return names.toArray(new String[names.size()]);
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/DefaultZernikeComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/DefaultZernikeComputerSet.java
@@ -1,0 +1,115 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.Ops.Zernike.Magnitude;
+import net.imagej.ops.Ops.Zernike.Phase;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessorUtils;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Default implementation of {@link ZernikeComputerSet}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+@Plugin(type = ComputerSet.class, label = "Zernike Computerset")
+@SuppressWarnings("rawtypes")
+public class DefaultZernikeComputerSet extends AbstractConfigurableComputerSet<Iterable, DoubleType>
+		implements ZernikeComputerSet<Iterable, DoubleType> {
+
+	public DefaultZernikeComputerSet() {
+		super(new DoubleType(), Iterable.class);
+	}
+
+	@Parameter(type = ItemIO.INPUT, label = "Minimum Order of Zernike Moment", description = "The minimum order of the zernike moment to be calculated.", min = "1", max = "2147483647", stepSize = "1")
+	private int orderMin = 2;
+
+	@Parameter(type = ItemIO.INPUT, label = "Maximum Order of Zernike Moment", description = "The maximum order of the zernike moment to be calculated.", min = "1", max = "2147483647", stepSize = "1")
+	private int orderMax = 4;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends Op>[] getFeatures() {
+		return new Class[] { Phase.class, Magnitude.class };
+	}
+
+	@Override
+	protected Iterable getFakeInput() {
+		return ComputerSetProcessorUtils.get2DImg();
+	}
+
+	@Override
+	protected void addComputer(final Class<? extends Op> clazz) {
+		for (int order = orderMin; order <= orderMax; order++) {
+			for (int repetition = 0; repetition <= order; repetition++) {
+				if (Math.abs(order - repetition) % 2 == 0) {
+					@SuppressWarnings("unchecked")
+					final UnaryComputerOp<Iterable, DoubleType> computer = Computers.unary(ops(), clazz,
+							(Class<DoubleType>) outputTypeInstance.getClass(), in(), order, repetition);
+					final DoubleType output = outputTypeInstance.createVariable();
+					namedOutputs.put(getKey(clazz, order, repetition), output);
+					computer.setOutput(output);
+					computers.put(clazz, computer);
+				}
+			}
+		}
+	}
+
+	private String getKey(final Class<? extends Op> clazz, final int order, final int repetition) {
+		return clazz.getSimpleName() + " for Order " + order + " and Repetition " + repetition;
+	}
+
+	@Override
+	public String[] getComputerNames() {
+		final List<String> names = new ArrayList<>();
+		for (final Class<? extends Op> clazz : getActive()) {
+			for (int order = orderMin; order <= orderMax; order++) {
+				for (int repetition = 0; repetition <= order; repetition++) {
+					if (Math.abs(order - repetition) % 2 == 0) {
+						names.add(getKey(clazz, order, repetition));
+					}
+				}
+			}
+		}
+		return names.toArray(new String[names.size()]);
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/FirstOrderStatsComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/FirstOrderStatsComputerSet.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import net.imagej.ops.special.computer.Computers;
+
+/**
+ * A {@link ComputerSet} which holds all {@link Computers} needed for a First
+ * Order Statistic analysis.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            input type
+ * @param <O>
+ *            output type
+ */
+public interface FirstOrderStatsComputerSet<I, O> extends ComputerSet<I, O> {
+	// NB: marker interface
+}

--- a/src/main/java/net/imagej/ops/features/sets/Geometric2DComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/Geometric2DComputerSet.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import net.imagej.ops.special.computer.Computers;
+
+/**
+ * A {@link ComputerSet} which holds all {@link Computers} needed for the
+ * analysis of 2D segments.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            input type
+ * @param <O>
+ *            output type
+ */
+public interface Geometric2DComputerSet<I, O> extends ComputerSet<I, O> {
+	// NB: Marker Interface
+}

--- a/src/main/java/net/imagej/ops/features/sets/HistogramComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/HistogramComputerSet.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import net.imagej.ops.special.computer.Computers;
+
+/**
+ * A {@link ComputerSet} which holds all {@link Computers} needed for a
+ * Histogram.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            input type
+ * @param <O>
+ *            output type
+ */
+public interface HistogramComputerSet<I, O> extends ComputerSet<I, O> {
+	// NB: Marker Interface
+}

--- a/src/main/java/net/imagej/ops/features/sets/ZernikeComputerSet.java
+++ b/src/main/java/net/imagej/ops/features/sets/ZernikeComputerSet.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets;
+
+import net.imagej.ops.special.computer.Computers;
+
+/**
+ * A {@link ComputerSet} which holds all {@link Computers} needed for a Zernike
+ * analysis.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            input type
+ * @param <O>
+ *            output type
+ */
+public interface ZernikeComputerSet<I, O> extends ComputerSet<I, O> {
+	// NB: Marker Interface
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/AbstractBinaryComputerSetProcessor.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/AbstractBinaryComputerSetProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.concurrent.ExecutorService;
+
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.Type;
+
+import org.scijava.convert.ConvertService;
+import org.scijava.plugin.Parameter;
+import org.scijava.thread.ThreadService;
+
+/**
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            Type of the input object.
+ * @param <J>
+ *            Type of the second input object.
+ * @param <F>
+ *            Inputtype of the featuresets.
+ * @param <O>
+ *            Outputtype of the featuresets.
+ */
+public abstract class AbstractBinaryComputerSetProcessor<I, J, F, O extends Type<O>>
+		extends AbstractBinaryHybridCF<I, J, Table<Column<O>, O>> implements ComputerSetProcessor<I, O> {
+
+	@Parameter
+	protected ComputerSet<F, O>[] sets;
+
+	@Parameter
+	protected ThreadService ts;
+
+	@Parameter
+	protected ConvertService cs;
+
+	protected ExecutorService es;
+
+	@Override
+	public void initialize() {
+		es = ts.getExecutorService();
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/AbstractUnaryComputerSetProcessor.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/AbstractUnaryComputerSetProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.concurrent.ExecutorService;
+
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.Type;
+
+import org.scijava.convert.ConvertService;
+import org.scijava.plugin.Parameter;
+import org.scijava.thread.ThreadService;
+
+/**
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            Type of the input object.
+ * @param <F>
+ *            Inputtype of the featuresets.
+ * @param <O>
+ *            Outputtype of the featuresets.
+ */
+public abstract class AbstractUnaryComputerSetProcessor<I, F, O extends Type<O>>
+		extends AbstractUnaryHybridCF<I, Table<Column<O>, O>> implements ComputerSetProcessor<I, O> {
+
+	@Parameter
+	protected ComputerSet<F, O>[] sets;
+
+	@Parameter
+	protected ThreadService ts;
+
+	@Parameter
+	protected ConvertService cs;
+
+	protected ExecutorService es;
+
+	@Override
+	public void initialize() {
+		es = ts.getExecutorService();
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/ComputerSetProcessor.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/ComputerSetProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.sets.processors;
+
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.special.hybrid.UnaryHybridCF;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.Type;
+
+/**
+ * A {@link ComputerSetProcessor} holds arbitrary many {@link ComputerSet} of
+ * the same types. All active features from every {@link ComputerSet} are
+ * compute on the input object and written to a FeatureTable.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            Input type
+ * @param <O>
+ *            Output type of the features
+ */
+public interface ComputerSetProcessor<I, O extends Type<O>> extends UnaryHybridCF<I, Table<Column<O>, O>> {
+	// NB: Marker Interface
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/ComputerSetProcessorUtils.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/ComputerSetProcessorUtils.java
@@ -1,0 +1,164 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.DefaultFirstOrderStatsComputerSet;
+import net.imagej.ops.features.sets.DefaultGeometric2DComputerSet;
+import net.imagej.ops.features.sets.DefaultZernikeComputerSet;
+import net.imagej.ops.geom.geom3d.mesh.Vertex;
+import net.imglib2.RealPoint;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.roi.geometric.Polygon;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.real.DoubleType;
+
+/**
+ * A utility class to handle {@link ComputerSet} with a
+ * {@link ComputerSetProcessor}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class ComputerSetProcessorUtils {
+
+	/**
+	 * Add unique suffix if needed.
+	 *
+	 * @param names
+	 *            already used names
+	 * @param n
+	 *            the new suggested name
+	 * @return the unique name
+	 */
+	private static String uniqueName(final Collection<String> names, final String n) {
+
+		if (!names.contains(n)) {
+			return n;
+		}
+
+		int c = 0;
+
+		while (names.contains(n + "[" + c + "]")) {
+			c++;
+		}
+
+		return n + "[" + c + "]";
+	}
+
+	/**
+	 * Concatenate featureset name with feature name.
+	 * 
+	 * @param featuresetName
+	 *            the name of the featureset
+	 * @param featureName
+	 *            the name of the feature
+	 * @return the concatenated string
+	 */
+	public static String getFeatureTableName(final String featuresetName, final String featureName) {
+		return featuresetName + "_" + featureName;
+	}
+
+	/**
+	 * Creates a map from {@link ComputerSet} to a unique String. If a
+	 * {@link ComputerSet} has a duplicate the suffix "[i]" (i = 0,...) is
+	 * added.
+	 *
+	 * @param featuresets
+	 *            for which unique names are required
+	 * @return map from featuresets to unique names
+	 */
+	public static <O> Map<ComputerSet<?, O>, String> getUniqueNames(final List<ComputerSet<?, O>> featuresets) {
+
+		final Map<ComputerSet<?, O>, String> names = new HashMap<>();
+
+		for (final ComputerSet<?, O> fs : featuresets) {
+			final String n = uniqueName(names.values(), fs.getClass().getSimpleName());
+			names.put(fs, n);
+		}
+
+		return names;
+	}
+
+	/**
+	 * This method is used in {@link DefaultGeometric2DComputerSet} as input
+	 * object which is needed for the matching.
+	 *
+	 * Note: This is just a workaround.
+	 *
+	 * @return polygon with two vertices.
+	 */
+	public static Polygon get2DPolygon() {
+		final List<RealPoint> v = new ArrayList<>();
+
+		v.add(new RealPoint(0, 0));
+		v.add(new RealPoint(1, 1));
+		return new Polygon(v);
+	}
+
+	/**
+	 * This method is used in {@link DefaultFirstOrderStatsComputerSet} as input
+	 * object which is needed for the matching.
+	 *
+	 * Note: This is just a workaround.
+	 *
+	 * @return an Iterable
+	 */
+	public static <T extends Type<T>> Iterable<T> getIterable() {
+		return new Iterable<T>() {
+
+			@Override
+			public Iterator<T> iterator() {
+				// just a fake object
+				return null;
+			}
+		};
+	}
+
+	/**
+	 * This method is used in {@link DefaultZernikeComputerSet} as input object
+	 * which is needed for the matching.
+	 *
+	 * Note: This is just a workaround.
+	 *
+	 * @return a 2D img
+	 */
+	public static <T extends Type<T>> ArrayImg<DoubleType, ?> get2DImg() {
+		return new ArrayImgFactory<DoubleType>().create(new long[] { 2, 2 }, new DoubleType());
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/IterableComputerSetProcessor.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/IterableComputerSetProcessor.java
@@ -1,0 +1,120 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.tables.ComputerSetTableService;
+import net.imagej.ops.features.sets.tables.DefaultTable;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * An IterableProcessor holds {@link ComputerSet}s and
+ * {@link IterableComputerSetProcessor#compute1(Iterable, Table)}
+ * computes the features on the given {@link Iterable} and returns a
+ * {@link DefaultTable}.
+ *
+ * The {@link DefaultTable} has one row and as many columns as features were
+ * calculated.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <I>
+ *            Iterable type
+ * @param <O>
+ *            Output type of the features.
+ */
+@Plugin(type = Op.class)
+public class IterableComputerSetProcessor<I, O extends Type<O>>
+		extends AbstractUnaryComputerSetProcessor<Iterable<I>, Iterable<I>, O> {
+
+	@Parameter
+	private ComputerSetTableService<O> fs;
+
+	/**
+	 * Maps each {@link ComputerSet} to a unique name. This ensures unique
+	 * column names in the {@link DefaultTable}.
+	 */
+	private Map<ComputerSet<?, O>, String> names;
+
+	@Override
+	public void initialize() {
+		super.initialize();
+	}
+
+	@Override
+	public Table<Column<O>, O> createOutput(final Iterable<I> input1) {
+		names = ComputerSetProcessorUtils.getUniqueNames(Arrays.asList(sets));
+		return fs.createTable(sets, names, 1);
+	}
+
+	@Override
+	public void compute1(final Iterable<I> input1, final Table<Column<O>, O> output) {
+
+		final List<Future<Void>> futures = new ArrayList<>();
+
+		for (final ComputerSet<Iterable<I>, O> featureset : sets) {
+
+			futures.add(es.submit(new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					final Map<String, O> result = featureset.compute1(input1);
+					for (final String name : result.keySet()) {
+						output.set(ComputerSetProcessorUtils.getFeatureTableName(names.get(featureset), name), 0,
+								result.get(name));
+					}
+					return null;
+				}
+			}));
+		}
+
+		for (final Future<Void> future : futures) {
+			try {
+				future.get();
+			} catch (InterruptedException | ExecutionException exc) {
+				throw new RuntimeException(exc);
+			}
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/LabelRegionsComputerSetProcessor.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/LabelRegionsComputerSetProcessor.java
@@ -1,0 +1,127 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.tables.ComputerSetTableService;
+import net.imagej.ops.features.sets.tables.DefaultTable;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.roi.labeling.LabelRegion;
+import net.imglib2.roi.labeling.LabelRegions;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A LabelRegionsProcessor holds {@link ComputerSet}s and
+ * {@link LabelRegionsComputerSetProcessor#compute1(LabelRegions, Table)}
+ * computes the features on the given {@link LabelRegions} and returns a
+ * {@link DefaultTable}.
+ *
+ * The {@link DefaultTable} holds for each {@link LabelRegion} a row and has as
+ * many columns as features were calculated.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <S>
+ *            LabelRegions type
+ * @param <F>
+ *            Type of the converted LabelRegion
+ * @param <O>
+ *            Output type of the features.
+ */
+@Plugin(type = Op.class)
+public class LabelRegionsComputerSetProcessor<S, F, O extends Type<O>>
+		extends AbstractUnaryComputerSetProcessor<LabelRegions<S>, F, O> {
+
+	@Parameter
+	private ComputerSetTableService<O> fs;
+
+	/**
+	 * Maps each {@link ComputerSet} to a unique name. This ensures unique
+	 * column names in the {@link DefaultTable}.
+	 */
+	private Map<ComputerSet<?, O>, String> names;
+
+	@Override
+	public Table<Column<O>, O> createOutput(final LabelRegions<S> input1) {
+		names = ComputerSetProcessorUtils.getUniqueNames(Arrays.asList(sets));
+		return fs.createTable(sets, names, input1.getExistingLabels().size());
+	}
+
+	@Override
+	public void compute1(final LabelRegions<S> input1, final Table<Column<O>, O> output) {
+
+		final List<Future<Void>> futures = new ArrayList<>();
+
+		int i = 0;
+
+		for (final LabelRegion<S> r : input1) {
+			final int j = i;
+			futures.add(es.submit(new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					for (final ComputerSet<F, O> featureset : sets) {
+						// LabelRegion has to be converted to Polygon or Mesh.
+						final Map<String, O> result = featureset.compute1(cs.convert(r, featureset.getInType()));
+						for (final String name : result.keySet()) {
+							output.set(ComputerSetProcessorUtils.getFeatureTableName(names.get(featureset), name), j,
+									result.get(name));
+						}
+					}
+					return null;
+				}
+			}));
+
+			++i;
+		}
+
+		for (final Future<Void> future : futures) {
+			try {
+				future.get();
+			} catch (InterruptedException | ExecutionException exc) {
+				throw new RuntimeException(exc);
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/processors/ROIComputerSetProcessor.java
+++ b/src/main/java/net/imagej/ops/features/sets/processors/ROIComputerSetProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.tables.ComputerSetTableService;
+import net.imagej.ops.features.sets.tables.DefaultTable;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.RandomAccessible;
+import net.imglib2.roi.Regions;
+import net.imglib2.roi.labeling.LabelRegion;
+import net.imglib2.roi.labeling.LabelRegions;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * A ROIProcessor holds {@link ComputerSet}s and
+ * {@link ROIComputerSetProcessor#compute2(RandomAccessible, LabelRegions, Table)}
+ * computes the features on the sampled {@link LabelRegion} of I and returns a
+ * {@link DefaultTable}.
+ *
+ * The {@link DefaultTable} holds for each {@link LabelRegion} a row and has as
+ * many columns as features were calculated.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <T>
+ *            type of the RandomAccessible
+ * @param <S>
+ *            type of the LabelRegions
+ * @param <O>
+ *            output type of the features
+ */
+@Plugin(type = Op.class)
+public class ROIComputerSetProcessor<T extends Type<T>, S, O extends Type<O>>
+		extends AbstractBinaryComputerSetProcessor<RandomAccessible<T>, LabelRegions<S>, Iterable<T>, O> {
+
+	@Parameter
+	private ComputerSetTableService<O> fs;
+
+	/**
+	 * Maps each {@link ComputerSet} to a unique name. This ensures unique
+	 * column names in the {@link DefaultTable}.
+	 */
+	private Map<ComputerSet<?, O>, String> names;
+
+	@Override
+	public Table<Column<O>, O> createOutput(final RandomAccessible<T> input1, final LabelRegions<S> input2) {
+		names = ComputerSetProcessorUtils.getUniqueNames(Arrays.asList(sets));
+		return fs.createTable(sets, names, input2.getExistingLabels().size());
+	}
+
+	@Override
+	public void compute2(final RandomAccessible<T> input1, final LabelRegions<S> input2,
+			final Table<Column<O>, O> output) {
+
+		final List<Future<Void>> futures = new ArrayList<>();
+
+		int i = 0;
+
+		for (final LabelRegion<S> r : input2) {
+			final int j = i;
+			final Iterable<T> roi = Regions.sample(r, input1);
+			futures.add(es.submit(new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					for (final ComputerSet<Iterable<T>, O> featureset : sets) {
+						final Map<String, O> result = featureset.compute1(roi);
+						for (final String name : result.keySet()) {
+							output.set(ComputerSetProcessorUtils.getFeatureTableName(names.get(featureset), name), j,
+									result.get(name));
+						}
+					}
+					return null;
+				}
+			}));
+
+			++i;
+		}
+
+		for (final Future<Void> future : futures) {
+			try {
+				future.get();
+			} catch (InterruptedException | ExecutionException exc) {
+				throw new RuntimeException(exc);
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/net/imagej/ops/features/sets/tables/ComputerSetTableService.java
+++ b/src/main/java/net/imagej/ops/features/sets/tables/ComputerSetTableService.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.tables;
+
+import java.util.Map;
+
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessor;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.Type;
+
+/**
+ * This class creates a result table for a {@link ComputerSetProcessor}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz.
+ *
+ * @param <O>
+ *            datatype of the table entries
+ */
+public interface ComputerSetTableService<O extends Type<O>> {
+
+	/**
+	 * Create a new {@link Table} to store the results of a
+	 * {@link ComputerSetProcessor}.
+	 *
+	 * @param featuresets
+	 *            of the {@link ComputerSetProcessor}
+	 * @param names
+	 *            a map which maps a unique name to each {@link ComputerSet}
+	 * @param numRows
+	 *            number of rows
+	 * @return a table with a column for each feature and numRows rows.
+	 */
+	public Table<Column<O>, O> createTable(final ComputerSet<?, O>[] featuresets,
+			final Map<ComputerSet<?, O>, String> names, final int numRows);
+}

--- a/src/main/java/net/imagej/ops/features/sets/tables/DefaultComputerSetTableService.java
+++ b/src/main/java/net/imagej/ops/features/sets/tables/DefaultComputerSetTableService.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.tables;
+
+import java.util.Map;
+
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessor;
+import net.imagej.ops.features.sets.processors.ComputerSetProcessorUtils;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.Type;
+
+/**
+ * Default implementation of {@link ComputerSetTableService}.
+ *
+ * The columns are added in the same order the {@link ComputerSet}s were added
+ * to the {@link ComputerSetProcessor}.
+ *
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ * @param <O>
+ *            datatype of the table entries.
+ */
+public class DefaultComputerSetTableService<O extends Type<O>> implements ComputerSetTableService<O> {
+
+	private final Table<Column<O>, O> table;
+
+	public DefaultComputerSetTableService() {
+		table = new DefaultTable<>();
+	}
+
+	@Override
+	public Table<Column<O>, O> createTable(final ComputerSet<?, O>[] featuresets,
+			final Map<ComputerSet<?, O>, String> names, final int numRows) {
+		for (final ComputerSet<?, O> fs : featuresets) {
+			final String fsName = names.get(fs);
+
+			for (final String n : fs.getComputerNames()) {
+				table.appendColumn(ComputerSetProcessorUtils.getFeatureTableName(fsName, n));
+
+			}
+		}
+
+		for (int i = 0; i < numRows; i++) {
+			table.appendRow();
+		}
+		return table;
+	}
+}

--- a/src/main/java/net/imagej/ops/features/sets/tables/DefaultTable.java
+++ b/src/main/java/net/imagej/ops/features/sets/tables/DefaultTable.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.features.sets.tables;
+
+import net.imagej.table.AbstractTable;
+import net.imagej.table.Column;
+import net.imagej.table.DefaultColumn;
+import net.imglib2.type.Type;
+
+/**
+ * DefaultTable implementation of {@link AbstractTable}. The user has to take
+ * care of unique column names.
+ *
+ * @author Tim-Oliver Buchholz, Univeristy of Konstanz
+ *
+ * @param <O>
+ *            datatype of the table
+ */
+public class DefaultTable<O extends Type<O>> extends AbstractTable<Column<O>, O> {
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	protected Column<O> createColumn(final String header) {
+		return new DefaultColumn<>(header);
+	}
+
+}

--- a/src/test/java/net/imagej/ops/features/AbstractFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/AbstractFeatureTest.java
@@ -264,6 +264,11 @@ public class AbstractFeatureTest extends AbstractOpTest {
 	protected static LabelRegion<String> createLabelRegion2D()
 		throws MalformedURLException, IOException
 	{
+		return createLabelRegions2D().getLabelRegion("1");
+
+	}
+
+	protected static LabelRegions<String> createLabelRegions2D() throws IOException {
 		final String imageName = expensiveTestsEnabled ? "cZgkFsK_expensive.png"
 			: "cZgkFsK.png";
 		// read simple polygon image
@@ -286,8 +291,7 @@ public class AbstractFeatureTest extends AbstractOpTest {
 		}
 
 		final LabelRegions<String> labelRegions = new LabelRegions<>(img);
-		return labelRegions.getLabelRegion("1");
-
+		return labelRegions;
 	}
 
 	protected static Img<FloatType> getTestImage3D() {

--- a/src/test/java/net/imagej/ops/features/sets/processors/AbstractComputerSetProcessorTest.java
+++ b/src/test/java/net/imagej/ops/features/sets/processors/AbstractComputerSetProcessorTest.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.List;
+import java.util.Map;
+
+import net.imagej.ops.features.AbstractFeatureTest;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Assert;
+
+/**
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public abstract class AbstractComputerSetProcessorTest extends AbstractFeatureTest {
+
+
+	protected void checkAllResultTableForOneComputerSet(
+			Table<Column<DoubleType>, DoubleType> result, List<ComputerSet<?, DoubleType>> tmp) {
+		String computerSetName = ComputerSetProcessorUtils.getUniqueNames(tmp).get(tmp.get(0));
+
+		String[] names = tmp.get(0).getComputerNames();
+
+		for (int i = 0; i < result.getColumnCount(); i++) {
+			String tmpName = computerSetName + "_" + names[i];
+			Assert.assertTrue("Wrong column order.", tmpName.equals(result.get(i).getHeader()));
+		}
+	}
+	
+
+	protected void checkResultTableForManyComputerSets(Table<Column<DoubleType>, DoubleType> result,
+			List<ComputerSet<?, DoubleType>> tmp) {
+		Map<ComputerSet<?, DoubleType>, String> computerSetNames = ComputerSetProcessorUtils.getUniqueNames(tmp);
+
+		int i = 0;
+		for (ComputerSet<?, DoubleType> set : tmp) {
+			String computerSetName = computerSetNames.get(set);
+			String[] names = set.getComputerNames();
+			for (String s : names) {
+				String tmpName = computerSetName + "_" + s;
+				Assert.assertTrue("Wrong column order.", tmpName.equals(result.get(i++).getHeader()));
+			}
+		}
+	}
+}

--- a/src/test/java/net/imagej/ops/features/sets/processors/ComputerSetProcessorUtilsTest.java
+++ b/src/test/java/net/imagej/ops/features/sets/processors/ComputerSetProcessorUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.FirstOrderStatsComputerSet;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for the {@link ComputerSetProcessorUtils}.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class ComputerSetProcessorUtilsTest extends AbstractOpTest {
+
+	@SuppressWarnings({ "cast", "unchecked" })
+	@Test
+	public void uniqueNamesTest() {
+		List<ComputerSet<?, DoubleType>> sets = new ArrayList<>();
+		sets.add((FirstOrderStatsComputerSet<?, DoubleType>) ops.op(FirstOrderStatsComputerSet.class, Iterable.class));
+		sets.add((FirstOrderStatsComputerSet<?, DoubleType>) ops.op(FirstOrderStatsComputerSet.class, Iterable.class));
+
+		Map<ComputerSet<?, DoubleType>, String> uniqueNames = ComputerSetProcessorUtils.getUniqueNames(sets);
+
+		Collection<String> names = uniqueNames.values();
+		Collection<String> copy = new HashSet<>(names);
+
+		for (String s : names) {
+			copy.remove(s);
+			Assert.assertTrue("Duplicated name.", !copy.contains(s));
+		}
+
+		int i = -1;
+		for (ComputerSet<?, DoubleType> computerSet : sets) {
+			if (i == -1) {
+				Assert.assertTrue("No suffix is needed.",
+						computerSet.getClass().getSimpleName().equals(uniqueNames.get(computerSet)));
+				i++;
+			} else {
+				String tmp = computerSet.getClass().getSimpleName();
+				tmp = tmp + "[" + i + "]";
+				Assert.assertTrue("Incorrect suffix.", tmp.equals(uniqueNames.get(computerSet)));
+			}
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/ops/features/sets/processors/IterableComputerSetProcessorTest.java
+++ b/src/test/java/net/imagej/ops/features/sets/processors/IterableComputerSetProcessorTest.java
@@ -1,0 +1,107 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import net.imagej.ops.Ops.Stats.Max;
+import net.imagej.ops.Ops.Stats.Mean;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.FirstOrderStatsComputerSet;
+import net.imagej.ops.features.sets.tables.DefaultComputerSetTableService;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Test;
+
+/**
+ * Test for the {@link IterableComputerSetProcessor}.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class IterableComputerSetProcessorTest extends AbstractComputerSetProcessorTest {
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void IterableComputerSetProcessorAllComputersAreActiveTest() {
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class);
+
+		IterableComputerSetProcessor<FloatType, DoubleType> processor = ops.op(IterableComputerSetProcessor.class,
+				Iterable.class, new ComputerSet[] { stats }, new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute1(getTestImage2D());
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(stats);
+		checkAllResultTableForOneComputerSet(result, tmp);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void IterableComputerSetProcessorSomeComputersAreActiveTest() {
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class, Arrays.asList(new Class[] { Mean.class, Max.class }));
+
+		IterableComputerSetProcessor<FloatType, DoubleType> processor = ops.op(IterableComputerSetProcessor.class,
+				Iterable.class, new ComputerSet[] { stats }, new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute1(getTestImage2D());
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(stats);
+		checkAllResultTableForOneComputerSet(result, tmp);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void IterableComputerSetProcessorWithTwoComputerSetsTest() {
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class);
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats1 = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class, Arrays.asList(new Class[] { Mean.class, Max.class }));
+
+		IterableComputerSetProcessor<FloatType, DoubleType> processor = ops.op(IterableComputerSetProcessor.class,
+				Iterable.class, new ComputerSet[] { stats, stats1 }, new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute1(getTestImage2D());
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(stats);
+		tmp.add(stats1);
+		checkResultTableForManyComputerSets(result, tmp);
+	}
+
+}

--- a/src/test/java/net/imagej/ops/features/sets/processors/LabelRegionsComputerSetProcessorTest.java
+++ b/src/test/java/net/imagej/ops/features/sets/processors/LabelRegionsComputerSetProcessorTest.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import net.imagej.ops.Ops.Geometric.Circularity;
+import net.imagej.ops.Ops.Geometric.Size;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.Geometric2DComputerSet;
+import net.imagej.ops.features.sets.tables.DefaultComputerSetTableService;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.roi.geometric.Polygon;
+import net.imglib2.roi.labeling.LabelRegions;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test for the {@link LabelRegionsComputerSetProcessor}.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class LabelRegionsComputerSetProcessorTest extends AbstractComputerSetProcessorTest {
+	
+	private LabelRegions<String> roi;
+
+	@Before
+	public void createROI() throws IOException {
+		roi = createLabelRegions2D();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void LabelRegionsComputerSetProcessorAllComputersAreActiveTest() {
+		Geometric2DComputerSet<Polygon, DoubleType> geom = ops.op(Geometric2DComputerSet.class, Polygon.class);
+
+		LabelRegionsComputerSetProcessor<String, DoubleType, DoubleType> processor = ops.op(
+				LabelRegionsComputerSetProcessor.class, LabelRegions.class, new ComputerSet[] { geom },
+				new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute1(roi);
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(geom);
+		checkAllResultTableForOneComputerSet(result, tmp);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void LabelRegionsComputerSetProcessorSomeComputersAreActiveTest() {
+		Geometric2DComputerSet<Polygon, DoubleType> geom = ops.op(Geometric2DComputerSet.class, Polygon.class,
+				Arrays.asList(new Class[] { Circularity.class, Size.class }));
+
+		LabelRegionsComputerSetProcessor<String, DoubleType, DoubleType> processor = ops.op(
+				LabelRegionsComputerSetProcessor.class, LabelRegions.class, new ComputerSet[] { geom },
+				new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute1(roi);
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(geom);
+		checkAllResultTableForOneComputerSet(result, tmp);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void LabelRegionsComputerSetProcessorWithTwoComputerSetsTest() {
+		Geometric2DComputerSet<Polygon, DoubleType> geom = ops.op(Geometric2DComputerSet.class, Polygon.class);
+		Geometric2DComputerSet<Polygon, DoubleType> geom1 = ops.op(Geometric2DComputerSet.class, Polygon.class,
+				Arrays.asList(new Class[] { Circularity.class, Size.class }));
+
+		LabelRegionsComputerSetProcessor<String, DoubleType, DoubleType> processor = ops.op(
+				LabelRegionsComputerSetProcessor.class, LabelRegions.class, new ComputerSet[] { geom, geom1 },
+				new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute1(roi);
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(geom);
+		tmp.add(geom1);
+		checkResultTableForManyComputerSets(result, tmp);
+	}
+
+}

--- a/src/test/java/net/imagej/ops/features/sets/processors/ROIComputerSetProcessorTest.java
+++ b/src/test/java/net/imagej/ops/features/sets/processors/ROIComputerSetProcessorTest.java
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.features.sets.processors;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import net.imagej.ops.Ops.Stats.Max;
+import net.imagej.ops.Ops.Stats.Mean;
+import net.imagej.ops.features.sets.ComputerSet;
+import net.imagej.ops.features.sets.FirstOrderStatsComputerSet;
+import net.imagej.ops.features.sets.tables.DefaultComputerSetTableService;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import net.imglib2.RandomAccessible;
+import net.imglib2.roi.labeling.LabelRegions;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Test;
+
+/**
+ * Test for the {@link ROIComputerSetProcessor}.
+ * 
+ * @author Tim-Oliver Buchholz, University of Konstanz
+ *
+ */
+public class ROIComputerSetProcessorTest extends AbstractComputerSetProcessorTest {
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void ROIComputerSetProcessorAllComputersAreActiveTest() throws IOException {
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class);
+
+		ROIComputerSetProcessor<FloatType, String, DoubleType> processor = ops.op(ROIComputerSetProcessor.class,
+				RandomAccessible.class, LabelRegions.class, new ComputerSet[] { stats },
+				new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute2(getTestImage2D(), createLabelRegions2D());
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(stats);
+		checkAllResultTableForOneComputerSet(result, tmp);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void ROIComputerSetProcessorSomeComputersAreActiveTest() throws IOException {
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class, Arrays.asList(new Class[] { Mean.class, Max.class }));
+
+		ROIComputerSetProcessor<FloatType, String, DoubleType> processor = ops.op(ROIComputerSetProcessor.class,
+				RandomAccessible.class, LabelRegions.class, new ComputerSet[] { stats },
+				new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute2(getTestImage2D(), createLabelRegions2D());
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(stats);
+		checkAllResultTableForOneComputerSet(result, tmp);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void ROIComputerSetProcessorWithTwoComputerSetsTest() throws IOException {
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class);
+		FirstOrderStatsComputerSet<Iterable, DoubleType> stats1 = ops.op(FirstOrderStatsComputerSet.class,
+				Iterable.class, Arrays.asList(new Class[] { Mean.class, Max.class }));
+
+		ROIComputerSetProcessor<FloatType, String, DoubleType> processor = ops.op(ROIComputerSetProcessor.class,
+				RandomAccessible.class, LabelRegions.class, new ComputerSet[] { stats, stats1 },
+				new DefaultComputerSetTableService<>());
+
+		Table<Column<DoubleType>, DoubleType> result = processor.compute2(getTestImage2D(), createLabelRegions2D());
+
+		List<ComputerSet<?, DoubleType>> tmp = new ArrayList<>();
+		tmp.add(stats);
+		tmp.add(stats1);
+		checkResultTableForManyComputerSets(result, tmp);
+	}
+
+}


### PR DESCRIPTION
This PR adds so called ComputerSets (<==> FeatureSet). A ComputerSet holds different ComputerOps which build a common known measurement-group. 

Now all FirstOrderStats ops could be combined in a FirstOrderStatsComputerSet. Same goes for different groups like Zernike, Histogram or Geometric2D (and many others which have to be implemented). 

There are non-configurable and configurable ComputerSets. Configurable means that each op of this ComputerSet could either be active or inactive. 

The ComputerSets are processed by the ComputerSetProcessor. There are three different implementations. One for ComputerSets based on Iterables (FirstOrderStats), one for ComputerSets based on LabelRegions (Geometric2D) and one for ComputerSets which should be computed over ROIs (FirstOrderStats on every segment of a LabelRegions).

To a ComputerSetProcessor arbitrarily many ComputerSets could be added. The ComputerSetProcessor will create a Table with a column for each computed op of every ComputerSet. The IterableComputerSetProcessor creates a table with one output row and the LabelRegions- and ROIComputerSetProcessor creates a output row for each segment of the Labeling. 
The ComputerSetProcessor takes care of unique column names in the output-table. 

```
// create a FirstOrderStatsComputerSet with all Computers activated
FirstOrderStatsComputerSet<Iterable, DoubleType> stats = ops.op(FirstOrderStatsComputerSet.class,
				Iterable.class);

// create a FirstOrderStatsComputerSet with only Mean and Max Computers activated
FirstOrderStatsComputerSet<Iterable, DoubleType> stats1 = ops.op(FirstOrderStatsComputerSet.class,
				Iterable.class, Arrays.asList(new Class[] { Mean.class, Max.class }));

// create an IterableComputerSetProcessor which holds the two ComputerSets
		IterableComputerSetProcessor<FloatType, DoubleType> processor = ops.op(IterableComputerSetProcessor.class,
				Iterable.class, new ComputerSet[] { stats, stats1 }, new DefaultComputerSetTableService<>());

// compute the ComputerSets on img
		Table<Column<DoubleType>, DoubleType> result = processor.compute1(img);
```

@dietzc and @ctrueden please take a look. 