### PR TITLE
Integral image-based local thresholdings use provided OOBF

### DIFF
--- a/src/main/java/net/imagej/ops/stats/IntegralMean.java
+++ b/src/main/java/net/imagej/ops/stats/IntegralMean.java
@@ -33,8 +33,7 @@ package net.imagej.ops.stats;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
 import net.imagej.ops.image.integral.IntegralCursor;
-import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
-import net.imglib2.Interval;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.RealDoubleConverter;
@@ -54,18 +53,18 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Stats.IntegralMean.class)
 public class IntegralMean<I extends RealType<I>> extends
-	AbstractBinaryComputerOp<RectangleNeighborhood<Composite<I>>, Interval, DoubleType>
+	AbstractUnaryComputerOp<RectangleNeighborhood<Composite<I>>, DoubleType>
 	implements Ops.Stats.IntegralMean
 {
 
 	@Override
-	public void compute2(final RectangleNeighborhood<Composite<I>> input1,
-		final Interval input2, final DoubleType output)
+	public void compute1(final RectangleNeighborhood<Composite<I>> input,
+		final DoubleType output)
 	{
 		// computation according to
 		// https://en.wikipedia.org/wiki/Summed_area_table
-		final IntegralCursor<Composite<I>> cursor = new IntegralCursor<>(input1);
-		final int dimensions = input1.numDimensions();
+		final IntegralCursor<Composite<I>> cursor = new IntegralCursor<>(input);
+		final int dimensions = input.numDimensions();
 
 		// Compute \sum (-1)^{dim - ||cornerVector||_{1}} * I(x^{cornerVector})
 		final DoubleType sum = new DoubleType();
@@ -91,8 +90,8 @@ public class IntegralMean<I extends RealType<I>> extends
 			sum.add(valueAsDoubleType);
 		}
 
-		final int area = (int) Intervals.numElements(Intervals.expand(input1, -1l));
-		
+		final int area = (int) Intervals.numElements(Intervals.expand(input, -1l));
+
 		// Compute mean by dividing the sum divided by the number of elements
 		valueAsDoubleType.set(area); // NB: Reuse DoubleType
 		sum.div(valueAsDoubleType);

--- a/src/main/java/net/imagej/ops/stats/IntegralMean.java
+++ b/src/main/java/net/imagej/ops/stats/IntegralMean.java
@@ -91,29 +91,13 @@ public class IntegralMean<I extends RealType<I>> extends
 			sum.add(valueAsDoubleType);
 		}
 
-		// Compute overlap
-		final int area = IntegralMean.overlap(Intervals.expand(input1, -1l),
-			input2);
-
+		final int area = (int) Intervals.numElements(Intervals.expand(input1, -1l));
+		
 		// Compute mean by dividing the sum divided by the number of elements
 		valueAsDoubleType.set(area); // NB: Reuse DoubleType
 		sum.div(valueAsDoubleType);
 
 		output.set(sum);
-	}
-
-	/**
-	 * Compute the overlap between to intervals.
-	 *
-	 * @param interval1
-	 * @param interval2
-	 * @return area/volume/etc
-	 */
-	public static int overlap(final Interval interval1,
-		final Interval interval2)
-	{
-		final Interval intersection = Intervals.intersect(interval1, interval2);
-		return (int) Intervals.numElements(intersection);
 	}
 
 	/**

--- a/src/main/java/net/imagej/ops/stats/IntegralVariance.java
+++ b/src/main/java/net/imagej/ops/stats/IntegralVariance.java
@@ -106,9 +106,7 @@ public class IntegralVariance<I extends RealType<I>> extends
 			sum2.add(valueAsDoubleType);
 		}
 
-		// Compute overlap
-		final int area = IntegralMean.overlap(Intervals.expand(input1, -1l),
-			input2);
+		final int area = (int) Intervals.numElements(Intervals.expand(input1, -1l));
 
 		valueAsDoubleType.set(area); // NB: Reuse available DoubleType
 		sum1.mul(sum1);

--- a/src/main/java/net/imagej/ops/stats/IntegralVariance.java
+++ b/src/main/java/net/imagej/ops/stats/IntegralVariance.java
@@ -33,8 +33,7 @@ package net.imagej.ops.stats;
 import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
 import net.imagej.ops.image.integral.IntegralCursor;
-import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
-import net.imglib2.Interval;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.RealDoubleConverter;
@@ -54,18 +53,18 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Stats.IntegralVariance.class)
 public class IntegralVariance<I extends RealType<I>> extends
-	AbstractBinaryComputerOp<RectangleNeighborhood<Composite<I>>, Interval, DoubleType>
+	AbstractUnaryComputerOp<RectangleNeighborhood<Composite<I>>, DoubleType>
 	implements Ops.Stats.IntegralVariance
 {
 
 	@Override
-	public void compute2(final RectangleNeighborhood<Composite<I>> input1,
-		final Interval input2, final DoubleType output)
+	public void compute1(final RectangleNeighborhood<Composite<I>> input,
+		final DoubleType output)
 	{
 		// computation according to
 		// https://en.wikipedia.org/wiki/Summed_area_table
-		final IntegralCursor<Composite<I>> cursorS1 = new IntegralCursor<>(input1);
-		final int dimensions = input1.numDimensions();
+		final IntegralCursor<Composite<I>> cursorS1 = new IntegralCursor<>(input);
+		final int dimensions = input.numDimensions();
 
 		// Compute \sum (-1)^{dim - ||cornerVector||_{1}} * I(x^{cornerVector})
 		final DoubleType sum1 = new DoubleType();
@@ -106,7 +105,7 @@ public class IntegralVariance<I extends RealType<I>> extends
 			sum2.add(valueAsDoubleType);
 		}
 
-		final int area = (int) Intervals.numElements(Intervals.expand(input1, -1l));
+		final int area = (int) Intervals.numElements(Intervals.expand(input, -1l));
 
 		valueAsDoubleType.set(area); // NB: Reuse available DoubleType
 		sum1.mul(sum1);

--- a/src/main/java/net/imagej/ops/stats/StatsNamespace.java
+++ b/src/main/java/net/imagej/ops/stats/StatsNamespace.java
@@ -96,10 +96,10 @@ public class StatsNamespace extends AbstractNamespace {
 	@SuppressWarnings("rawtypes")
 	@OpMethod(op = net.imagej.ops.stats.IntegralMean.class)
 	public DoubleType integralMean(final DoubleType out,
-		final RectangleNeighborhood in1, final Interval in2)
+		final RectangleNeighborhood in)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.stats.IntegralMean.class, out, in1, in2);
+			net.imagej.ops.stats.IntegralMean.class, out, in);
 		return result;
 	}
 
@@ -124,10 +124,10 @@ public class StatsNamespace extends AbstractNamespace {
 	@SuppressWarnings("rawtypes")
 	@OpMethod(op = net.imagej.ops.stats.IntegralVariance.class)
 	public DoubleType integralVariance(final DoubleType out,
-		final RectangleNeighborhood in1, final Interval in2)
+		final RectangleNeighborhood in)
 	{
 		final DoubleType result = (DoubleType) ops().run(
-			net.imagej.ops.stats.IntegralVariance.class, out, in1, in2);
+			net.imagej.ops.stats.IntegralVariance.class, out, in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/apply/LocalThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/LocalThreshold.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.threshold.apply;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.filter.AbstractCenterAwareNeighborhoodBasedFilter;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
@@ -43,7 +44,12 @@ import net.imglib2.type.numeric.RealType;
  * @author Stefan Helfrich (University of Konstanz)
  */
 public abstract class LocalThreshold<T extends RealType<T>> extends
-	AbstractCenterAwareNeighborhoodBasedFilter<T, BitType>
+	AbstractCenterAwareNeighborhoodBasedFilter<T, BitType> implements Contingent
 {
-	// NB
+
+	@Override
+	public boolean conforms() {
+		return true;
+	}
+
 }

--- a/src/main/java/net/imagej/ops/threshold/apply/LocalThresholdIntegral.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/LocalThresholdIntegral.java
@@ -33,6 +33,7 @@ package net.imagej.ops.threshold.apply;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.Ops.Map;
 import net.imagej.ops.map.neighborhood.CenterAwareIntegralComputerOp;

--- a/src/main/java/net/imagej/ops/threshold/apply/LocalThresholdIntegral.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/LocalThresholdIntegral.java
@@ -142,33 +142,51 @@ public abstract class LocalThresholdIntegral<I extends RealType<I>> extends
 	private RandomAccessibleInterval<RealType> getIntegralImage(
 		final RandomAccessibleInterval<I> input, final int order)
 	{
+		ExtendedRandomAccessibleInterval<I, RandomAccessibleInterval<I>> extendedInput =
+			Views.extend(input, outOfBoundsFactory);
+		FinalInterval expandedInterval = Intervals.expand(input, shape.getSpan()-1);
+		IntervalView<I> offsetInterval2 = Views.offsetInterval(extendedInput, expandedInterval);
+		
 		RandomAccessibleInterval<RealType> img = null;
 		switch (order) {
 			case 1:
-				img = (RandomAccessibleInterval) integralImgOp.compute1(input);
+				img = (RandomAccessibleInterval) integralImgOp.compute1(offsetInterval2);
 				break;
 			case 2:
-				img = (RandomAccessibleInterval) squareIntegralImgOp.compute1(input);
+				img = (RandomAccessibleInterval) squareIntegralImgOp.compute1(offsetInterval2);
 				break;
 		}
 
-		final long[] min = Intervals.minAsLongArray(img);
-		final long[] max = Intervals.maxAsLongArray(img);
+		img = addLeadingZeros(img);
+
+		return img;
+	}
+
+	/**
+	 * Add 0s before axis minimum.
+	 * 
+	 * @param input Input RAI
+	 * @return An extended and cropped version of input
+	 */
+	private <T extends RealType<T>> RandomAccessibleInterval<T> addLeadingZeros(
+		RandomAccessibleInterval<T> input)
+	{
+		final long[] min = Intervals.minAsLongArray(input);
+		final long[] max = Intervals.maxAsLongArray(input);
 
 		for (int i = 0; i < max.length; i++) {
 			min[i]--;
 		}
 
-		final RealType realZero = (RealType) Util.getTypeFromInterval(img).copy();
+		final T realZero = Util.getTypeFromInterval(input).copy();
 		realZero.setZero();
 
-		final ExtendedRandomAccessibleInterval extendedImg = Views.extendValue(img,
+		final ExtendedRandomAccessibleInterval<T, RandomAccessibleInterval<T>> extendedImg = Views.extendValue(input,
 			realZero);
-		final IntervalView<RealType> offsetInterval = Views.interval(extendedImg,
+		final IntervalView<T> offsetInterval = Views.interval(extendedImg,
 			min, max);
-		img = Views.zeroMin(offsetInterval);
-
-		return img;
+		
+		return Views.zeroMin(offsetInterval);
 	}
 
 	/**
@@ -185,7 +203,9 @@ public abstract class LocalThresholdIntegral<I extends RealType<I>> extends
 		final long[] max = Intervals.maxAsLongArray(input);
 
 		for (int d = 0; d < input.numDimensions(); ++d) {
-			min[d]++;
+			int correctedSpan = getShape().getSpan() - 1;
+			min[d] += (1 + correctedSpan);
+			max[d] -= correctedSpan;
 		}
 
 		// Define the Interval on the infinite random accessibles

--- a/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThreshold.java
@@ -40,6 +40,7 @@ import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -85,5 +86,16 @@ public class LocalMeanThreshold<T extends RealType<T>> extends
 		op.setEnvironment(ops());
 		return op;
 	}
-	
+
+	@Override
+	public boolean conforms() {
+		RectangleShape rect = getShape() instanceof RectangleShape
+			? (RectangleShape) getShape() : null;
+		if (rect == null) {
+			return true;
+		}
+
+		return rect.getSpan() <= 2;
+	}
+
 }

--- a/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThresholdIntegral.java
+++ b/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThresholdIntegral.java
@@ -35,7 +35,6 @@ import net.imagej.ops.map.neighborhood.CenterAwareIntegralComputerOp;
 import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.stats.IntegralMean;
 import net.imagej.ops.threshold.apply.LocalThresholdIntegral;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.converter.Converter;
@@ -80,8 +79,8 @@ public class LocalMeanThresholdIntegral<T extends RealType<T>> extends
 	@Override
 	protected CenterAwareIntegralComputerOp<T, BitType> unaryComputer() {
 		final CenterAwareIntegralComputerOp<T, BitType> op =
-			new LocalMeanThresholdComputer<>(in(), ops().op(IntegralMean.class,
-				DoubleType.class, RectangleNeighborhood.class, Interval.class));
+			new LocalMeanThresholdComputer<>(ops().op(IntegralMean.class,
+				DoubleType.class, RectangleNeighborhood.class));
 
 		op.setEnvironment(ops());
 		return op;
@@ -92,14 +91,11 @@ public class LocalMeanThresholdIntegral<T extends RealType<T>> extends
 		implements CenterAwareIntegralComputerOp<I, BitType>
 	{
 
-		RandomAccessibleInterval<I> source;
 		private final IntegralMean<DoubleType> integralMean;
 
-		public LocalMeanThresholdComputer(final RandomAccessibleInterval<I> source,
-			final IntegralMean<DoubleType> integralMean)
+		public LocalMeanThresholdComputer(final IntegralMean<DoubleType> integralMean)
 		{
 			super();
-			this.source = source;
 			this.integralMean = integralMean;
 		}
 
@@ -110,7 +106,7 @@ public class LocalMeanThresholdIntegral<T extends RealType<T>> extends
 		{
 
 			final DoubleType sum = new DoubleType();
-			integralMean.compute2(neighborhood, source, sum);
+			integralMean.compute1(neighborhood, sum);
 
 			// Subtract the contrast
 			sum.sub(new DoubleType(c));

--- a/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThreshold.java
@@ -40,6 +40,7 @@ import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -97,6 +98,17 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends LocalThreshold
 
 		op.setEnvironment(ops());
 		return op;
+	}
+
+	@Override
+	public boolean conforms() {
+		RectangleShape rect = getShape() instanceof RectangleShape
+			? (RectangleShape) getShape() : null;
+		if (rect == null) {
+			return true;
+		}
+
+		return rect.getSpan() <= 2;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThresholdIntegral.java
+++ b/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThresholdIntegral.java
@@ -7,7 +7,6 @@ import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.stats.IntegralMean;
 import net.imagej.ops.stats.IntegralVariance;
 import net.imagej.ops.threshold.apply.LocalThresholdIntegral;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.converter.Converter;
@@ -54,10 +53,10 @@ public class LocalNiblackThresholdIntegral<T extends RealType<T>> extends
 	@Override
 	protected CenterAwareIntegralComputerOp<T, BitType> unaryComputer() {
 		final CenterAwareIntegralComputerOp<T, BitType> op =
-			new LocalNiblackThresholdComputer<>(in(), ops().op(IntegralMean.class,
-				DoubleType.class, RectangleNeighborhood.class, Interval.class), ops()
+			new LocalNiblackThresholdComputer<>(ops().op(IntegralMean.class,
+				DoubleType.class, RectangleNeighborhood.class), ops()
 					.op(IntegralVariance.class, DoubleType.class,
-						RectangleNeighborhood.class, Interval.class));
+						RectangleNeighborhood.class));
 
 		op.setEnvironment(ops());
 		return op;
@@ -68,17 +67,14 @@ public class LocalNiblackThresholdIntegral<T extends RealType<T>> extends
 		implements CenterAwareIntegralComputerOp<I, BitType>
 	{
 
-		RandomAccessibleInterval<I> source;
 		private final IntegralMean<DoubleType> integralMean;
 		private final IntegralVariance<DoubleType> integralVariance;
 
 		public LocalNiblackThresholdComputer(
-			final RandomAccessibleInterval<I> source,
 			final IntegralMean<DoubleType> integralMean,
 			final IntegralVariance<DoubleType> integralVariance)
 		{
 			super();
-			this.source = source;
 			this.integralMean = integralMean;
 			this.integralVariance = integralVariance;
 		}
@@ -92,12 +88,12 @@ public class LocalNiblackThresholdIntegral<T extends RealType<T>> extends
 			final DoubleType threshold = new DoubleType(0.0d);
 
 			final DoubleType mean = new DoubleType();
-			integralMean.compute2(neighborhood, source, mean);
+			integralMean.compute1(neighborhood, mean);
 
 			threshold.add(mean);
 
 			final DoubleType variance = new DoubleType();
-			integralVariance.compute2(neighborhood, source, variance);
+			integralVariance.compute1(neighborhood, variance);
 
 			final DoubleType stdDev = new DoubleType(Math.sqrt(variance.get()));
 			stdDev.mul(k);

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThreshold.java
@@ -40,6 +40,7 @@ import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -122,6 +123,17 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 
 		op.setEnvironment(ops());
 		return op;
+	}
+
+	@Override
+	public boolean conforms() {
+		RectangleShape rect = getShape() instanceof RectangleShape
+			? (RectangleShape) getShape() : null;
+		if (rect == null) {
+			return true;
+		}
+
+		return rect.getSpan() <= 2;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThresholdIntegral.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThresholdIntegral.java
@@ -36,7 +36,6 @@ import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.stats.IntegralMean;
 import net.imagej.ops.stats.IntegralVariance;
 import net.imagej.ops.threshold.apply.LocalThresholdIntegral;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.converter.Converter;
@@ -86,10 +85,10 @@ public class LocalPhansalkarThresholdIntegral<T extends RealType<T>> extends
 	@Override
 	protected CenterAwareIntegralComputerOp<T, BitType> unaryComputer() {
 		final CenterAwareIntegralComputerOp<T, BitType> op =
-			new LocalPhansalkarThresholdComputer<>(in(), ops().op(IntegralMean.class,
-				DoubleType.class, RectangleNeighborhood.class, Interval.class), ops()
+			new LocalPhansalkarThresholdComputer<>(ops().op(IntegralMean.class,
+				DoubleType.class, RectangleNeighborhood.class), ops()
 					.op(IntegralVariance.class, DoubleType.class,
-						RectangleNeighborhood.class, Interval.class));
+						RectangleNeighborhood.class));
 
 		op.setEnvironment(ops());
 		return op;
@@ -100,17 +99,14 @@ public class LocalPhansalkarThresholdIntegral<T extends RealType<T>> extends
 		implements CenterAwareIntegralComputerOp<I, BitType>
 	{
 
-		RandomAccessibleInterval<I> source;
 		private final IntegralMean<DoubleType> integralMean;
 		private final IntegralVariance<DoubleType> integralVariance;
 
 		public LocalPhansalkarThresholdComputer(
-			final RandomAccessibleInterval<I> source,
 			final IntegralMean<DoubleType> integralMean,
 			final IntegralVariance<DoubleType> integralVariance)
 		{
 			super();
-			this.source = source;
 			this.integralMean = integralMean;
 			this.integralVariance = integralVariance;
 		}
@@ -122,10 +118,10 @@ public class LocalPhansalkarThresholdIntegral<T extends RealType<T>> extends
 		{
 
 			final DoubleType mean = new DoubleType();
-			integralMean.compute2(neighborhood, source, mean);
+			integralMean.compute1(neighborhood, mean);
 
 			final DoubleType variance = new DoubleType();
-			integralVariance.compute2(neighborhood, source, variance);
+			integralVariance.compute1(neighborhood, variance);
 
 			final DoubleType stdDev = new DoubleType(Math.sqrt(variance.get()));
 

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThreshold.java
@@ -40,6 +40,7 @@ import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -112,5 +113,16 @@ public class LocalSauvolaThreshold<T extends RealType<T>> extends LocalThreshold
 		op.setEnvironment(ops());
 		return op;
 	}
-	
+
+	@Override
+	public boolean conforms() {
+		RectangleShape rect = getShape() instanceof RectangleShape
+			? (RectangleShape) getShape() : null;
+		if (rect == null) {
+			return true;
+		}
+
+		return rect.getSpan() <= 2;
+	}
+
 }

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThresholdIntegral.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThresholdIntegral.java
@@ -36,7 +36,6 @@ import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.stats.IntegralMean;
 import net.imagej.ops.stats.IntegralVariance;
 import net.imagej.ops.threshold.apply.LocalThresholdIntegral;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.converter.Converter;
@@ -83,10 +82,10 @@ public class LocalSauvolaThresholdIntegral<T extends RealType<T>> extends
 	@Override
 	protected CenterAwareIntegralComputerOp<T, BitType> unaryComputer() {
 		final CenterAwareIntegralComputerOp<T, BitType> op =
-			new LocalSauvolaThresholdComputer<>(in(), ops().op(IntegralMean.class,
-				DoubleType.class, RectangleNeighborhood.class, Interval.class), ops()
+			new LocalSauvolaThresholdComputer<>(ops().op(IntegralMean.class,
+				DoubleType.class, RectangleNeighborhood.class), ops()
 					.op(IntegralVariance.class, DoubleType.class,
-						RectangleNeighborhood.class, Interval.class));
+						RectangleNeighborhood.class));
 
 		op.setEnvironment(ops());
 		return op;
@@ -97,17 +96,14 @@ public class LocalSauvolaThresholdIntegral<T extends RealType<T>> extends
 		implements CenterAwareIntegralComputerOp<I, BitType>
 	{
 
-		RandomAccessibleInterval<I> source;
 		private final IntegralMean<DoubleType> integralMean;
 		private final IntegralVariance<DoubleType> integralVariance;
 
 		public LocalSauvolaThresholdComputer(
-			final RandomAccessibleInterval<I> source,
 			final IntegralMean<DoubleType> integralMean,
 			final IntegralVariance<DoubleType> integralVariance)
 		{
 			super();
-			this.source = source;
 			this.integralMean = integralMean;
 			this.integralVariance = integralVariance;
 		}
@@ -119,10 +115,10 @@ public class LocalSauvolaThresholdIntegral<T extends RealType<T>> extends
 		{
 
 			final DoubleType mean = new DoubleType();
-			integralMean.compute2(neighborhood, source, mean);
+			integralMean.compute1(neighborhood, mean);
 
 			final DoubleType variance = new DoubleType();
-			integralVariance.compute2(neighborhood, source, variance);
+			integralVariance.compute1(neighborhood, variance);
 
 			final DoubleType stdDev = new DoubleType(Math.sqrt(variance.get()));
 

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -197,6 +197,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out,
 			in,
 			new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0);
 		
 		assertEquals(out.firstElement().get(), true);
@@ -229,6 +230,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out3,
 			in,
 			new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0);
 		
 		testIterableIntervalSimilarity(out2, out3);
@@ -274,8 +276,9 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalNiblackThresholdIntegral() {
-		ops.run(LocalNiblackThresholdIntegral.class, out, in, new RectangleShape(3, false),
-			0.0, 0.0);
+		ops.run(LocalNiblackThresholdIntegral.class, out, in, new RectangleShape(3,
+			false), new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(
+				Boundary.SINGLE), 0.0, 0.0);
 
 		assertEquals(out.firstElement().get(), true);
 	}
@@ -306,6 +309,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 			out3,
 			in,
 			new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 		
 		testIterableIntervalSimilarity(out2, out3);

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -181,7 +181,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalThresholdMean() {
-		ops.run(LocalMeanThreshold.class, out, in, new RectangleShape(3, false),
+		ops.run(LocalMeanThreshold.class, out, in, new RectangleShape(1, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0);
 
@@ -221,7 +221,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		}
 		
 		// Default implementation
-		ops.run(LocalMeanThreshold.class, out2, in, new RectangleShape(1, false),
+		ops.run(LocalMeanThreshold.class, out2, in, new RectangleShape(2, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0);
 		
@@ -229,7 +229,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.run(LocalMeanThresholdIntegral.class,
 			out3,
 			in,
-			new RectangleShape(1, false),
+			new RectangleShape(2, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0);
 		
@@ -264,7 +264,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalNiblackThreshold() {
-		ops.run(LocalNiblackThreshold.class, out, in, new RectangleShape(3, false),
+		ops.run(LocalNiblackThreshold.class, out, in, new RectangleShape(1, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 
@@ -300,7 +300,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		}
 		
 		// Default implementation
-		ops.run(LocalNiblackThreshold.class, out2, in, new RectangleShape(1, false),
+		ops.run(LocalNiblackThreshold.class, out2, in, new RectangleShape(2, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 		
@@ -308,7 +308,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.run(LocalNiblackThresholdIntegral.class,
 			out3,
 			in,
-			new RectangleShape(1, false),
+			new RectangleShape(2, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 		
@@ -320,7 +320,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalPhansalkar() {
-		ops.run(LocalPhansalkarThreshold.class, out, in, new RectangleShape(3,
+		ops.run(LocalPhansalkarThreshold.class, out, in, new RectangleShape(1,
 			false), new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(
 				Boundary.SINGLE), 0.0, 0.0);
 
@@ -355,7 +355,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		}
 		
 		// Default implementation
-		ops.run(LocalPhansalkarThreshold.class, out2, in, new RectangleShape(1, false),
+		ops.run(LocalPhansalkarThreshold.class, out2, in, new RectangleShape(2, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 		
@@ -363,7 +363,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.run(LocalPhansalkarThresholdIntegral.class,
 			out3,
 			in,
-			new RectangleShape(1, false), null,
+			new RectangleShape(2, false), null,
 			0.0, 0.0);
 		
 		testIterableIntervalSimilarity(out2, out3);
@@ -374,7 +374,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testLocalSauvola() {
-		ops.run(LocalSauvolaThreshold.class, out, in, new RectangleShape(3, false),
+		ops.run(LocalSauvolaThreshold.class, out, in, new RectangleShape(1, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 
@@ -396,7 +396,6 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 * @see LocalSauvolaThresholdIntegral
 	 * @see LocalSauvolaThreshold
 	 */
-	@SuppressWarnings("null")
 	@Test
 	public void testLocalSauvolaResultsConsistency() {
 		Img<BitType> out2 = null;
@@ -410,7 +409,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		}
 		
 		// Default implementation
-		ops.run(LocalSauvolaThreshold.class, out2, in, new RectangleShape(1, false),
+		ops.run(LocalSauvolaThreshold.class, out2, in, new RectangleShape(2, false),
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 			0.0, 0.0);
 		
@@ -418,10 +417,17 @@ public class LocalThresholdTest extends AbstractOpTest {
 		ops.run(LocalSauvolaThresholdIntegral.class,
 			out3,
 			in,
-			new RectangleShape(1, false), null,
+			new RectangleShape(2, false), null,
 			0.0, 0.0);
 		
 		testIterableIntervalSimilarity(out2, out3);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testContingencyOfNormalImplementation() {
+		ops.run(LocalSauvolaThreshold.class, out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
+			0.0, 0.0);
 	}
 
 	public ArrayImg<ByteType, ByteArray> generateKnownByteArrayTestImgSmall() {


### PR DESCRIPTION
This PR changes the behavior of integral image-based local thresholding techniques such that the user provided OOBF is properly incorporated. This is achieved by increasing the size of the input image by the span of the local window/kernel and computing the integral image from this version instead of the smaller input. Hence, the provided OOBF will be used to construct the integral image. The output interval is set back to the one of the input image. 

The integral image-based implementations are now chosen based on the span as well as the image size using `Contingent`.

Closes #403 and is related to #404 (this PR removes the exact computation that is discussed in there). 