### PR TITLE
Add thresholds ops

### DIFF
--- a/src/main/java/net/imagej/ops/mask/MaskNamespace.java
+++ b/src/main/java/net/imagej/ops/mask/MaskNamespace.java
@@ -1,0 +1,63 @@
+
+package net.imagej.ops.mask;
+
+import net.imagej.ops.AbstractNamespace;
+import net.imagej.ops.Namespace;
+import net.imagej.ops.OpMethod;
+import net.imagej.ops.mask.maskHigh.DefaultMaskHigh;
+import net.imagej.ops.mask.maskLow.DefaultMaskLow;
+import net.imagej.ops.mask.maskRange.DefaultMaskRange;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * The mask namespace contains ops for creating iterables where certain values
+ * have been masked out
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+@Plugin(type = Namespace.class)
+public class MaskNamespace extends AbstractNamespace {
+
+	// -- Mask high --
+	@OpMethod(ops = DefaultMaskHigh.class)
+	public <T, S extends Comparable<T>> Iterable<T> maskHigh(Iterable<T> in,
+		S value)
+	{
+		@SuppressWarnings("unchecked")
+		Iterable<T> result = (Iterable<T>) ops().run(DefaultMaskHigh.class, in,
+			value);
+
+		return result;
+	}
+
+	// -- Mask low --
+	@OpMethod(ops = DefaultMaskLow.class)
+	public <T, S extends Comparable<T>> Iterable<T> maskLow(Iterable<T> in,
+		S value)
+	{
+		@SuppressWarnings("unchecked")
+		Iterable<T> result = (Iterable<T>) ops().run(DefaultMaskLow.class, in,
+			value);
+
+		return result;
+	}
+
+	// -- Mask range --
+	@OpMethod(ops = DefaultMaskRange.class)
+	public <T, S extends Comparable<T>> Iterable<T> maskRange(Iterable<T> in,
+		DefaultMaskRange.Range<S> range)
+	{
+		@SuppressWarnings("unchecked")
+		Iterable<T> result = (Iterable<T>) ops().run(DefaultMaskRange.class, in,
+			range);
+
+		return result;
+	}
+
+	// -- Namespace methods --
+	@Override
+	public String getName() {
+		return "mask";
+	}
+}

--- a/src/main/java/net/imagej/ops/mask/MaskNamespace.java
+++ b/src/main/java/net/imagej/ops/mask/MaskNamespace.java
@@ -7,6 +7,7 @@ import net.imagej.ops.OpMethod;
 import net.imagej.ops.mask.maskHigh.DefaultMaskHigh;
 import net.imagej.ops.mask.maskLow.DefaultMaskLow;
 import net.imagej.ops.mask.maskRange.DefaultMaskRange;
+import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Plugin;
 
@@ -45,8 +46,8 @@ public class MaskNamespace extends AbstractNamespace {
 
 	// -- Mask range --
 	@OpMethod(ops = DefaultMaskRange.class)
-	public <T, S extends Comparable<T>> Iterable<T> maskRange(Iterable<T> in,
-		DefaultMaskRange.Range<S> range)
+	public <T, U extends Comparable<T>> Iterable<T> maskRange(Iterable<T> in,
+		Pair<U, U> range)
 	{
 		@SuppressWarnings("unchecked")
 		Iterable<T> result = (Iterable<T>) ops().run(DefaultMaskRange.class, in,

--- a/src/main/java/net/imagej/ops/mask/maskHigh/DefaultMaskHigh.java
+++ b/src/main/java/net/imagej/ops/mask/maskHigh/DefaultMaskHigh.java
@@ -1,0 +1,30 @@
+
+package net.imagej.ops.mask.maskHigh;
+
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Creates an Iterable from all the elements in the input that are greater than
+ * the given value
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+@Plugin(type = Ops.Mask.MaskHigh.class)
+public class DefaultMaskHigh<T extends Type<T>, S extends Comparable<T>>
+	extends AbstractBinaryFunctionOp<Iterable<T>, S, Iterable<T>> implements
+	Ops.Mask.MaskHigh
+{
+
+	@Override
+	public Iterable<T> compute2(Iterable<T> in, S value) {
+		return StreamSupport.stream(in.spliterator(), false).filter(e -> value
+			.compareTo(e) <= 0).map(Type::copy).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/net/imagej/ops/mask/maskLow/DefaultMaskLow.java
+++ b/src/main/java/net/imagej/ops/mask/maskLow/DefaultMaskLow.java
@@ -1,0 +1,30 @@
+
+package net.imagej.ops.mask.maskLow;
+
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Creates an Iterable from all the elements in the input that are less than the
+ * given value
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+@Plugin(type = Ops.Mask.MaskLow.class)
+public class DefaultMaskLow<T extends Type<T>, S extends Comparable<T>> extends
+	AbstractBinaryFunctionOp<Iterable<T>, S, Iterable<T>> implements
+	Ops.Mask.MaskLow
+{
+
+	@Override
+	public Iterable<T> compute2(Iterable<T> in, S value) {
+		return StreamSupport.stream(in.spliterator(), false).filter(e -> value
+			.compareTo(e) >= 0).map(Type::copy).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/net/imagej/ops/mask/maskRange/DefaultMaskRange.java
+++ b/src/main/java/net/imagej/ops/mask/maskRange/DefaultMaskRange.java
@@ -8,6 +8,7 @@ import java.util.stream.StreamSupport;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
 import net.imglib2.type.Type;
+import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Plugin;
 
@@ -18,36 +19,18 @@ import org.scijava.plugin.Plugin;
  * @author Richard Domander (Royal Veterinary College, London)
  */
 @Plugin(type = Ops.Mask.MaskRange.class)
-public class DefaultMaskRange<T extends Type<T>, S extends Comparable<T>>
-	extends
-	AbstractBinaryFunctionOp<Iterable<T>, DefaultMaskRange.Range<S>, Iterable<T>>
+public class DefaultMaskRange<T extends Type<T>, U extends Comparable<T>>
+	extends AbstractBinaryFunctionOp<Iterable<T>, Pair<U, U>, Iterable<T>>
 	implements Ops.Mask.MaskRange
 {
 
 	@Override
-	public Iterable<T> compute2(Iterable<T> iterable, Range<S> range) {
+	public Iterable<T> compute2(Iterable<T> iterable, Pair<U, U> range) {
 		final Stream<T> inStream = StreamSupport.stream(iterable.spliterator(),
 			false);
-		final Stream<T> filtered = inStream.filter(e -> range.min.compareTo(
-			e) <= 0 && range.max.compareTo(e) >= 0);
+		final Stream<T> filtered = inStream.filter(e -> range.getA().compareTo(
+			e) <= 0 && range.getB().compareTo(e) >= 0);
 
 		return filtered.map(Type::copy).collect(Collectors.toList());
-	}
-
-	public static final class Range<S> {
-
-		/**
-		 * Minimum value for elements within the range
-		 */
-		public final S min;
-		/**
-		 * Maximum value for elements within the range
-		 */
-		public final S max;
-
-		public Range(S min, S max) {
-			this.min = min;
-			this.max = max;
-		}
 	}
 }

--- a/src/main/java/net/imagej/ops/mask/maskRange/DefaultMaskRange.java
+++ b/src/main/java/net/imagej/ops/mask/maskRange/DefaultMaskRange.java
@@ -1,0 +1,53 @@
+
+package net.imagej.ops.mask.maskRange;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
+import net.imglib2.type.Type;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Creates an Iterable from all the elements in the input that are in the given
+ * range of values
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+@Plugin(type = Ops.Mask.MaskRange.class)
+public class DefaultMaskRange<T extends Type<T>, S extends Comparable<T>>
+	extends
+	AbstractBinaryFunctionOp<Iterable<T>, DefaultMaskRange.Range<S>, Iterable<T>>
+	implements Ops.Mask.MaskRange
+{
+
+	@Override
+	public Iterable<T> compute2(Iterable<T> iterable, Range<S> range) {
+		final Stream<T> inStream = StreamSupport.stream(iterable.spliterator(),
+			false);
+		final Stream<T> filtered = inStream.filter(e -> range.min.compareTo(
+			e) <= 0 && range.max.compareTo(e) >= 0);
+
+		return filtered.map(Type::copy).collect(Collectors.toList());
+	}
+
+	public static final class Range<S> {
+
+		/**
+		 * Minimum value for elements within the range
+		 */
+		public final S min;
+		/**
+		 * Maximum value for elements within the range
+		 */
+		public final S max;
+
+		public Range(S min, S max) {
+			this.min = min;
+			this.max = max;
+		}
+	}
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -226,6 +226,11 @@ namespaces = ```
 		[name: "or",                             iface: "Or"],
 		[name: "xor",                            iface: "Xor"],
 	]],
+	[name: "mask", iface: "Mask", ops: [
+		[name: "maskHigh",                       iface: "MaskHigh"],
+		[name: "maskLow",                        iface: "MaskLow"],
+		[name: "maskRange",                      iface: "MaskRange"],
+	]],
 	[name: "math", iface: "Math", ops: [
 		[name: "abs",                            iface: "Abs"],
 		[name: "add",                            iface: "Add",                 aliases: ["sum"]],

--- a/src/test/java/net/imagej/ops/mask/MaskNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/mask/MaskNamespaceTest.java
@@ -1,0 +1,25 @@
+
+package net.imagej.ops.mask;
+
+import net.imagej.ops.AbstractNamespaceTest;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link MaskNamespace}
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class MaskNamespaceTest extends AbstractNamespaceTest {
+
+	/**
+	 * Tests that the ops of the {@code mask} namespace have corresponding
+	 * type-safe Java method signatures declared in the {@link MaskNamespace}
+	 * class.
+	 */
+	@Test
+	public void testCompleteness() {
+		assertComplete("mask", MaskNamespace.class);
+	}
+
+}

--- a/src/test/java/net/imagej/ops/mask/maskHigh/DefaultMaskHighTest.java
+++ b/src/test/java/net/imagej/ops/mask/maskHigh/DefaultMaskHighTest.java
@@ -1,0 +1,45 @@
+
+package net.imagej.ops.mask.maskHigh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.LongType;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link DefaultMaskHigh}
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class DefaultMaskHighTest extends AbstractOpTest {
+
+	@Test
+	public void testCompute2() throws Exception {
+		final LongType value = new LongType(6L);
+		// Create a 4x4x4 test image with values from 0 to 7
+		final Img<LongType> img = ArrayImgs.longs(4, 4, 4);
+		final Iterator<Long> longIterator = LongStream.iterate(0, i -> (i + 1) % 8)
+			.iterator();
+		img.cursor().forEachRemaining(e -> e.set(longIterator.next()));
+
+		@SuppressWarnings("unchecked")
+		List<LongType> result = (List<LongType>) ops.run(DefaultMaskHigh.class,
+			img, value);
+
+		assertEquals("Wrong number of elements in result iterable", 16, result
+			.size());
+		assertTrue("All elements refer the same object (shallow copy?)", result
+			.stream().distinct().count() > 1);
+		assertTrue("Wrong values in result iterable", result.stream().allMatch(
+			e -> e.get() >= value.get()));
+	}
+}

--- a/src/test/java/net/imagej/ops/mask/maskLow/DefaultMaskLowTest.java
+++ b/src/test/java/net/imagej/ops/mask/maskLow/DefaultMaskLowTest.java
@@ -1,0 +1,45 @@
+
+package net.imagej.ops.mask.maskLow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.LongType;
+
+import org.junit.Test;
+
+/**
+ * Test for {@link DefaultMaskLow}
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class DefaultMaskLowTest extends AbstractOpTest {
+
+	@Test
+	public void testCompute2() throws Exception {
+		final LongType value = new LongType(1L);
+		// Create a 4x4x4 test image with values from 0 to 7
+		final Img<LongType> img = ArrayImgs.longs(4, 4, 4);
+		final Iterator<Long> longIterator = LongStream.iterate(0, i -> (i + 1) % 8)
+			.iterator();
+		img.cursor().forEachRemaining(e -> e.set(longIterator.next()));
+
+		@SuppressWarnings("unchecked")
+		List<LongType> result = (List<LongType>) ops.run(DefaultMaskLow.class, img,
+			value);
+
+		assertEquals("Wrong number of elements in result iterable", 16, result
+			.size());
+		assertTrue("All elements refer the same object (shallow copy?)", result
+			.stream().distinct().count() > 1);
+		assertTrue("Wrong values in result iterable", result.stream().allMatch(
+			e -> e.get() <= value.get()));
+	}
+}

--- a/src/test/java/net/imagej/ops/mask/maskRange/DefaultMaskRangeTest.java
+++ b/src/test/java/net/imagej/ops/mask/maskRange/DefaultMaskRangeTest.java
@@ -12,6 +12,8 @@ import net.imagej.ops.AbstractOpTest;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
 
 import org.junit.Test;
 
@@ -26,8 +28,7 @@ public class DefaultMaskRangeTest extends AbstractOpTest {
 	public void testCompute2() throws Exception {
 		LongType min = new LongType(2L);
 		LongType max = new LongType(5L);
-		final DefaultMaskRange.Range limits = new DefaultMaskRange.Range<>(min,
-			max);
+		final Pair limits = new ValuePair<>(min, max);
 		// Create a 2x2x2x2x2 test image with values from 0 to 7
 		final Img<LongType> img = ArrayImgs.longs(2, 2, 2, 2, 2);
 		final Iterator<Long> iterator = LongStream.iterate(0, i -> (i + 1) % 8)

--- a/src/test/java/net/imagej/ops/mask/maskRange/DefaultMaskRangeTest.java
+++ b/src/test/java/net/imagej/ops/mask/maskRange/DefaultMaskRangeTest.java
@@ -1,0 +1,48 @@
+
+package net.imagej.ops.mask.maskRange;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.LongType;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link DefaultMaskRange}
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class DefaultMaskRangeTest extends AbstractOpTest {
+
+	@Test
+	public void testCompute2() throws Exception {
+		LongType min = new LongType(2L);
+		LongType max = new LongType(5L);
+		final DefaultMaskRange.Range limits = new DefaultMaskRange.Range<>(min,
+			max);
+		// Create a 2x2x2x2x2 test image with values from 0 to 7
+		final Img<LongType> img = ArrayImgs.longs(2, 2, 2, 2, 2);
+		final Iterator<Long> iterator = LongStream.iterate(0, i -> (i + 1) % 8)
+			.iterator();
+		img.cursor().forEachRemaining(e -> e.set(iterator.next()));
+
+		@SuppressWarnings("unchecked")
+		final List<LongType> result = (List<LongType>) ops.run(
+			DefaultMaskRange.class, img, limits);
+
+		assertEquals("Wrong number of elements in the result iterable", 16, result
+			.size());
+		assertTrue("All elements refer the same object (shallow copy?)", result
+			.stream().distinct().count() > 1);
+		assertTrue("Wrong values in the result iterable", result.stream().allMatch(
+			e -> e.compareTo(min) >= 0 && e.compareTo(max) <= 0));
+	}
+}


### PR DESCRIPTION
- Add an op that creates a binary mask based on thresholds
- Create an op that filters elements that fall within thresholds (this should go to the SciJava ops module).
  Elements and thresholds can be any type as long as they are comparable.

I don't know if the Thresholds name space is the best fit for these, but at least conceptually it seemed like the place to add these
