### PR TITLE
Bug found and fixed in Minimum method

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/minimum/ComputeMinimumThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/minimum/ComputeMinimumThreshold.java
@@ -89,7 +89,7 @@ public class ComputeMinimumThreshold<T extends RealType<T>> extends
 			if (histogram[i] > 0)
 				max = i;
 		}
-		double[] tHisto = iHisto;
+		double[] tHisto = new double[iHisto.length] ;
 
 		while (!Thresholds.bimodalTest(iHisto)) {
 			// smooth with a 3 point running mean filter
@@ -99,7 +99,7 @@ public class ComputeMinimumThreshold<T extends RealType<T>> extends
 			tHisto[0] = (iHisto[0] + iHisto[1]) / 3;
 			// 0 outside
 			tHisto[histogram.length - 1] = (iHisto[histogram.length - 2] + iHisto[histogram.length - 1]) / 3;
-			iHisto = tHisto;
+			System.arraycopy(tHisto, 0, iHisto, 0, iHisto.length) ;
 			iter++;
 			if (iter > 10000) {
 				errMsg = "Minimum Threshold not found after 10000 iterations.";


### PR DESCRIPTION
The affectation iHisto = tHisto (and opposite) didn't make any sense and were wrong. The computation result has to be store into a separate directory.