### PR TITLE
DefaultContour remove isInverted parameter

### DIFF
--- a/src/main/java/net/imagej/ops/geom/GeomNamespace.java
+++ b/src/main/java/net/imagej/ops/geom/GeomNamespace.java
@@ -260,12 +260,10 @@ public class GeomNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultContour.class)
 	public <T extends Type<T>> Polygon contour(
-		final RandomAccessibleInterval<T> in, final boolean useJacobs,
-		final boolean isInverted)
+		final RandomAccessibleInterval<T> in, final boolean useJacobs)
 	{
 		final Polygon result = (Polygon) ops().run(
-			net.imagej.ops.Ops.Geometric.Contour.class, in, useJacobs,
-			isInverted);
+			net.imagej.ops.Ops.Geometric.Contour.class, in, useJacobs);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/geom/geom2d/DefaultContour.java
+++ b/src/main/java/net/imagej/ops/geom/geom2d/DefaultContour.java
@@ -53,6 +53,9 @@ import org.scijava.plugin.Plugin;
 /**
  * Generic implementation of {@code geom.contour}.
  * 
+ * This implementation assumes that foreground-pixels are True and
+ * background-pixels are False.
+ * 
  * @author Jonathan Hale (University of Konstanz)
  * @author Daniel Seebacher (University of Konstanz)
  */
@@ -65,10 +68,6 @@ public class DefaultContour<B extends BooleanType<B>> extends
 	@Parameter(type = ItemIO.INPUT,
 		description = "Set this flag to use  refined Jacobs stopping criteria")
 	private boolean useJacobs = true;
-
-	@Parameter(type = ItemIO.INPUT,
-		description = "Set this flag to invert between foreground/background.")
-	private boolean isInverted = false;
 
 	/**
 	 * ClockwiseMooreNeighborhoodIterator Iterates clockwise through a 2D Moore
@@ -199,7 +198,6 @@ public class DefaultContour<B extends BooleanType<B>> extends
 		List<RealPoint> p = new ArrayList<>();
 
 		final B var = Util.getTypeFromInterval(input).createVariable();
-		var.set(!isInverted);
 
 		final RandomAccess<B> raInput = Views.extendValue(input, var)
 			.randomAccess();
@@ -213,7 +211,7 @@ public class DefaultContour<B extends BooleanType<B>> extends
 		// find first black pixel
 		while (cInput.hasNext()) {
 			// we are looking for a black pixel
-			if (cInput.next().get() == isInverted) {
+			if (cInput.next().get()) {
 				raInput.setPosition(cInput);
 				raInput.localize(startPos);
 
@@ -226,7 +224,7 @@ public class DefaultContour<B extends BooleanType<B>> extends
 				cNeigh.reset();
 
 				while (cNeigh.hasNext()) {
-					if (cNeigh.next().get() == isInverted) {
+					if (cNeigh.next().get()) {
 
 						boolean specialBacktrack = false;
 

--- a/src/test/java/net/imagej/ops/geom/GeomTest.java
+++ b/src/test/java/net/imagej/ops/geom/GeomTest.java
@@ -107,13 +107,13 @@ public class GeomTest extends AbstractFeatureTest {
 	public void setup() {
 		// no implementation is needed since the tests in this class will not use
 		// the features provided in super#setup()
-		contour = (Polygon) ops.run(DefaultContour.class, region2D, true, true);
+		contour = (Polygon) ops.run(DefaultContour.class, region2D, true);
 		mesh = (Mesh) ops.run(DefaultMarchingCubes.class, region3D);
 	}
 
 	@Test
 	public void createPolygon() {
-		ops.run(DefaultContour.class, region2D, true, true);
+		ops.run(DefaultContour.class, region2D, true);
 	}
 
 	@Test


### PR DESCRIPTION
The isInverted parameter is a bit confusing.

I removed the parameter and updated all tests.

This is a possible solution to this discussion:
https://github.com/imagej/imagej-ops/pull/424#issuecomment-233307097
