### PR TITLE
Bugfix in CentroidPolygon op

### DIFF
--- a/src/main/java/net/imagej/ops/geom/CentroidPolygon.java
+++ b/src/main/java/net/imagej/ops/geom/CentroidPolygon.java
@@ -64,9 +64,10 @@ public class CentroidPolygon extends
 		double area = sizeFunc.compute1(input).get();
 		double cx = 0;
 		double cy = 0;
-		for (int i = 0; i < input.getVertices().size() - 1; i++) {
+		for (int i = 0; i < input.getVertices().size(); i++) {
 			RealLocalizable p0 = input.getVertices().get(i);
-			RealLocalizable p1 = input.getVertices().get(i + 1);
+			RealLocalizable p1 = input.getVertices().get((i + 1) % input.getVertices()
+					.size());
 
 			double p0_x = p0.getDoublePosition(0);
 			double p0_y = p0.getDoublePosition(1);

--- a/src/main/java/net/imagej/ops/geom/geom2d/DefaultSizePolygon.java
+++ b/src/main/java/net/imagej/ops/geom/geom2d/DefaultSizePolygon.java
@@ -57,8 +57,7 @@ public class DefaultSizePolygon extends AbstractUnaryHybridCF<Polygon, DoubleTyp
 		double sum = 0;
 		for (int i = 0; i < input.getVertices().size(); i++) {
 
-			RealLocalizable p0 = input.getVertices().get(i % input.getVertices()
-				.size());
+			RealLocalizable p0 = input.getVertices().get(i);
 			RealLocalizable p1 = input.getVertices().get((i + 1) % input.getVertices()
 				.size());
 

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultMarchingCubes.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultMarchingCubes.java
@@ -175,15 +175,15 @@ public class DefaultMarchingCubes<T extends BooleanType<T>> extends
 				for (i = 0; TRIANGLE_TABLE[cubeindex][i] != -1; i += 3) {
 
 					TriangularFacet face = new TriangularFacet(new Vertex(
-						vertlist[TRIANGLE_TABLE[cubeindex][i]][0],
-						vertlist[TRIANGLE_TABLE[cubeindex][i]][1],
-						vertlist[TRIANGLE_TABLE[cubeindex][i]][2]), new Vertex(
+						vertlist[TRIANGLE_TABLE[cubeindex][i + 2]][0],
+						vertlist[TRIANGLE_TABLE[cubeindex][i + 2]][1],
+						vertlist[TRIANGLE_TABLE[cubeindex][i + 2]][2]), new Vertex(
 							vertlist[TRIANGLE_TABLE[cubeindex][i + 1]][0],
 							vertlist[TRIANGLE_TABLE[cubeindex][i + 1]][1],
 							vertlist[TRIANGLE_TABLE[cubeindex][i + 1]][2]), new Vertex(
-								vertlist[TRIANGLE_TABLE[cubeindex][i + 2]][0],
-								vertlist[TRIANGLE_TABLE[cubeindex][i + 2]][1],
-								vertlist[TRIANGLE_TABLE[cubeindex][i + 2]][2]));
+								vertlist[TRIANGLE_TABLE[cubeindex][i]][0],
+								vertlist[TRIANGLE_TABLE[cubeindex][i]][1],
+								vertlist[TRIANGLE_TABLE[cubeindex][i]][2]));
 					output.addFace(face);
 				}
 			}


### PR DESCRIPTION
Hi guys,

i maybe found a bug in CentroidPolygon. I reported the bug on the forum:
http://forum.imagej.net/t/issue-with-polygons-in-ops/2227/7

The issue was: In CentroidPolygon.java, the stopping criterion of a loop was wrong. After fixing this, an index needs to be changed a bit as well. Now indexes and for-loop-stop-criterion are identical in CentroidPolygon and DefaultSizePolygon. In the same way, formulas are given on wikipedia:

https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon

So, I guess this was really a bug...

Furthermore, I removed an unnneccesary modulo operation from DefaultSizePolygon.

Cheers,
Robert
