### PR TITLE
Fix geom tests.

### DIFF
--- a/src/test/java/net/imagej/ops/geom/GeomTest.java
+++ b/src/test/java/net/imagej/ops/geom/GeomTest.java
@@ -211,9 +211,9 @@ public class GeomTest extends AbstractFeatureTest {
 
 	@Test
 	public void testCentroidMesh() {
-		final double expected1 = expensiveTestsEnabled ? -25.700 : -12.237808234;
-		final double expected2 = expensiveTestsEnabled ? -24.644 : -12.524262243;
-		final double expected3 = expensiveTestsEnabled ? -19.945 : -9.568196449;
+		final double expected1 = expensiveTestsEnabled ? 25.700 : 12.237808234;
+		final double expected2 = expensiveTestsEnabled ? 24.644 : 12.524262243;
+		final double expected3 = expensiveTestsEnabled ? 19.945 : 9.568196449;
 		final RealPoint c = (RealPoint) ops.run(CentroidMesh.class, mesh);
 		assertEquals(expected1, c.getDoublePosition(0),
 			AbstractFeatureTest.BIG_DELTA);
@@ -290,7 +290,7 @@ public class GeomTest extends AbstractFeatureTest {
 
 	@Test
 	public void testBoundaryPixelCountConvexHull() {
-		final double expected = expensiveTestsEnabled ? 32 : 177;
+		final double expected = expensiveTestsEnabled ? 32 : 179;
 		// Verified by hand. qhull merges faces and therefore has another number
 		// of surface pixels
 		assertEquals(Ops.Geometric.BoundaryPixelCountConvexHull.NAME, expected,


### PR DESCRIPTION
@ctrueden  and @dietzc

I looked really carefully at the geom tests:

- testCentroidMesh(): MarchingCubes stored the vertices in clockwise order instead of counter-clockwise. This was fixed and leads now to positive centroid coordinates, which makes sense because the whole structure was only in positive coordinates.
- testBoundaryPixelCountConvexHull(): The change is again based on the MarchingCubes fix. Now all vertices are stored in a different order, which leads to different point selections during the convex hull computation. I tested the new convex hull for correctness and everything looks fine. Just the number of points changed, because of the selection. 

(All tests are passing now.)