### PR TITLE
Add local versions for global thresholds

### DIFF
--- a/src/main/java/net/imagej/ops/filter/AbstractCenterAwareNeighborhoodBasedFilter.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractCenterAwareNeighborhoodBasedFilter.java
@@ -43,6 +43,7 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.view.Views;
 
 public abstract class AbstractCenterAwareNeighborhoodBasedFilter<I, O> extends
 	AbstractUnaryComputerOp<RandomAccessibleInterval<I>, IterableInterval<O>>
@@ -61,7 +62,7 @@ public abstract class AbstractCenterAwareNeighborhoodBasedFilter<I, O> extends
 
 	@Override
 	public void initialize() {
-		filterOp = unaryComputer(out().firstElement());
+		filterOp = unaryComputer(Views.iterable(in()).firstElement(), out().firstElement());
 		map = Computers.unary(ops(), Map.class, out(), in(), shape, filterOp);
 	}
 
@@ -83,10 +84,13 @@ public abstract class AbstractCenterAwareNeighborhoodBasedFilter<I, O> extends
 	}
 
 	/**
-	 * @param out First element from the output {@link IterableInterval}. May be
-	 *          used for determining the class.
+	 * @param inType First element from the input {@link RandomAccessibleInterval}
+	 *          that may be used for determining the class.
+	 * @param outType First element from the output {@link IterableInterval} that
+	 *          may be used for determining the class.
 	 * @return the Computer to map to all neighborhoods of input to output.
 	 */
-	protected abstract CenterAwareComputerOp<I, O> unaryComputer(final O out);
+	protected abstract CenterAwareComputerOp<I, O> unaryComputer(final I inType,
+		final O outType);
 
 }

--- a/src/main/java/net/imagej/ops/filter/sigma/DefaultSigmaFilter.java
+++ b/src/main/java/net/imagej/ops/filter/sigma/DefaultSigmaFilter.java
@@ -63,7 +63,9 @@ public class DefaultSigmaFilter<T extends RealType<T>, V extends RealType<V>>
 	private Double minPixelFraction;
 
 	@Override
-	protected CenterAwareComputerOp<T, V> unaryComputer(final V outType) {
+	protected CenterAwareComputerOp<T, V> unaryComputer(final T inType,
+		final V outType)
+	{
 
 		final AbstractCenterAwareComputerOp<T, V> op =
 			new AbstractCenterAwareComputerOp<T, V>()

--- a/src/main/java/net/imagej/ops/threshold/LocalThresholdMethodHistogram.java
+++ b/src/main/java/net/imagej/ops/threshold/LocalThresholdMethodHistogram.java
@@ -69,16 +69,17 @@ public abstract class LocalThresholdMethodHistogram<T extends RealType<T>>
 	public void compute2(final Iterable<T> neighborhood, final T center,
 		final BitType output)
 	{
+		// TODO Move to initialize when NIL objects are available
 		if (applyThreshold == null) {
 			applyThreshold = Computers.binary(ops(), Ops.Threshold.Apply.class, output,
 				center, center);
 		}
-		
+
 		// Compute histogram for neighborhood
 		final Histogram1d<T> hist = histCreator.compute1(neighborhood);
 
 		// Compute threshold
-		T computedThreshold = center.createVariable();
+		final T computedThreshold = center.createVariable();
 		thresholdComputer.compute1(hist, computedThreshold);
 
 		// Apply threshold

--- a/src/main/java/net/imagej/ops/threshold/LocalThresholdMethodHistogram.java
+++ b/src/main/java/net/imagej/ops/threshold/LocalThresholdMethodHistogram.java
@@ -1,0 +1,90 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.threshold;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.Ops.Image.Histogram;
+import net.imagej.ops.map.neighborhood.AbstractCenterAwareComputerOp;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.histogram.Histogram1d;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+
+/**
+ * {@link AbstractCenterAwareComputerOp} for use in {@link LocalThreshold}s.
+ * 
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+public abstract class LocalThresholdMethodHistogram<T extends RealType<T>>
+	extends AbstractCenterAwareComputerOp<T, BitType>
+{
+
+	protected UnaryFunctionOp<Iterable<T>, Histogram1d<T>> histCreator;
+	protected UnaryComputerOp<Histogram1d<T>, T> thresholdComputer;
+	protected BinaryComputerOp<T, T, BitType> applyThreshold;
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public void initialize() {
+		histCreator = (UnaryFunctionOp) Functions.unary(ops(), Histogram.class,
+			Histogram1d.class, in1() == null ? Iterable.class : in1());
+
+		thresholdComputer = getThresholdComputer();
+	}
+
+	@Override
+	public void compute2(final Iterable<T> neighborhood, final T center,
+		final BitType output)
+	{
+		if (applyThreshold == null) {
+			applyThreshold = Computers.binary(ops(), Ops.Threshold.Apply.class, output,
+				center, center);
+		}
+		
+		// Compute histogram for neighborhood
+		final Histogram1d<T> hist = histCreator.compute1(neighborhood);
+
+		// Compute threshold
+		T computedThreshold = center.createVariable();
+		thresholdComputer.compute1(hist, computedThreshold);
+
+		// Apply threshold
+		applyThreshold.compute2(center, computedThreshold, output);
+	}
+
+	protected abstract UnaryComputerOp<Histogram1d<T>, T> getThresholdComputer();
+
+}

--- a/src/main/java/net/imagej/ops/threshold/LocalThresholdMethodHistogram.java
+++ b/src/main/java/net/imagej/ops/threshold/LocalThresholdMethodHistogram.java
@@ -40,7 +40,7 @@ import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imagej.ops.threshold.apply.LocalThreshold;
 import net.imglib2.histogram.Histogram1d;
-import net.imglib2.type.logic.BitType;
+import net.imglib2.type.BooleanType;
 import net.imglib2.type.numeric.RealType;
 
 /**
@@ -48,13 +48,13 @@ import net.imglib2.type.numeric.RealType;
  * 
  * @author Stefan Helfrich (University of Konstanz)
  */
-public abstract class LocalThresholdMethodHistogram<T extends RealType<T>>
-	extends AbstractCenterAwareComputerOp<T, BitType>
+public abstract class LocalThresholdMethodHistogram<T extends RealType<T>, O extends BooleanType<O>>
+	extends AbstractCenterAwareComputerOp<T, O>
 {
 
 	protected UnaryFunctionOp<Iterable<T>, Histogram1d<T>> histCreator;
 	protected UnaryComputerOp<Histogram1d<T>, T> thresholdComputer;
-	protected BinaryComputerOp<T, T, BitType> applyThreshold;
+	protected BinaryComputerOp<T, T, O> applyThreshold;
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
@@ -67,7 +67,7 @@ public abstract class LocalThresholdMethodHistogram<T extends RealType<T>>
 
 	@Override
 	public void compute2(final Iterable<T> neighborhood, final T center,
-		final BitType output)
+		final O output)
 	{
 		// TODO Move to initialize when NIL objects are available
 		if (applyThreshold == null) {

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -42,6 +42,7 @@ import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 
@@ -172,30 +173,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> huang(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		huang(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> huang(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		huang(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -248,30 +247,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> ij1(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		ij1(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> ij1(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		ij1(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -331,30 +328,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> intermodes(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		intermodes(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> intermodes(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		intermodes(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -409,30 +404,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> isoData(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		isoData(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> isoData(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		isoData(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -482,30 +475,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> li(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		li(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> li(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		li(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1022,30 +1013,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> maxEntropy(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		maxEntropy(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> maxEntropy(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		maxEntropy(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1108,30 +1097,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> maxLikelihood(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		maxLikelihood(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> maxLikelihood(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		maxLikelihood(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1231,30 +1218,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> minError(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		minError(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> minError(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		minError(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1309,30 +1294,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> minimum(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		minimum(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> minimum(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		minimum(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1387,30 +1370,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> moments(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		moments(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> moments(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		moments(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1460,30 +1441,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> otsu(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		otsu(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> otsu(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		otsu(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1541,30 +1520,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> percentile(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		percentile(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> percentile(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		percentile(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1627,30 +1604,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> renyiEntropy(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		renyiEntropy(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> renyiEntropy(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		renyiEntropy(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1704,30 +1679,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> shanbhag(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		shanbhag(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> shanbhag(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		shanbhag(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1781,30 +1754,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> triangle(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		triangle(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> triangle(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		triangle(final IterableInterval<B> out,
+			final RandomAccessibleInterval<T> in, final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1854,30 +1825,28 @@ public class ThresholdNamespace extends AbstractNamespace {
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> yen(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		yen(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class,
-				out, in, shape);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class,
+			out, in, shape);
 		return result;
 	}
 
 	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class)
-	public <T extends RealType<T>> IterableInterval<BitType> yen(
-		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
-		final Shape shape,
-		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	public <T extends RealType<T>, B extends BooleanType<B>> IterableInterval<B>
+		yen(final IterableInterval<B> out, final RandomAccessibleInterval<T> in,
+			final Shape shape,
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
 	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
-			.run(
-				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class,
-				out, in, shape, outOfBoundsFactory);
+		final IterableInterval<B> result = (IterableInterval<B>) ops().run(
+			net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class,
+			out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -171,6 +171,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> huang(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> huang(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.ij1.ComputeIJ1Threshold.class)
 	public <T extends RealType<T>> T ij1(final Histogram1d<T> in) {
 		@SuppressWarnings("unchecked")
@@ -214,6 +243,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 			(IterableInterval<BitType>) ops().run(
 				net.imagej.ops.Ops.Threshold.IJ1.class,
 				out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> ij1(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> ij1(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -272,6 +330,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> intermodes(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> intermodes(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.IsoData.class)
 	public <T extends RealType<T>> IterableInterval<BitType> isoData(final IterableInterval<T> in) {
 		@SuppressWarnings("unchecked")
@@ -320,6 +407,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> isoData(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> isoData(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.threshold.ApplyThresholdMethod.Li.class)
 	public
 		<T extends RealType<T>> IterableInterval<BitType> li(final IterableInterval<T> in) {
@@ -361,6 +477,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 			(T) ops().run(
 				net.imagej.ops.Ops.Threshold.Li.class, out,
 				in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> li(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> li(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -876,6 +1021,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> maxEntropy(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> maxEntropy(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.MaxLikelihood.class)
 	public
 		<T extends RealType<T>> IterableInterval<BitType> maxLikelihood(final IterableInterval<T> in) {
@@ -929,6 +1103,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 				.run(
 					net.imagej.ops.Ops.Threshold.MaxLikelihood.class,
 					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> maxLikelihood(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> maxLikelihood(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1027,6 +1230,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> minError(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> minError(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.Minimum.class)
 	public <T extends RealType<T>> IterableInterval<BitType> minimum(final IterableInterval<T> in) {
 		@SuppressWarnings("unchecked")
@@ -1072,6 +1304,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 			(List<Object>) ops().run(
 				net.imagej.ops.Ops.Threshold.Minimum.class,
 				out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> minimum(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> minimum(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1125,6 +1386,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> moments(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> moments(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.otsu.ComputeOtsuThreshold.class)
 	public <T extends RealType<T>> T otsu(final Histogram1d<T> in) {
 		@SuppressWarnings("unchecked")
@@ -1165,6 +1455,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 			(IterableInterval<BitType>) ops().run(
 				net.imagej.ops.Ops.Threshold.Otsu.class, out,
 				in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> otsu(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> otsu(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1217,6 +1536,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 				.run(
 					net.imagej.ops.Ops.Threshold.Percentile.class,
 					out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> percentile(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> percentile(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1278,6 +1626,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> renyiEntropy(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> renyiEntropy(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.ApplyThresholdMethod.Shanbhag.class)
 	public <T extends RealType<T>> IterableInterval<BitType> shanbhag(final IterableInterval<T> in) {
 		@SuppressWarnings("unchecked")
@@ -1322,6 +1699,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 			(T) ops().run(
 				net.imagej.ops.Ops.Threshold.Shanbhag.class,
 				out, in);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> shanbhag(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> shanbhag(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold.class,
+				out, in, shape, outOfBoundsFactory);
 		return result;
 	}
 
@@ -1374,6 +1780,35 @@ public class ThresholdNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> triangle(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> triangle(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
+	@OpMethod(
 		op = net.imagej.ops.threshold.yen.ComputeYenThreshold.class)
 	public <T extends RealType<T>> T yen(final Histogram1d<T> in) {
 		@SuppressWarnings("unchecked")
@@ -1416,7 +1851,36 @@ public class ThresholdNamespace extends AbstractNamespace {
 				in);
 		return result;
 	}
-	
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> yen(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class,
+				out, in, shape);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class)
+	public <T extends RealType<T>> IterableInterval<BitType> yen(
+		final IterableInterval<BitType> out, final RandomAccessibleInterval<T> in,
+		final Shape shape,
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<BitType> result = (IterableInterval<BitType>) ops()
+			.run(
+				net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold.class,
+				out, in, shape, outOfBoundsFactory);
+		return result;
+	}
+
 	// -- Named methods --
 
 	@Override

--- a/src/main/java/net/imagej/ops/threshold/localBernsen/LocalBernsenThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localBernsen/LocalBernsenThreshold.java
@@ -65,7 +65,7 @@ public class LocalBernsenThreshold<T extends RealType<T>> extends
 	private double halfMaxValue;
 
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localContrast/LocalContrastThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localContrast/LocalContrastThreshold.java
@@ -54,7 +54,7 @@ public class LocalContrastThreshold<T extends RealType<T>> extends
 		LocalThreshold<T> implements Ops.Threshold.LocalContrastThreshold {
 
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMean/LocalMeanThreshold.java
@@ -62,7 +62,7 @@ public class LocalMeanThreshold<T extends RealType<T>> extends
 	private double c;
 
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localMedian/LocalMedianThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMedian/LocalMedianThreshold.java
@@ -58,7 +58,7 @@ public class LocalMedianThreshold<T extends RealType<T>> extends LocalThreshold<
 	private double c;
 
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localMidGrey/LocalMidGreyThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localMidGrey/LocalMidGreyThreshold.java
@@ -59,7 +59,7 @@ public class LocalMidGreyThreshold<T extends RealType<T>> extends
 	private double c;
 	
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localNiblack/LocalNiblackThreshold.java
@@ -64,7 +64,7 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends LocalThreshold
 	private double k;
 	
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localPhansalkar/LocalPhansalkarThreshold.java
@@ -87,7 +87,7 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 	private double q = 10.0;
 
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThreshold.java
+++ b/src/main/java/net/imagej/ops/threshold/localSauvola/LocalSauvolaThreshold.java
@@ -76,7 +76,7 @@ public class LocalSauvolaThreshold<T extends RealType<T>> extends LocalThreshold
 	private double r = 0.5d;
 
 	@Override
-	protected CenterAwareComputerOp<T, BitType> unaryComputer(
+	protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 		final BitType outClass)
 	{
 		final LocalThresholdMethod<T> op = new LocalThresholdMethod<T>() {

--- a/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.list
+++ b/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.list
@@ -1,0 +1,21 @@
+[ApplyThresholdMethodLocal.java]
+methods = ```
+[
+	[name: "localHuang",         iface: "Huang"],
+	[name: "localIj1",           iface: "IJ1"],
+	[name: "localIntermodes",    iface: "Intermodes"],
+	[name: "localIsoData",       iface: "IsoData"],
+	[name: "localLi",            iface: "Li"],
+	[name: "localMaxEntropy",    iface: "MaxEntropy"],
+	[name: "localMaxLikelihood", iface: "MaxLikelihood"],
+	[name: "localMinError",      iface: "MinError"],
+	[name: "localMinimum",       iface: "Minimum"],
+	[name: "localMoments",       iface: "Moments"],
+	[name: "localOtsu",          iface: "Otsu"],
+	[name: "localPercentile",    iface: "Percentile"],
+	[name: "localRenyiEntropy",  iface: "RenyiEntropy"],
+	[name: "localShanbhag",      iface: "Shanbhag"],
+	[name: "localTriangle",      iface: "Triangle"],
+	[name: "localYen",           iface: "Yen"]
+]
+```

--- a/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.vm
+++ b/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.vm
@@ -64,25 +64,23 @@ public final class ApplyThresholdMethodLocal {
 		protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
 			final BitType outClass)
 		{
+			final LocalThresholdMethodHistogram<T, BitType> op =
+				new LocalThresholdMethodHistogram<T, BitType>()
 			{
-				final LocalThresholdMethodHistogram<T> op =
-					new LocalThresholdMethodHistogram<T>()
+				@SuppressWarnings({ "rawtypes", "unchecked" })
+				@Override
+				protected UnaryComputerOp<Histogram1d<T>, T>
+					getThresholdComputer()
 				{
-					@SuppressWarnings({ "rawtypes", "unchecked" })
-					@Override
-					protected UnaryComputerOp<Histogram1d<T>, T>
-						getThresholdComputer()
-					{
-						UnaryComputerOp unary = Computers.unary(ops(),
-							${iface}.class, inClass.getClass(), Histogram1d.class);
-						return unary;
-					}
-				};
+					UnaryComputerOp unary = Computers.unary(ops(),
+						${iface}.class, inClass.getClass(), Histogram1d.class);
+					return unary;
+				}
+			};
 
-				op.setEnvironment(ops());
-				op.initialize();
-				return op;
-			}
+			op.setEnvironment(ops());
+			op.initialize();
+			return op;
 		}
 
 	}

--- a/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.vm
+++ b/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.vm
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.threshold;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.map.neighborhood.CenterAwareComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.histogram.Histogram1d;
+import net.imglib2.img.Img;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * Ops that apply a global threshold locally to an {@link Img}.
+ * 
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+public final class ApplyThresholdMethodLocal {
+
+	private ApplyThresholdMethodLocal() {
+		// NB: Prevent instantiation of utility class.
+	}
+#foreach ($method in $methods)
+#set ($iface = "Ops.Threshold.${method.iface}")
+
+	@Plugin(type = ${iface}.class)
+	public static class Local${method.iface}Threshold<T extends RealType<T>> extends
+		LocalThreshold<T> implements ${iface}
+	{
+
+		@Override
+		protected CenterAwareComputerOp<T, BitType> unaryComputer(final T inClass,
+			final BitType outClass)
+		{
+			{
+				final LocalThresholdMethodHistogram<T> op =
+					new LocalThresholdMethodHistogram<T>()
+				{
+					@SuppressWarnings({ "rawtypes", "unchecked" })
+					@Override
+					protected UnaryComputerOp<Histogram1d<T>, T>
+						getThresholdComputer()
+					{
+						UnaryComputerOp unary = Computers.unary(ops(),
+							${iface}.class, inClass.getClass(), Histogram1d.class);
+						return unary;
+					}
+				};
+
+				op.setEnvironment(ops());
+				op.initialize();
+				return op;
+			}
+		}
+
+	}
+#end
+
+}

--- a/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.vm
+++ b/src/main/templates/net/imagej/ops/threshold/ApplyThresholdMethodLocal.vm
@@ -35,15 +35,15 @@ import net.imagej.ops.map.neighborhood.CenterAwareComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.threshold.apply.LocalThreshold;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.histogram.Histogram1d;
-import net.imglib2.img.Img;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
 
 /**
- * Ops that apply a global threshold locally to an {@link Img}.
+ * Ops that apply a global threshold locally to a {@link RandomAccessibleInterval}.
  * 
  * @author Stefan Helfrich (University of Konstanz)
  */

--- a/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/LocalThresholdTest.java
@@ -33,6 +33,38 @@ package net.imagej.ops.threshold.apply;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Ops.Threshold.Huang;
+import net.imagej.ops.Ops.Threshold.IJ1;
+import net.imagej.ops.Ops.Threshold.Intermodes;
+import net.imagej.ops.Ops.Threshold.IsoData;
+import net.imagej.ops.Ops.Threshold.Li;
+import net.imagej.ops.Ops.Threshold.MaxEntropy;
+import net.imagej.ops.Ops.Threshold.MaxLikelihood;
+import net.imagej.ops.Ops.Threshold.MinError;
+import net.imagej.ops.Ops.Threshold.Minimum;
+import net.imagej.ops.Ops.Threshold.Moments;
+import net.imagej.ops.Ops.Threshold.Otsu;
+import net.imagej.ops.Ops.Threshold.Percentile;
+import net.imagej.ops.Ops.Threshold.RenyiEntropy;
+import net.imagej.ops.Ops.Threshold.Shanbhag;
+import net.imagej.ops.Ops.Threshold.Triangle;
+import net.imagej.ops.Ops.Threshold.Yen;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalHuangThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIJ1Threshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIntermodesThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalIsoDataThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalLiThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxEntropyThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMaxLikelihoodThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinErrorThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMinimumThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalMomentsThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalOtsuThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalPercentileThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalRenyiEntropyThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalShanbhagThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalTriangleThreshold;
+import net.imagej.ops.threshold.ApplyThresholdMethodLocal.LocalYenThreshold;
 import net.imagej.ops.threshold.LocalThresholdMethod;
 import net.imagej.ops.threshold.ThresholdNamespace;
 import net.imagej.ops.threshold.localBernsen.LocalBernsenThreshold;
@@ -151,6 +183,71 @@ public class LocalThresholdTest extends AbstractOpTest {
 				Boundary.SINGLE), 0.5, 0.5);
 		ops.threshold().localSauvolaThreshold(out, in, new RectangleShape(3,
 			false));
+
+		/* Locally applied global threshold ops */
+		ops.threshold().huang(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().huang(out, in, new RectangleShape(3, false));
+
+		ops.threshold().ij1(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().ij1(out, in, new RectangleShape(3, false));
+
+		ops.threshold().intermodes(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().intermodes(out, in, new RectangleShape(3, false));
+
+		ops.threshold().isoData(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().isoData(out, in, new RectangleShape(3, false));
+
+		ops.threshold().li(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().li(out, in, new RectangleShape(3, false));
+
+		ops.threshold().maxEntropy(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().maxEntropy(out, in, new RectangleShape(3, false));
+
+		ops.threshold().maxLikelihood(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().maxLikelihood(out, in, new RectangleShape(3, false));
+
+		ops.threshold().minError(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().minError(out, in, new RectangleShape(3, false));
+
+		ops.threshold().minimum(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().minimum(out, in, new RectangleShape(3, false));
+
+		ops.threshold().moments(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().moments(out, in, new RectangleShape(3, false));
+
+		ops.threshold().otsu(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().otsu(out, in, new RectangleShape(3, false));
+
+		ops.threshold().percentile(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().percentile(out, in, new RectangleShape(3, false));
+
+		ops.threshold().renyiEntropy(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().renyiEntropy(out, in, new RectangleShape(3, false));
+
+		ops.threshold().shanbhag(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().shanbhag(out, in, new RectangleShape(3, false));
+
+		ops.threshold().triangle(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().triangle(out, in, new RectangleShape(3, false));
+
+		ops.threshold().yen(out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE));
+		ops.threshold().yen(out, in, new RectangleShape(3, false));
 	}
 
 	/**
@@ -174,6 +271,85 @@ public class LocalThresholdTest extends AbstractOpTest {
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
 
 		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
+	 * @see LocalHuangThreshold
+	 */
+	@Test
+	public void testLocalHuangThreshold() {
+		ops.run(Huang.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalIJ1Threshold
+	 */
+	@Test
+	public void testLocalIJ1Threshold() {
+		ops.run(IJ1.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalIntermodesThreshold
+	 */
+	@Test
+	public void testLocalIntermodesThreshold() {
+		ops.run(Intermodes.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
+	 * @see LocalIsoDataThreshold
+	 */
+	@Test
+	public void testLocalIsoDataThreshold() {
+		// NB: Test fails for RectangleShapes of span 1
+		ops.run(IsoData.class, out, in, new RectangleShape(2, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalLiThreshold
+	 */
+	@Test
+	public void testLocalLiThreshold() {
+		ops.run(Li.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalMaxEntropyThreshold
+	 */
+	@Test
+	public void testLocalMaxEntropyThreshold() {
+		ops.run(MaxEntropy.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
+	 * @see LocalMaxLikelihoodThreshold
+	 */
+	@Test
+	public void testLocalMaxLikelihoodThreshold() {
+		// NB: Test fails for RectangleShapes of up to span==2
+		ops.run(MaxLikelihood.class, out, in, new RectangleShape(3, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
 	}
 
 	/**
@@ -207,7 +383,6 @@ public class LocalThresholdTest extends AbstractOpTest {
 	 * @see LocalMeanThresholdIntegral
 	 * @see LocalMeanThreshold
 	 */
-	@SuppressWarnings("null")
 	@Test
 	public void testLocalMeanResultsConsistency() {
 		Img<BitType> out2 = null;
@@ -257,6 +432,39 @@ public class LocalThresholdTest extends AbstractOpTest {
 			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE), 0.0);
 		
 		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalMinErrorThreshold
+	 */
+	@Test
+	public void testLocalMinErrorThreshold() {
+		ops.run(MinError.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalMinimumThreshold
+	 */
+	@Test
+	public void testLocalMinimumThreshold() {
+		ops.run(Minimum.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), true);
+	}
+
+	/**
+	 * @see LocalMomentsThreshold
+	 */
+	@Test
+	public void testLocalMomentsThreshold() {
+		ops.run(Moments.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
 	}
 
 	/**
@@ -316,6 +524,28 @@ public class LocalThresholdTest extends AbstractOpTest {
 	}
 
 	/**
+	 * @see LocalOtsuThreshold
+	 */
+	@Test
+	public void testLocalOtsuThreshold() {
+		ops.run(Otsu.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
+	 * @see LocalPercentileThreshold
+	 */
+	@Test
+	public void testLocalPercentileThreshold() {
+		ops.run(Percentile.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
 	 * @see LocalPhansalkarThreshold
 	 */
 	@Test
@@ -368,7 +598,18 @@ public class LocalThresholdTest extends AbstractOpTest {
 		
 		testIterableIntervalSimilarity(out2, out3);
 	}
-	
+
+	/**
+	 * @see LocalRenyiEntropyThreshold
+	 */
+	@Test
+	public void testLocalRenyiEntropyThreshold() {
+		ops.run(RenyiEntropy.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
 	/**
 	 * @see LocalSauvolaThreshold
 	 */
@@ -421,6 +662,39 @@ public class LocalThresholdTest extends AbstractOpTest {
 			0.0, 0.0);
 		
 		testIterableIntervalSimilarity(out2, out3);
+	}
+
+	/**
+	 * @see LocalShanbhagThreshold
+	 */
+	@Test
+	public void testLocalShanbhagThreshold() {
+		ops.run(Shanbhag.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
+	 * @see LocalTriangleThreshold
+	 */
+	@Test
+	public void testLocalTriangleThreshold() {
+		ops.run(Triangle.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
+	}
+
+	/**
+	 * @see LocalYenThreshold
+	 */
+	@Test
+	public void testLocalYenThreshold() {
+		ops.run(Yen.class, out, in, new RectangleShape(1, false),
+			new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE));
+
+		assertEquals(out.firstElement().get(), false);
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR establishes an abstract class `LocalThresholdMethodHistogram` and auto-generated sub-classes that apply the available global threshold methods (e.g. Huang, Otsu, etc) to each neighborhood of the input image individually.