### PR TITLE
Add multiple thresholds for range filtering

### DIFF
--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -53,6 +53,7 @@ import org.scijava.plugin.Plugin;
  * The threshold namespace contains operations related to binary thresholding.
  *
  * @author Curtis Rueden
+ * @author Stefan Helfrich (University of Konstanz)
  */
 @Plugin(type = Namespace.class)
 public class ThresholdNamespace extends AbstractNamespace {

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -37,7 +37,6 @@ import java.util.List;
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
-import net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.ThresholdPair;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
@@ -46,6 +45,7 @@ import net.imglib2.histogram.Histogram1d;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Pair;
 
 import org.scijava.plugin.Plugin;
 
@@ -128,7 +128,7 @@ public class ThresholdNamespace extends AbstractNamespace {
 		op = net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.class)
 	public <T extends RealType<T>> Iterable<BitType> apply(
 		final Iterable<BitType> out, final Iterable<T> in,
-		final ThresholdPair<T> thresholdPair)
+		final Pair<T, T> thresholdPair)
 	{
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		final Iterable<BitType> result = (Iterable) ops().run(

--- a/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
+++ b/src/main/java/net/imagej/ops/threshold/ThresholdNamespace.java
@@ -30,12 +30,14 @@
 
 package net.imagej.ops.threshold;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
+import net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.ThresholdPair;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
@@ -119,6 +121,29 @@ public class ThresholdNamespace extends AbstractNamespace {
 			(BitType) ops().run(
 				net.imagej.ops.Ops.Threshold.Apply.class,
 				out, in, threshold, comparator);
+		return result;
+	}
+
+	@OpMethod(
+		op = net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.class)
+	public <T extends RealType<T>> Iterable<BitType> apply(
+		final Iterable<BitType> out, final Iterable<T> in,
+		final ThresholdPair<T> thresholdPair)
+	{
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		final Iterable<BitType> result = (Iterable) ops().run(
+			net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.class, out, in,
+			thresholdPair);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.threshold.apply.ApplyThresholdCollection.class)
+	public <T> BitType apply(final BitType out, final T in,
+		final Collection<ApplyThreshold<T, BitType>> thresholdOps)
+	{
+		final BitType result = (BitType) ops().run(
+			net.imagej.ops.threshold.apply.ApplyThresholdCollection.class, out, in,
+			thresholdOps);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPair.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPair.java
@@ -38,9 +38,9 @@ import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.ThresholdPair;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Pair;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
@@ -53,7 +53,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Threshold.Apply.class, priority = Priority.HIGH_PRIORITY)
 public class ApplyConstantThresholdPair<T extends RealType<T>> extends
-	AbstractBinaryComputerOp<Iterable<T>, ThresholdPair<T>, Iterable<BitType>>
+	AbstractBinaryComputerOp<Iterable<T>, Pair<T, T>, Iterable<BitType>>
 	implements Ops.Threshold.Apply
 {
 
@@ -80,50 +80,13 @@ public class ApplyConstantThresholdPair<T extends RealType<T>> extends
 	}
 
 	@Override
-	public void compute2(final Iterable<T> input1, final ThresholdPair<T> input2,
+	public void compute2(final Iterable<T> input1, final Pair<T, T> input2,
 		final Iterable<BitType> output)
 	{
-		applyThresholdMin.setInput2(input2.min);
-		applyThresholdMax.setInput2(input2.max);
+		applyThresholdMin.setInput2(input2.getA());
+		applyThresholdMax.setInput2(input2.getB());
 
 		mapper.compute1(input1, output);
-	}
-
-	// -- Helper classes --
-	/**
-	 * A class to pass threshold values as a single input
-	 *
-	 * @author Richard Domander (Royal Veterinary College, London)
-	 */
-	public static final class ThresholdPair<T extends RealType<T>> {
-
-		public final T min;
-		public final T max;
-
-		/**
-		 * Constructor for Thresholds
-		 *
-		 * @param type Type of the min and max values
-		 * @param min Minimum value for elements within threshold
-		 * @param max Maximum value for elements within threshold
-		 */
-		public ThresholdPair(final T type, final double min, final double max) {
-			this.min = type.createVariable();
-			this.min.setReal(min);
-			this.max = type.createVariable();
-			this.max.setReal(max);
-		}
-
-		/**
-		 * Constructor for Thresholds
-		 *
-		 * @param min Minimum value for elements within threshold
-		 * @param max Maximum value for elements within threshold
-		 */
-		public ThresholdPair(final T min, final T max) {
-			this.min = min;
-			this.max = max;
-		}
 	}
 
 }

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPair.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPair.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.threshold.apply;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.ThresholdPair;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Applies the given threshold pair to every element along the given
+ * {@link Iterable} input.
+ *
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+@Plugin(type = Ops.Threshold.Apply.class, priority = Priority.HIGH_PRIORITY)
+public class ApplyConstantThresholdPair<T extends RealType<T>> extends
+	AbstractBinaryComputerOp<Iterable<T>, ThresholdPair<T>, Iterable<BitType>>
+	implements Ops.Threshold.Apply
+{
+
+	private UnaryComputerOp<T, BitType> applyThresholdCollection;
+
+	private BinaryComputerOp<T, T, BitType> applyThresholdMin;
+	private BinaryComputerOp<T, T, BitType> applyThresholdMax;
+
+	private UnaryComputerOp<Iterable<T>, Iterable<BitType>> mapper;
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void initialize() {
+		T type = in1().iterator().next();
+		applyThresholdMin = Computers.binary(ops(), ApplyThresholdComparator.class,
+			BitType.class, type, type, Comparator.naturalOrder());
+		applyThresholdMax = Computers.binary(ops(), ApplyThresholdComparator.class,
+			BitType.class, type, type, Comparator.reverseOrder());
+		applyThresholdCollection = Computers.unary(ops(),
+			ApplyThresholdCollection.class, BitType.class, type, Arrays.asList(
+				applyThresholdMin, applyThresholdMax));
+		mapper = (UnaryComputerOp) Computers.unary(ops(), Ops.Map.class,
+			out() == null ? Iterable.class : out(), in1(), applyThresholdCollection);
+	}
+
+	@Override
+	public void compute2(final Iterable<T> input1, final ThresholdPair<T> input2,
+		final Iterable<BitType> output)
+	{
+		applyThresholdMin.setInput2(input2.min);
+		applyThresholdMax.setInput2(input2.max);
+
+		mapper.compute1(input1, output);
+	}
+
+	// -- Helper classes --
+	/**
+	 * A class to pass threshold values as a single input
+	 *
+	 * @author Richard Domander (Royal Veterinary College, London)
+	 */
+	public static final class ThresholdPair<T extends RealType<T>> {
+
+		public final T min;
+		public final T max;
+
+		/**
+		 * Constructor for Thresholds
+		 *
+		 * @param type Type of the min and max values
+		 * @param min Minimum value for elements within threshold
+		 * @param max Maximum value for elements within threshold
+		 */
+		public ThresholdPair(final T type, final double min, final double max) {
+			this.min = type.createVariable();
+			this.min.setReal(min);
+			this.max = type.createVariable();
+			this.max.setReal(max);
+		}
+
+		/**
+		 * Constructor for Thresholds
+		 *
+		 * @param min Minimum value for elements within threshold
+		 * @param max Maximum value for elements within threshold
+		 */
+		public ThresholdPair(final T min, final T max) {
+			this.min = min;
+			this.max = max;
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/ops/threshold/apply/ApplyThresholdCollection.java
+++ b/src/main/java/net/imagej/ops/threshold/apply/ApplyThresholdCollection.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.threshold.apply;
+
+import java.util.Collection;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.threshold.ApplyThreshold;
+import net.imglib2.type.logic.BitType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Applies a collection of threshold ops to the given object, producing a
+ * {@link BitType} set to 1 iff the threshold ops all evaluate to 1.
+ *
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+@Plugin(type = Ops.Threshold.Apply.class)
+public class ApplyThresholdCollection<T> extends
+	AbstractUnaryComputerOp<T, BitType> implements ApplyThreshold<T, BitType>
+{
+
+	@Parameter
+	Collection<ApplyThreshold<T, BitType>> thresholdOps;
+
+	@Override
+	public void compute1(final T input, final BitType output) {
+		output.set(true);
+		BitType tempOutput = output.createVariable();
+
+		for (ApplyThreshold<T, BitType> thresholdOp : thresholdOps) {
+			thresholdOp.compute1(input, tempOutput);
+			output.and(tempOutput);
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPairTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPairTest.java
@@ -31,11 +31,12 @@
 package net.imagej.ops.threshold.apply;
 
 import net.imagej.ops.threshold.AbstractThresholdTest;
-import net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.ThresholdPair;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
 
 import org.junit.Test;
 
@@ -51,7 +52,7 @@ public class ApplyConstantThresholdPairTest extends AbstractThresholdTest {
 		final Img<BitType> out = bitmap();
 		final UnsignedShortType thresholdMin = new UnsignedShortType(30000);
 		final UnsignedShortType thresholdMax = new UnsignedShortType(40000);
-		ThresholdPair<UnsignedShortType> thresholdPair = new ThresholdPair<>(
+		Pair<UnsignedShortType, UnsignedShortType> thresholdPair = new ValuePair<>(
 			thresholdMin, thresholdMax);
 		ops.run(ApplyConstantThresholdPair.class, out, in, thresholdPair);
 		assertCount(out, 15);

--- a/src/test/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPairTest.java
+++ b/src/test/java/net/imagej/ops/threshold/apply/ApplyConstantThresholdPairTest.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.threshold.apply;
+
+import net.imagej.ops.threshold.AbstractThresholdTest;
+import net.imagej.ops.threshold.apply.ApplyConstantThresholdPair.ThresholdPair;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ApplyConstantThresholdPair}.
+ * 
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+public class ApplyConstantThresholdPairTest extends AbstractThresholdTest {
+
+	@Test
+	public void testApplyThresholdPair() throws IncompatibleTypeException {
+		final Img<BitType> out = bitmap();
+		final UnsignedShortType thresholdMin = new UnsignedShortType(30000);
+		final UnsignedShortType thresholdMax = new UnsignedShortType(40000);
+		ThresholdPair<UnsignedShortType> thresholdPair = new ThresholdPair<>(
+			thresholdMin, thresholdMax);
+		ops.run(ApplyConstantThresholdPair.class, out, in, thresholdPair);
+		assertCount(out, 15);
+	}
+
+}


### PR DESCRIPTION
This adds the ability to apply a `Pair` of constant thresholds where `Pair.A` denotes the lower threshold and `Pair.B` denotes an upper threshold. Outputs will be computed as `Pair.A < I && I < Pair.B` (where `I` is the element intensity).

The PR also adds an `ApplyThresholdCollection` op that applies a `Collection<ApplyThreshold>` to an element by computing `out = thresholdOp1(in) && thresholdOp2(in) && thresholdOp3(in) && ...`.