### PR TITLE
Fix NormalizeScaleRealTypes

### DIFF
--- a/src/main/java/net/imagej/ops/convert/RealTypeConverter.java
+++ b/src/main/java/net/imagej/ops/convert/RealTypeConverter.java
@@ -45,9 +45,12 @@ public abstract class RealTypeConverter<I extends RealType<I>, O extends RealTyp
 
 	/**
 	 * Allows the convert pix operation to determine some parameters from the
-	 * conrete input and output types.
+	 * concrete input and output types.
 	 */
-	public abstract void checkInput(I inType, O outType);
+	@SuppressWarnings("unused")
+	public void checkInput(I inType, O outType) {
+		// NB: default implementation
+	}
 
 	/**
 	 * If the pixels to be converted stem from an {@link IterableInterval} some
@@ -55,6 +58,9 @@ public abstract class RealTypeConverter<I extends RealType<I>, O extends RealTyp
 	 * here (hence, some heavier calculation might take place here). Might never
 	 * be called!
 	 */
-	public abstract void checkInput(IterableInterval<I> in);
+	@SuppressWarnings("unused")
+	public void checkInput(IterableInterval<I> in) {
+		// NB: default implementation
+	}
 
 }

--- a/src/main/java/net/imagej/ops/convert/clip/ClipRealTypes.java
+++ b/src/main/java/net/imagej/ops/convert/clip/ClipRealTypes.java
@@ -32,7 +32,6 @@ package net.imagej.ops.convert.clip;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.convert.RealTypeConverter;
-import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
@@ -68,11 +67,6 @@ public class ClipRealTypes<I extends RealType<I>, O extends RealType<O>>
 		outMax = outType.getMaxValue();
 		outMin = outType.getMinValue();
 
-	}
-
-	@Override
-	public void checkInput(final IterableInterval<I> in) {
-		// nothing to do here
 	}
 
 }

--- a/src/main/java/net/imagej/ops/convert/copy/CopyRealTypes.java
+++ b/src/main/java/net/imagej/ops/convert/copy/CopyRealTypes.java
@@ -32,7 +32,6 @@ package net.imagej.ops.convert.copy;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.convert.RealTypeConverter;
-import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
@@ -48,16 +47,6 @@ public class CopyRealTypes<I extends RealType<I>, O extends RealType<O>>
 	@Override
 	public void compute(final I input, final O output) {
 		output.setReal(input.getRealDouble());
-	}
-
-	@Override
-	public void checkInput(final I inType, final O outType) {
-		// nothing to do here
-	}
-
-	@Override
-	public void checkInput(final IterableInterval<I> in) {
-		// nothing to do here
 	}
 
 }

--- a/src/main/java/net/imagej/ops/convert/normalizeScale/NormalizeScaleRealTypes.java
+++ b/src/main/java/net/imagej/ops/convert/normalizeScale/NormalizeScaleRealTypes.java
@@ -30,7 +30,6 @@
 
 package net.imagej.ops.convert.normalizeScale;
 
-import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.convert.scale.ScaleRealTypes;
 import net.imagej.ops.special.function.Functions;
@@ -46,7 +45,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Convert.NormalizeScale.class)
 public class NormalizeScaleRealTypes<I extends RealType<I>, O extends RealType<O>>
-	extends ScaleRealTypes<I, O> implements Ops.Convert.NormalizeScale, Contingent
+	extends ScaleRealTypes<I, O> implements Ops.Convert.NormalizeScale
 {
 
 	private UnaryFunctionOp<IterableInterval<I>, Pair<I, I>> minMaxFunc;
@@ -73,14 +72,6 @@ public class NormalizeScaleRealTypes<I extends RealType<I>, O extends RealType<O
 			.getRealDouble()) / (outMax - outMin);
 
 		inMin = minMax.getA().getRealDouble();
-	}
-
-	@Override
-	public boolean conforms() {
-		// only conforms if an input source has been provided and the scale factor
-		// was calculated
-		// FIXME Prevents this op from being matched for use with Ops.Convert.ImageType
-		return factor != 0;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/convert/normalizeScale/NormalizeScaleRealTypes.java
+++ b/src/main/java/net/imagej/ops/convert/normalizeScale/NormalizeScaleRealTypes.java
@@ -48,8 +48,10 @@ import org.scijava.plugin.Plugin;
 public class NormalizeScaleRealTypes<I extends RealType<I>, O extends RealType<O>>
 	extends ScaleRealTypes<I, O> implements Ops.Convert.NormalizeScale, Contingent
 {
-	
+
 	private UnaryFunctionOp<IterableInterval<I>, Pair<I, I>> minMaxFunc;
+
+	protected double outMax;
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
@@ -61,24 +63,23 @@ public class NormalizeScaleRealTypes<I extends RealType<I>, O extends RealType<O
 	@Override
 	public void checkInput(final I inType, final O outType) {
 		outMin = outType.getMinValue();
+		outMax = outType.getMaxValue();
 	}
 
 	@Override
 	public void checkInput(final IterableInterval<I> in) {
 		final Pair<I, I> minMax = minMaxFunc.calculate(in);
-		final I inType = in.firstElement().createVariable();
-		factor =
-			1.0 / (minMax.getB().getRealDouble() - minMax.getA().getRealDouble()) *
-				(inType.getMaxValue() - inType.getMinValue());
+		factor = (minMax.getB().getRealDouble() - minMax.getA()
+			.getRealDouble()) / (outMax - outMin);
 
 		inMin = minMax.getA().getRealDouble();
-
 	}
 
 	@Override
 	public boolean conforms() {
 		// only conforms if an input source has been provided and the scale factor
 		// was calculated
+		// FIXME Prevents this op from being matched for use with Ops.Convert.ImageType
 		return factor != 0;
 	}
 

--- a/src/main/java/net/imagej/ops/convert/scale/ScaleRealTypes.java
+++ b/src/main/java/net/imagej/ops/convert/scale/ScaleRealTypes.java
@@ -32,7 +32,6 @@ package net.imagej.ops.convert.scale;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.convert.RealTypeConverter;
-import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
@@ -62,11 +61,6 @@ public class ScaleRealTypes<I extends RealType<I>, O extends RealType<O>>
 		inMin = inType.getMinValue();
 		outMin = outType.getMinValue();
 		factor = (inType.getMaxValue() - inMin) / (outType.getMaxValue() - outMin);
-	}
-
-	@Override
-	public void checkInput(final IterableInterval<I> in) {
-		// nothing to do here
 	}
 
 }

--- a/src/main/java/net/imagej/ops/convert/scale/ScaleRealTypes.java
+++ b/src/main/java/net/imagej/ops/convert/scale/ScaleRealTypes.java
@@ -53,6 +53,7 @@ public class ScaleRealTypes<I extends RealType<I>, O extends RealType<O>>
 
 	@Override
 	public void compute(final I input, final O output) {
+		// FIXME Throw exception if factor == 0.0
 		output.setReal((input.getRealDouble() - inMin) / factor + outMin);
 	}
 


### PR DESCRIPTION
Fixes a bug in `NormalizeScaleRealTypes` and addresses (to some extent) the last point of #463 by enabling:

```groovy
ops.op(Ops.Convert.NormalizeScale.class, out.firstElement(), in.firstElement()));
ops.run(Ops.Convert.ImageType.class, out, in, scaleOp);
```

Previously, matching of `Ops.Convert.NormalizeScale` was prohibited by a misleading contingency assumption.

@hornm, you are listed as the original author of these converters. Could you take a look if you find some time?