### PR TITLE
Replace DefaultFloodFill

### DIFF
--- a/src/main/java/net/imagej/ops/morphology/MorphologyNamespace.java
+++ b/src/main/java/net/imagej/ops/morphology/MorphologyNamespace.java
@@ -38,7 +38,6 @@ import net.imagej.ops.OpMethod;
 import net.imglib2.IterableInterval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.BooleanType;
@@ -305,7 +304,7 @@ public class MorphologyNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.morphology.extractHoles.DefaultExtractHolesComputer.class)
 	public <T extends BooleanType<T>> RandomAccessibleInterval<T> extractHoles(final RandomAccessibleInterval<T> out,
-			final RandomAccessibleInterval<T> in, final StructuringElement structElement) {
+			final RandomAccessibleInterval<T> in, final Shape structElement) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
 				.run(net.imagej.ops.morphology.extractHoles.DefaultExtractHolesComputer.class, out, in, structElement);
@@ -322,7 +321,7 @@ public class MorphologyNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.morphology.extractHoles.DefaultExtractHolesFunction.class)
 	public <T extends BooleanType<T>> RandomAccessibleInterval<T> extractHoles(final RandomAccessibleInterval<T> in,
-			final StructuringElement structElement) {
+			final Shape structElement) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
 				.run(net.imagej.ops.morphology.extractHoles.DefaultExtractHolesFunction.class, in, structElement);
@@ -348,7 +347,7 @@ public class MorphologyNamespace extends AbstractNamespace {
 
 	@OpMethod(op = net.imagej.ops.morphology.fillHoles.DefaultFillHoles.class)
 	public <T extends BooleanType<T>> RandomAccessibleInterval<T> fillHoles(final RandomAccessibleInterval<T> out,
-			final RandomAccessibleInterval<T> in, final StructuringElement structElement) {
+			final RandomAccessibleInterval<T> in, final Shape structElement) {
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result = (RandomAccessibleInterval<T>) ops()
 				.run(net.imagej.ops.morphology.fillHoles.DefaultFillHoles.class, out, in, structElement);
@@ -359,7 +358,7 @@ public class MorphologyNamespace extends AbstractNamespace {
 	public <T extends Type<T> & Comparable<T>> RandomAccessibleInterval<T>
 		floodFill(final RandomAccessibleInterval<T> out,
 			final RandomAccessibleInterval<T> in, final Localizable startPos,
-			final StructuringElement structElement)
+			final Shape structElement)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =
@@ -372,7 +371,7 @@ public class MorphologyNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.morphology.floodFill.DefaultFloodFill.class)
 	public <T extends Type<T> & Comparable<T>> RandomAccessibleInterval<T>
 		floodFill(final RandomAccessibleInterval<T> in1, final Localizable in2,
-			final StructuringElement structElement)
+			final Shape structElement)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<T> result =

--- a/src/main/java/net/imagej/ops/morphology/extractHoles/DefaultExtractHolesComputer.java
+++ b/src/main/java/net/imagej/ops/morphology/extractHoles/DefaultExtractHolesComputer.java
@@ -35,7 +35,8 @@ import net.imagej.ops.special.chain.RAIs;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.type.BooleanType;
 
 import org.scijava.plugin.Parameter;
@@ -54,7 +55,7 @@ public class DefaultExtractHolesComputer<T extends BooleanType<T>> extends
 {
 
 	@Parameter(required=false)
-	private StructuringElement structElement = StructuringElement.EIGHT_CONNECTED;
+	private Shape structElement = new RectangleShape(1, false);
 
 	private UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> xorMapOp;
 

--- a/src/main/java/net/imagej/ops/morphology/extractHoles/DefaultExtractHolesFunction.java
+++ b/src/main/java/net/imagej/ops/morphology/extractHoles/DefaultExtractHolesFunction.java
@@ -36,7 +36,8 @@ import net.imagej.ops.special.chain.UFViaUCAllSame;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.type.BooleanType;
 
 import org.scijava.plugin.Parameter;
@@ -53,7 +54,7 @@ public class DefaultExtractHolesFunction<T extends BooleanType<T>> extends
 {
 
 	@Parameter(required = false)
-	private StructuringElement structElement = StructuringElement.EIGHT_CONNECTED;
+	private Shape structElement = new RectangleShape(1, false);
 
 	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> createFunc;
 

--- a/src/main/java/net/imagej/ops/morphology/fillHoles/DefaultFillHoles.java
+++ b/src/main/java/net/imagej/ops/morphology/fillHoles/DefaultFillHoles.java
@@ -32,7 +32,6 @@ package net.imagej.ops.morphology.fillHoles;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.create.img.CreateImgFromDimsAndType;
-import net.imagej.ops.create.img.CreateImgFromInterval;
 import net.imagej.ops.special.chain.RAIs;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
@@ -42,7 +41,8 @@ import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.view.Views;
@@ -63,7 +63,7 @@ public class DefaultFillHoles<T extends BooleanType<T>> extends
 {
 
 	@Parameter(required = false)
-	private StructuringElement structElement = StructuringElement.EIGHT_CONNECTED;
+	private Shape structElement = new RectangleShape(1, false);
 
 	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> createFunc;
 	private BinaryComputerOp<RandomAccessibleInterval<T>, Localizable, RandomAccessibleInterval<T>> floodFillComp;

--- a/src/main/java/net/imagej/ops/morphology/floodFill/DefaultFloodFill.java
+++ b/src/main/java/net/imagej/ops/morphology/floodFill/DefaultFloodFill.java
@@ -30,9 +30,6 @@
 
 package net.imagej.ops.morphology.floodFill;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-
 import net.imagej.ops.Ops;
 import net.imagej.ops.create.img.CreateImgFromInterval;
 import net.imagej.ops.special.chain.RAIs;
@@ -41,9 +38,13 @@ import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
 import net.imglib2.Localizable;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.fill.Filter;
 import net.imglib2.algorithm.fill.FloodFill;
-import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.type.Type;
+import net.imglib2.util.Pair;
+import net.imglib2.view.Views;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -59,7 +60,7 @@ public class DefaultFloodFill<T extends Type<T> & Comparable<T>> extends
 {
 
 	@Parameter()
-	private StructuringElement structElement = StructuringElement.EIGHT_CONNECTED;
+	private Shape structElement = new RectangleShape(1, false);
 
 	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> createFunc;
 
@@ -72,77 +73,16 @@ public class DefaultFloodFill<T extends Type<T> & Comparable<T>> extends
 	public void compute(RandomAccessibleInterval<T> op0, Localizable loc,
 		RandomAccessibleInterval<T> r)
 	{
-		long[] posAsArray = new long[loc.numDimensions()];
-		loc.localize(posAsArray);
-
-		final RandomAccess<T> rc = r.randomAccess();
 		final RandomAccess<T> op0c = op0.randomAccess();
 		op0c.setPosition(loc);
-		final T floodVal = op0c.get().copy();
-		final LinkedList<long[]> q = new LinkedList<>();
-		q.addFirst(posAsArray.clone());
-		long[] pos, nextPos;
-		long[] perm = new long[r.numDimensions()];
-		while (!q.isEmpty()) {
-			pos = q.removeLast();
-			rc.setPosition(pos);
-			if (rc.get().compareTo(floodVal) == 0) {
-				continue;
+		final T fillValue = op0c.get().copy();
+		FloodFill.fill(Views.extendValue(op0, fillValue), Views.extendValue(r, fillValue), loc, fillValue, structElement, new Filter<Pair<T,T >, Pair<T,T>>() {
+
+			@Override
+			public boolean accept(Pair<T, T> t, Pair<T, T> u) {
+				return !t.getB().valueEquals(u.getB()) && t.getA().valueEquals(u.getA());
 			}
-			op0c.setPosition(pos);
-			if (op0c.get().compareTo(floodVal) == 0) {
-				// set new label
-				rc.get().set(floodVal);
-				switch (structElement) {
-					case EIGHT_CONNECTED:
-						Arrays.fill(perm, -1);
-						int i = r.numDimensions() - 1;
-						boolean add;
-						while (i > -1) {
-							nextPos = pos.clone();
-							add = true;
-							// Modify position
-							for (int j = 0; j < r.numDimensions(); j++) {
-								nextPos[j] += perm[j];
-								// Check boundaries
-								if (nextPos[j] < 0 || nextPos[j] >= r.dimension(j)) {
-									add = false;
-									break;
-								}
-							}
-							if (add) {
-								q.addFirst(nextPos);
-							}
-							// Calculate next permutation
-							for (i = perm.length - 1; i > -1; i--) {
-								if (perm[i] < 1) {
-									perm[i]++;
-									for (int j = i + 1; j < perm.length; j++) {
-										perm[j] = -1;
-									}
-									break;
-								}
-							}
-						}
-						break;
-					case FOUR_CONNECTED:
-					default:
-						for (int j = 0; j < r.numDimensions(); j++) {
-							if (pos[j] + 1 < r.dimension(j)) {
-								nextPos = pos.clone();
-								nextPos[j]++;
-								q.addFirst(nextPos);
-							}
-							if (pos[j] - 1 >= 0) {
-								nextPos = pos.clone();
-								nextPos[j]--;
-								q.addFirst(nextPos);
-							}
-						}
-						break;
-				}
-			}
-		}
+		});
 	}
 
 	@Override

--- a/src/test/java/net/imagej/ops/morphology/MorphologyOpsTest.java
+++ b/src/test/java/net/imagej/ops/morphology/MorphologyOpsTest.java
@@ -37,7 +37,7 @@ import net.imagej.ops.AbstractOpTest;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
 import net.imglib2.img.Img;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -94,15 +94,14 @@ public class MorphologyOpsTest extends AbstractOpTest {
 
 	@Test
 	public void testExtractHoles() {
-		assertNotNull("Img Without Holes",
-				ops.morphology().extractHoles(imgWithoutHoles, StructuringElement.FOUR_CONNECTED));
-		assertNotNull("Img With Holes", ops.morphology().extractHoles(imgWithHoles, StructuringElement.FOUR_CONNECTED));
+		assertNotNull("Img Without Holes", ops.morphology().extractHoles(imgWithoutHoles, new DiamondShape(1)));
+		assertNotNull("Img With Holes", ops.morphology().extractHoles(imgWithHoles, new DiamondShape(1)));
 	}
 
 	@Test
 	public void testFillHoles() {
 		Img<BitType> result = ops.create().img(imgWithHoles);
-		ops.morphology().fillHoles(result, imgWithHoles, StructuringElement.FOUR_CONNECTED);
+		ops.morphology().fillHoles(result, imgWithHoles, new DiamondShape(1));
 
 		Cursor<BitType> resultC = result.cursor();
 		final BitType one = new BitType(true);
@@ -116,7 +115,7 @@ public class MorphologyOpsTest extends AbstractOpTest {
 		Img<BitType> result = ops.create().img(invertedImgWithFilledHoles);
 		Img<BitType> inverted = ops.create().img(invertedImgWithFilledHoles);
 		ops.image().invert(inverted, imgWithHoles);
-		ops.morphology().fillHoles(result, inverted, StructuringElement.FOUR_CONNECTED);
+		ops.morphology().fillHoles(result, inverted, new DiamondShape(1));
 
 		Cursor<BitType> resultC = result.localizingCursor();
 		RandomAccess<BitType> groundTruthRA = invertedImgWithFilledHoles.randomAccess();


### PR DESCRIPTION
DefaultFloodFill implementation is replaced by the n-dimensional FloodFill implementation from imglib2. 

https://github.com/imagej/imagej-ops/issues/391
https://github.com/imagej/imagej-ops/pull/394

All tests are still passing. 