### PR TITLE
Fix SquareIntegralImg

### DIFF
--- a/src/main/java/net/imagej/ops/image/integral/AbstractIntegralImg.java
+++ b/src/main/java/net/imagej/ops/image/integral/AbstractIntegralImg.java
@@ -61,22 +61,19 @@ public abstract class AbstractIntegralImg<I extends RealType<I>> extends
 	implements Contingent
 {
 
-	private AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>> integralAdd;
 	private UnaryComputerOp[] slicewiseOps;
 	private UnaryFunctionOp<Dimensions, RandomAccessibleInterval> createLongRAI;
 	private UnaryFunctionOp<Dimensions, RandomAccessibleInterval> createDoubleRAI;
 
 	@Override
 	public void initialize() {
-		integralAdd = getComputer();
-
 		if (in() != null) {
 			slicewiseOps = new UnaryComputerOp[in().numDimensions()];
 
 			for (int i = 0; i < in().numDimensions(); ++i) {
 				slicewiseOps[i] = Computers.unary(ops(), Slice.class,
 					RandomAccessibleInterval.class, RandomAccessibleInterval.class,
-					integralAdd, i);
+					getComputer(i), i);
 			}
 		}
 
@@ -91,13 +88,14 @@ public abstract class AbstractIntegralImg<I extends RealType<I>> extends
 	public void compute(final RandomAccessibleInterval<I> input,
 		final RandomAccessibleInterval<RealType<?>> output)
 	{
+		// TODO Should become obsolete (duplication of initialize())
 		if (slicewiseOps == null) {
 			slicewiseOps = new UnaryComputerOp[in().numDimensions()];
 
 			for (int i = 0; i < in().numDimensions(); ++i) {
 				slicewiseOps[i] = Computers.unary(ops(), Slice.class,
 					RandomAccessibleInterval.class, RandomAccessibleInterval.class,
-					integralAdd, i);
+					getComputer(i), i);
 			}
 		}
 
@@ -136,7 +134,7 @@ public abstract class AbstractIntegralImg<I extends RealType<I>> extends
 	 * images.
 	 */
 	public abstract
-		AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>>
-		getComputer();
+		AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>> getComputer(
+			int dimension);
 
 }

--- a/src/main/java/net/imagej/ops/image/integral/DefaultIntegralImg.java
+++ b/src/main/java/net/imagej/ops/image/integral/DefaultIntegralImg.java
@@ -32,7 +32,6 @@ package net.imagej.ops.image.integral;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCI;
-import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.LongType;
@@ -57,43 +56,10 @@ public class DefaultIntegralImg<I extends RealType<I>> extends
 {
 
 	@Override
-	public
-		AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>>
-		getComputer()
+	public AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>>
+		getComputer(final int dimension)
 	{
-		return new IntegralAddComputer();
-	}
-
-	/**
-	 * Implements the row-wise addition required for computations of integral
-	 * images of order=1.
-	 *
-	 * @author Stefan Helfrich (University of Konstanz)
-	 */
-	private class IntegralAddComputer extends
-		AbstractUnaryHybridCI<IterableInterval<RealType<?>>, IterableInterval<RealType<?>>>
-	{
-
-		@Override
-		public void compute(final IterableInterval<RealType<?>> input,
-			final IterableInterval<RealType<?>> output)
-		{
-
-			final Cursor<RealType<?>> inputCursor = input.cursor();
-			final Cursor<RealType<?>> outputCursor = output.cursor();
-
-			double tmp = 0.0d;
-			while (outputCursor.hasNext()) {
-
-				final RealType<?> inputValue = inputCursor.next();
-				final RealType<?> outputValue = outputCursor.next();
-
-				tmp += inputValue.getRealDouble();
-
-				outputValue.setReal(tmp);
-			}
-		}
-
+		return new IntegralAdd<>();
 	}
 
 }

--- a/src/main/java/net/imagej/ops/image/integral/IntegralAdd.java
+++ b/src/main/java/net/imagej/ops/image/integral/IntegralAdd.java
@@ -30,42 +30,40 @@
 
 package net.imagej.ops.image.integral;
 
-import net.imagej.ops.Ops;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCI;
+import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.LongType;
-import net.imglib2.type.numeric.real.DoubleType;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
 
 /**
- * <p>
- * <i>n</i>-dimensional squared integral image that stores sums using
- * {@code RealType}. Care must be taken that sums do not overflow the capacity
- * of {@code RealType} (i.e. {@link DoubleType} or {@link LongType}). Instead of
- * the sum of values the sum of squared values is computed.
- * </p>
+ * Implements the row-wise addition required for computations of integral images
+ * of order=1.
  *
- * @param <I> The type of the input image.
  * @author Stefan Helfrich (University of Konstanz)
+ * @param <I> type of inputs
  */
-@Plugin(type = Ops.Image.SquareIntegral.class,
-	priority = Priority.LOW_PRIORITY + 1)
-public class SquareIntegralImg<I extends RealType<I>> extends
-	AbstractIntegralImg<I> implements Ops.Image.SquareIntegral
+class IntegralAdd<I extends RealType<I>> extends
+	AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>>
 {
 
 	@Override
-	public AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>>
-		getComputer(final int dimension)
+	public void compute(final IterableInterval<I> input,
+		final IterableInterval<I> output)
 	{
-		if (dimension == 0) {
-			return new IntegralSquareAndAdd<>();
-		}
 
-		return new IntegralAdd<>();
+		final Cursor<I> inputCursor = input.cursor();
+		final Cursor<I> outputCursor = output.cursor();
+
+		double tmp = 0.0d;
+		while (outputCursor.hasNext()) {
+
+			final I inputValue = inputCursor.next();
+			final I outputValue = outputCursor.next();
+
+			tmp += inputValue.getRealDouble();
+
+			outputValue.setReal(tmp);
+		}
 	}
 
 }

--- a/src/main/java/net/imagej/ops/image/integral/IntegralSquareAndAdd.java
+++ b/src/main/java/net/imagej/ops/image/integral/IntegralSquareAndAdd.java
@@ -40,6 +40,7 @@ import net.imglib2.type.numeric.RealType;
  * integral images.
  *
  * @author Stefan Helfrich (University of Konstanz)
+ * @param <I> type of inputs
  */
 class IntegralSquareAndAdd<I extends RealType<I>> extends
 	AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>>

--- a/src/main/java/net/imagej/ops/image/integral/IntegralSquareAndAdd.java
+++ b/src/main/java/net/imagej/ops/image/integral/IntegralSquareAndAdd.java
@@ -30,42 +30,39 @@
 
 package net.imagej.ops.image.integral;
 
-import net.imagej.ops.Ops;
 import net.imagej.ops.special.hybrid.AbstractUnaryHybridCI;
+import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.LongType;
-import net.imglib2.type.numeric.real.DoubleType;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Plugin;
 
 /**
- * <p>
- * <i>n</i>-dimensional squared integral image that stores sums using
- * {@code RealType}. Care must be taken that sums do not overflow the capacity
- * of {@code RealType} (i.e. {@link DoubleType} or {@link LongType}). Instead of
- * the sum of values the sum of squared values is computed.
- * </p>
+ * Implements the row-wise addition required for computations of squared
+ * integral images.
  *
- * @param <I> The type of the input image.
  * @author Stefan Helfrich (University of Konstanz)
  */
-@Plugin(type = Ops.Image.SquareIntegral.class,
-	priority = Priority.LOW_PRIORITY + 1)
-public class SquareIntegralImg<I extends RealType<I>> extends
-	AbstractIntegralImg<I> implements Ops.Image.SquareIntegral
+class IntegralSquareAndAdd<I extends RealType<I>> extends
+	AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>>
 {
 
 	@Override
-	public AbstractUnaryHybridCI<IterableInterval<I>, IterableInterval<I>>
-		getComputer(final int dimension)
+	public void compute(final IterableInterval<I> input,
+		final IterableInterval<I> output)
 	{
-		if (dimension == 0) {
-			return new IntegralSquareAndAdd<>();
-		}
 
-		return new IntegralAdd<>();
+		final Cursor<I> inputCursor = input.cursor();
+		final Cursor<I> outputCursor = output.cursor();
+
+		double tmp = 0.0d;
+		while (outputCursor.hasNext()) {
+
+			final I inputValue = inputCursor.next();
+			final I outputValue = outputCursor.next();
+
+			tmp += Math.pow(inputValue.getRealDouble(), 2);
+
+			outputValue.setReal(tmp);
+		}
 	}
 
 }

--- a/src/main/java/net/imagej/ops/stats/IntegralVariance.java
+++ b/src/main/java/net/imagej/ops/stats/IntegralVariance.java
@@ -112,6 +112,7 @@ public class IntegralVariance<I extends RealType<I>> extends
 		sum1.div(valueAsDoubleType); // NB
 
 		sum2.sub(sum1);
+		valueAsDoubleType.sub(new DoubleType(1)); // NB
 		sum2.div(valueAsDoubleType); // NB
 
 		output.set(sum2);

--- a/src/test/java/net/imagej/ops/image/integral/IntegralImgTest.java
+++ b/src/test/java/net/imagej/ops/image/integral/IntegralImgTest.java
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imagej.ops.image.integral;
 
 import net.imagej.ops.AbstractOpTest;
@@ -49,7 +50,7 @@ import org.junit.Test;
 /**
  * @author Stefan Helfrich (University of Konstanz)
  */
-public class IntegralImgTest extends AbstractOpTest  {
+public class IntegralImgTest extends AbstractOpTest {
 
 	Img<ByteType> in;
 	RandomAccessibleInterval<DoubleType> out;
@@ -63,7 +64,7 @@ public class IntegralImgTest extends AbstractOpTest  {
 	public void before() throws Exception {
 		in = generateByteArrayTestImg(true, new long[] { 10, 10 });
 	}
-	
+
 	/**
 	 * @see DefaultIntegralImg
 	 * @see SquareIntegralImg
@@ -71,8 +72,10 @@ public class IntegralImgTest extends AbstractOpTest  {
 	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testIntegralImageCreation() {
-		out = (RandomAccessibleInterval<DoubleType>) ops.run(Ops.Image.Integral.class, in);
-		out = (RandomAccessibleInterval<DoubleType>) ops.run(Ops.Image.SquareIntegral.class, in);
+		out = (RandomAccessibleInterval<DoubleType>) ops.run(
+			Ops.Image.Integral.class, in);
+		out = (RandomAccessibleInterval<DoubleType>) ops.run(
+			Ops.Image.SquareIntegral.class, in);
 	}
 
 	/**
@@ -82,24 +85,27 @@ public class IntegralImgTest extends AbstractOpTest  {
 	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testIntegralImageSimilarity() {
-		RandomAccessibleInterval<LongType> out1 = (RandomAccessibleInterval<LongType>) ops.run(DefaultIntegralImg.class,
+		RandomAccessibleInterval<LongType> out1 =
+			(RandomAccessibleInterval<LongType>) ops.run(DefaultIntegralImg.class,
 				in);
-		RandomAccessibleInterval<DoubleType> out2 = (RandomAccessibleInterval<DoubleType>) ops
-				.run(WrappedIntegralImg.class, in);
+		RandomAccessibleInterval<DoubleType> out2 =
+			(RandomAccessibleInterval<DoubleType>) ops.run(WrappedIntegralImg.class,
+				in);
 
 		// Remove 0s from integralImg by shifting its interval by +1
 		final long[] min = new long[out2.numDimensions()];
 		final long[] max = new long[out2.numDimensions()];
 
 		for (int d = 0; d < out2.numDimensions(); ++d) {
-			min[d] = out2.min(d)+1;
+			min[d] = out2.min(d) + 1;
 			max[d] = out2.max(d);
 		}
 
 		// Define the Interval on the infinite random accessibles
 		final FinalInterval interval = new FinalInterval(min, max);
-		
-		LocalThresholdTest.testIterableIntervalSimilarity(Views.iterable(out1), Views.iterable(Views.offsetInterval(out2, interval)));
+
+		LocalThresholdTest.testIterableIntervalSimilarity(Views.iterable(out1),
+			Views.iterable(Views.offsetInterval(out2, interval)));
 	}
 
 	public ArrayImg<ByteType, ByteArray> generateKnownByteArrayTestImgLarge() {

--- a/src/test/java/net/imagej/ops/image/integral/SquareIntegralImgTest.java
+++ b/src/test/java/net/imagej/ops/image/integral/SquareIntegralImgTest.java
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.image.integral;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Ops;
+import net.imagej.ops.threshold.apply.LocalThresholdTest;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Stefan Helfrich (University of Konstanz)
+ */
+public class SquareIntegralImgTest extends AbstractOpTest {
+
+	Img<ByteType> in;
+	RandomAccessibleInterval<DoubleType> out;
+
+	/**
+	 * Initialize image.
+	 *
+	 * @throws Exception
+	 */
+	@Before
+	public void before() throws Exception {
+		in = generateByteArrayTestImg(true, new long[] { 10, 10 });
+	}
+
+	/**
+	 * @see SquareIntegralImg
+	 */
+	@Test
+	public void testIntegralImageCreation() {
+		ops.run(Ops.Image.SquareIntegral.class, in);
+	}
+
+	/**
+	 * @see SquareIntegralImg
+	 */
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSquareIntegralImageCorrectness() {
+		RandomAccessibleInterval<LongType> out1 =
+			(RandomAccessibleInterval<LongType>) ops.run(SquareIntegralImg.class,
+				generateKnownByteArrayTestImg());
+
+		Img<ByteType> bytes = generateKnownSquareIntegralImage();
+
+		LocalThresholdTest.testIterableIntervalSimilarity(Views.iterable(bytes),
+			Views.iterable(out1));
+	}
+
+	private Img<ByteType> generateKnownSquareIntegralImage() {
+		final long[] dims = new long[] { 3, 3 };
+		final byte[] array = new byte[9];
+
+		array[0] = (byte) 16;
+		array[1] = (byte) 32;
+		array[2] = (byte) 36;
+
+		array[3] = (byte) 32;
+		array[4] = (byte) 64;
+		array[5] = (byte) 72;
+
+		array[6] = (byte) 36;
+		array[7] = (byte) 72;
+		array[8] = (byte) 116;
+
+		Img<ByteType> bytes = ArrayImgs.bytes(array, dims);
+		return bytes;
+	}
+
+	public ArrayImg<ByteType, ByteArray> generateKnownByteArrayTestImg() {
+		final long[] dims = new long[] { 3, 3 };
+		final byte[] array = new byte[9];
+
+		array[0] = (byte) 4;
+		array[1] = (byte) 4;
+		array[2] = (byte) 2;
+
+		array[3] = (byte) 4;
+		array[4] = (byte) 4;
+		array[5] = (byte) 2;
+
+		array[6] = (byte) 2;
+		array[7] = (byte) 2;
+		array[8] = (byte) 6;
+
+		return ArrayImgs.bytes(array, dims);
+	}
+
+}


### PR DESCRIPTION
This PR fixes the computation of squared integral images: squaring of input values only needs to be done in one dimension; computations along other axes are just summations.

This makes the tests that are fixed in #475 pass again. Hence, this PR fixes #474 in combination with #475. 