### PR TITLE
Zernike tests

### DIFF
--- a/src/main/java/net/imagej/ops/features/zernike/helper/ZernikeComputer.java
+++ b/src/main/java/net/imagej/ops/features/zernike/helper/ZernikeComputer.java
@@ -83,8 +83,6 @@ public class ZernikeComputer<T extends RealType<T>> extends
 		// get the cursor of the iterable interval
 		final Cursor<? extends RealType<?>> cur = ii.localizingCursor();
 
-		// count number of pixel inside the unit circle
-		int count = 0;
 
 		// run over itarble interval
 		while (cur.hasNext()) {
@@ -126,12 +124,28 @@ public class ZernikeComputer<T extends RealType<T>> extends
 		}
 
 		// normalization
-		normalize(moment.getZm(), moment.getN(), count);
-
+		normalize(moment.getZm(), moment.getN(), getNumberOfPixelsInUnitDisk(radius));
 		return moment;
 	}
 
 	/**
+	 * Computes the number of whole pixels within a disk with radius r. This is
+	 * based on Gauss's Circle Problem.
+	 * 
+	 * http://mathworld.wolfram.com/GausssCircleProblem.html
+	 * 
+	 * @param r
+	 *            the radius
+	 * @return number of pixels within the disk
+	 */
+	private long getNumberOfPixelsInUnitDisk(final double r) {
+		long tmp = 0;
+		for (int i = 1; i <= Math.floor(r); i++) {
+			tmp += Math.floor(Math.sqrt(r * r - i * i));
+		}
+
+		return (long) (1 + 4 * Math.floor(r)) + 4 * tmp;
+	}
 	 * 
 	 * Multiplication of pixel * rad * exp(-m*theta) using eulers formula
 	 * (pixel*rad) * (cos(m*theta) - i*sin(m*theta))

--- a/src/main/java/net/imagej/ops/features/zernike/helper/ZernikeComputer.java
+++ b/src/main/java/net/imagej/ops/features/zernike/helper/ZernikeComputer.java
@@ -29,8 +29,6 @@
  */
 package net.imagej.ops.features.zernike.helper;
 
-import java.util.List;
-
 import net.imagej.ops.Op;
 import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imagej.types.BigComplex;
@@ -48,23 +46,23 @@ import org.scijava.plugin.Plugin;
  * @author Andreas Graumann (University of Konstanz)
  */
 @Plugin(type = Op.class)
-public class ZernikeComputer<T extends RealType<T>> extends
-	AbstractUnaryFunctionOp<IterableInterval<T>, ZernikeMoment>
-{
+public class ZernikeComputer<T extends RealType<T>>
+		extends AbstractUnaryFunctionOp<IterableInterval<T>, ZernikeMoment> {
 
 	@Parameter
 	private int order;
 
 	@Parameter
 	private int repetition;
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
 	}
 
 	@Override
-	public ZernikeMoment calculate(IterableInterval<T> ii) {
+	public ZernikeMoment calculate(final IterableInterval<T> ii) {
+
 		final double width2 = (ii.dimension(0) - 1) / 2.0;
 		final double height2 = (ii.dimension(1) - 1) / 2.0;
 
@@ -75,16 +73,15 @@ public class ZernikeComputer<T extends RealType<T>> extends
 
 		// Compute pascal's triangle for binomal coefficients: d[x][y] equals (x
 		// over y)
-		double[][] d = computePascalsTriangle(order);
+		final double[][] d = computePascalsTriangle(order);
 
 		// initialize zernike moment
-		ZernikeMoment moment = initZernikeMoment(order, repetition, d);
+		final ZernikeMoment moment = initZernikeMoment(order, repetition, d);
 
 		// get the cursor of the iterable interval
 		final Cursor<? extends RealType<?>> cur = ii.localizingCursor();
 
-
-		// run over itarble interval
+		// run over iterable interval
 		while (cur.hasNext()) {
 			cur.fwd();
 
@@ -96,33 +93,12 @@ public class ZernikeComputer<T extends RealType<T>> extends
 			final double ym = (y - centerY) / radius;
 
 			final double r = Math.sqrt(xm * xm + ym * ym);
-
-			// calculate theta for this position
-			final double theta = Math.atan2(xm, ym);
-
-			// get current pixel value
-			double pixel = cur.get().getRealDouble();
-			if (pixel != 0.0) {
-				pixel = 1.0;
+			if (r <= 1 && cur.get().getRealDouble() != 0.0) {
+				// calculate theta for this position
+				final double theta = Math.atan2(xm, ym);
+				moment.getZm().add(multiplyExp(1, moment.getP().evaluate(r), theta, moment.getM()));
 			}
-
-			if (pixel >= 0.0) {
-				// increment number of pixel inside the unit circle
-				count++;
-
-				// calculate the desired moment
-				// evaluate radial polynom at position r
-				final double rad = moment.getP().evaluate(r);
-
-				// p * rad * exp(-1i * m * theta);
-				final BigComplex product = multiplyExp(pixel, rad, theta, moment.getM());
-
-				// add together
-				moment.getZm().add(product);
-			}
-
 		}
-
 		// normalization
 		normalize(moment.getZm(), moment.getN(), getNumberOfPixelsInUnitDisk(radius));
 		return moment;
@@ -146,24 +122,26 @@ public class ZernikeComputer<T extends RealType<T>> extends
 
 		return (long) (1 + 4 * Math.floor(r)) + 4 * tmp;
 	}
+
+	/**
 	 * 
 	 * Multiplication of pixel * rad * exp(-m*theta) using eulers formula
 	 * (pixel*rad) * (cos(m*theta) - i*sin(m*theta))
 	 * 
-	 * @param _pixel
+	 * @param pixel
 	 *            Current pixel
-	 * @param _rad
+	 * @param rad
 	 *            Computed value of radial polynom,
-	 * @param _theta
+	 * @param theta
 	 *            Angle of current position
-	 * @param _m
+	 * @param m
 	 *            Repitition m
 	 * @return Computed term
 	 */
-	private BigComplex multiplyExp(final double _pixel, final double _rad, final double _theta, final int _m) {
+	private BigComplex multiplyExp(final double pixel, final double rad, final double theta, final int m) {
 		BigComplex c = new BigComplex();
-		c.setReal(_pixel * _rad * Math.cos(_m * _theta));
-		c.setImag(-(_pixel * _rad * Math.sin(_m * _theta)));
+		c.setReal(pixel * rad * Math.cos(m * theta));
+		c.setImag(-(pixel * rad * Math.sin(m * theta)));
 		return c;
 	}
 
@@ -171,38 +149,38 @@ public class ZernikeComputer<T extends RealType<T>> extends
 	 * 
 	 * Normalization of all calculated zernike moments in complex representation
 	 * 
-	 * @param _complex
+	 * @param complex
 	 *            Complex representation of zernike moment
-	 * @param _n
+	 * @param n
 	 *            Order n
-	 * @param _count
+	 * @param count
 	 *            Number of pixel within unit circle
 	 */
-	private void normalize(BigComplex _complex, int _n, int _count) {
-		_complex.setReal(_complex.getRealDouble() * (_n + 1) / _count);
-		_complex.setImag(_complex.getImaginaryDouble() * (_n + 1) / _count);
+	private void normalize(final BigComplex complex, final int n, final long count) {
+		complex.setReal(complex.getRealDouble() * (n + 1) / count);
+		complex.setImag(complex.getImaginaryDouble() * (n + 1) / count);
 	}
 
 	/**
 	 * 
 	 * Initialize a zernike moment with a given order and repition
 	 * 
-	 * @param _order
+	 * @param o
 	 *            Order n
-	 * @param _repitition
+	 * @param repitition
 	 *            Repitition m
-	 * @param _d
+	 * @param d
 	 *            Pascal matrix
 	 * @return Empty Zernike moment of order n and repitition m
 	 */
-	private ZernikeMoment initZernikeMoment(final int _order, final int _repitition, final double[][] _d) {
+	private ZernikeMoment initZernikeMoment(final int o, final int repitition, final double[][] d) {
 
-		if (_order - Math.abs(_repitition) % 2 != 0) {
+		if (o - Math.abs(repitition) % 2 != 0) {
 			// throw new IllegalArgumentException("This combination of order an
 			// repitition is not valid!");
 		}
 
-		return createZernikeMoment(_d, _order, _repitition);
+		return createZernikeMoment(d, o, repitition);
 	}
 
 	/**
@@ -210,19 +188,19 @@ public class ZernikeComputer<T extends RealType<T>> extends
 	 * Create one zernike moment of order n and repitition m with suitable
 	 * radial polynom
 	 * 
-	 * @param _d
+	 * @param d
 	 *            Pascal matrix
-	 * @param _n
+	 * @param n
 	 *            Order n
-	 * @param _m
+	 * @param m
 	 *            Repition m
 	 * @return Empty Zernike moment of order n and repition m
 	 */
-	private ZernikeMoment createZernikeMoment(double[][] _d, int _n, int _m) {
+	private ZernikeMoment createZernikeMoment(double[][] d, int n, int m) {
 		ZernikeMoment p = new ZernikeMoment();
-		p.setM(_m);
-		p.setN(_n);
-		p.setP(createRadialPolynom(_n, _m, _d));
+		p.setM(m);
+		p.setN(n);
+		p.setP(createRadialPolynom(n, m, d));
 		BigComplex complexNumber = new BigComplex();
 		p.setZm(complexNumber);
 		return p;
@@ -231,13 +209,13 @@ public class ZernikeComputer<T extends RealType<T>> extends
 	/**
 	 * Efficient calculation of pascal's triangle up to order max
 	 * 
-	 * @param _max
+	 * @param max
 	 *            maximal order of pascal's triangle
 	 * @return pascal's triangle
 	 */
-	private double[][] computePascalsTriangle(int _max) {
-		double[][] d = new double[_max + 1][_max + 1];
-		for (int n = 0; n <= _max; n++) {
+	private double[][] computePascalsTriangle(int max) {
+		double[][] d = new double[max + 1][max + 1];
+		for (int n = 0; n <= max; n++) {
 			for (int k = 0; k <= n; k++) {
 				if ((n == 0 && k == 0) || (n == k) || (k == 0)) {
 					d[n][k] = 1.0;
@@ -251,20 +229,20 @@ public class ZernikeComputer<T extends RealType<T>> extends
 
 	/**
 	 * 
-	 * @param _n
+	 * @param n
 	 *            Order n
-	 * @param _m
+	 * @param m
 	 *            Repitition m
-	 * @param _k
+	 * @param k
 	 *            Radius k
-	 * @param _d
+	 * @param d
 	 *            Pascal matrix
 	 * @return computed term
 	 */
-	public static int computeBinomialFactorial(final int _n, final int _m, final int _k, double[][] _d) {
-		int fac1 = (int) _d[_n - _k][_k];
-		int fac2 = (int) _d[_n - 2 * _k][((_n - _m) / 2) - _k];
-		int sign = (int) Math.pow(-1, _k);
+	public static int computeBinomialFactorial(final int n, final int m, final int k, double[][] d) {
+		int fac1 = (int) d[n - k][k];
+		int fac2 = (int) d[n - 2 * k][((n - m) / 2) - k];
+		int sign = (int) Math.pow(-1, k);
 
 		return sign * fac1 * fac2;
 	}
@@ -281,19 +259,19 @@ public class ZernikeComputer<T extends RealType<T>> extends
 	 * 
 	 * Creates a radial polynom for zernike moment with order n and repitition m
 	 * 
-	 * @param _n
+	 * @param n
 	 *            Order n
-	 * @param _m
+	 * @param m
 	 *            Repitition m
-	 * @param _d
+	 * @param d
 	 *            Pascal matrix
 	 * @return Radial polnom for moment of order n and repition m
 	 */
-	public static Polynom createRadialPolynom(final int _n, final int _m, final double[][] _d) {
-		final Polynom result = new Polynom(_n);
-		for (int s = 0; s <= ((_n - Math.abs(_m)) / 2); ++s) {
-			final int pos = _n - (2 * s);
-			result.setCoefficient(pos, computeBinomialFactorial(_n, _m, s, _d));
+	public static Polynom createRadialPolynom(final int n, final int m, final double[][] d) {
+		final Polynom result = new Polynom(n);
+		for (int s = 0; s <= ((n - Math.abs(m)) / 2); ++s) {
+			final int pos = n - (2 * s);
+			result.setCoefficient(pos, computeBinomialFactorial(n, m, s, d));
 		}
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/features/zernike/helper/ZernikeComputer.java
+++ b/src/main/java/net/imagej/ops/features/zernike/helper/ZernikeComputer.java
@@ -65,16 +65,13 @@ public class ZernikeComputer<T extends RealType<T>> extends
 
 	@Override
 	public ZernikeMoment calculate(IterableInterval<T> ii) {
+		final double width2 = (ii.dimension(0) - 1) / 2.0;
+		final double height2 = (ii.dimension(1) - 1) / 2.0;
 
-		// what is the acutal N
-		final double width = ii.dimension(0);
-		final double height = ii.dimension(1);
+		final double centerX = width2 + ii.min(0);
+		final double centerY = height2 + ii.min(1);
 
-		double size = (width > height) ? width : height;
-		final double centerX = width / 2.0d + ii.min(0);
-		final double centerY = height / 2.0d + ii.min(1);
-		
-		double radius = Math.sqrt((size + size) * size) / 2;
+		final double radius = Math.sqrt(width2 * width2 + height2 * height2);
 
 		// Compute pascal's triangle for binomal coefficients: d[x][y] equals (x
 		// over y)

--- a/src/test/java/net/imagej/ops/features/AbstractFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/AbstractFeatureTest.java
@@ -40,9 +40,14 @@ import java.util.Random;
 
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.OpService;
+import net.imagej.ops.geom.geom3d.mesh.DefaultMesh;
+import net.imagej.ops.geom.geom3d.mesh.Mesh;
+import net.imagej.ops.geom.geom3d.mesh.TriangularFacet;
+import net.imagej.ops.geom.geom3d.mesh.Vertex;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealPoint;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayCursor;
@@ -56,9 +61,11 @@ import net.imglib2.roi.labeling.LabelRegion;
 import net.imglib2.roi.labeling.LabelRegions;
 import net.imglib2.roi.labeling.LabelingType;
 import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.RandomAccessibleIntervalCursor;
 
 import org.junit.Before;
 import org.scijava.Context;
@@ -256,17 +263,13 @@ public class AbstractFeatureTest extends AbstractOpTest {
 	}
 
 	protected static Img<FloatType> getTestImage2D() {
-		final String imageName = expensiveTestsEnabled ? "2d_geometric_features_testlabel_expensive.png"
-			: "2d_geometric_features_testlabel.tif";
-		return openFloatImg(AbstractFeatureTest.class, imageName);
+		return openFloatImg(AbstractFeatureTest.class, "2d_geometric_features_testlabel.tif");
 	}
 	
 	protected static Polygon getPolygon() {
-		final String polygonName = expensiveTestsEnabled ? "2d_geometric_features_polygon_expensive.txt"
-			: "2d_geometric_features_polygon.txt";
-		List<RealPoint> vertices = new ArrayList<>();
+		final List<RealPoint> vertices = new ArrayList<>();
 		try {
-			Files.lines(Paths.get(AbstractFeatureTest.class.getResource(polygonName).toURI()))
+			Files.lines(Paths.get(AbstractFeatureTest.class.getResource("2d_geometric_features_polygon.txt").toURI()))
 										.forEach(l -> {
 											String[] coord = l.split(" ");
 											RealPoint v = new RealPoint(new double[]{	Double.parseDouble(coord[0]), 
@@ -274,35 +277,53 @@ public class AbstractFeatureTest extends AbstractOpTest {
 											vertices.add(v);
 										});
 		} catch (IOException | URISyntaxException exc) {
-			// TODO Auto-generated catch block
 			exc.printStackTrace();
 		}
 		return new Polygon(vertices);
 	}
 
 	protected static Img<FloatType> getTestImage3D() {
-		final String imageName = expensiveTestsEnabled
-			? "3d_geometric_features_testlabel_expensive.tif"
-			: "3d_geometric_features_testlabel.tif";
-		return openFloatImg(AbstractFeatureTest.class, imageName);
+		return openFloatImg(AbstractFeatureTest.class, "3d_geometric_features_testlabel.tif");
+	}
+	
+	protected static Mesh getMesh() {
+		final List<Vertex> vertices = new ArrayList<>();
+		try {
+			Files.lines(Paths.get(AbstractFeatureTest.class.getResource("3d_geometric_features_mesh.txt").toURI()))
+										.forEach(l -> {
+											String[] coord = l.split(" ");
+											Vertex v = new Vertex(Double.parseDouble(coord[0]), 
+																  Double.parseDouble(coord[1]),
+																  Double.parseDouble(coord[2]));
+											vertices.add(v);
+										});
+		} catch (IOException | URISyntaxException exc) {
+			exc.printStackTrace();
+		}
+		final DefaultMesh m = new DefaultMesh();
+		for (int i = 0; i < vertices.size(); i+=3) {
+			final TriangularFacet f = new TriangularFacet(vertices.get(i), vertices.get(i+1), vertices.get(i+2));
+			m.addFace(f);
+		}
+		return m;
 	}
 
-	protected static LabelRegion<String> createLabelRegion(
-		final Img<FloatType> img, final float min, final float max, long... dims)
+	protected static <T extends RealType<T>> LabelRegion<String> createLabelRegion(
+		final RandomAccessibleInterval<T> interval, final float min, final float max, long... dims)
 	{
 		if (dims == null || dims.length == 0) {
-			dims = new long[img.numDimensions()];
-			img.dimensions(dims);
+			dims = new long[interval.numDimensions()];
+			interval.dimensions(dims);
 		}
 		final ImgLabeling<String, IntType> labeling = 
 			new ImgLabeling<>(ArrayImgs.ints(dims));
 
 		final RandomAccess<LabelingType<String>> ra = labeling.randomAccess();
-		final Cursor<FloatType> c = img.cursor();
+		final RandomAccessibleIntervalCursor<T> c = new RandomAccessibleIntervalCursor<>(interval);		
 		final long[] pos = new long[labeling.numDimensions()];
 		while (c.hasNext()) {
-			final FloatType item = c.next();
-			final float value = item.get();
+			final T item = c.next();
+			final float value = item.getRealFloat();
 			if (value >= min && value <= max) {
 				c.localize(pos);
 				ra.setPosition(pos);

--- a/src/test/java/net/imagej/ops/features/zernike/ZernikeFeatureTest.java
+++ b/src/test/java/net/imagej/ops/features/zernike/ZernikeFeatureTest.java
@@ -46,13 +46,15 @@ import org.junit.Test;
  */
 public class ZernikeFeatureTest extends AbstractFeatureTest {
 	
+	private static final double EPSILON = 1e-12;
+
 	@Test
 	public void testPhaseFeature() {
 
-		assertEquals(Ops.Zernike.Phase.NAME, 180.0, ((RealType<?>) ops.run(
-			DefaultPhaseFeature.class, ellipse, 4, 2)).getRealDouble(), 1e-3);
-		assertEquals(Ops.Zernike.Phase.NAME, 360.0, ((RealType<?>) ops.run(
-			DefaultPhaseFeature.class, rotatedEllipse, 4, 2)).getRealDouble(), 1e-3);
+		assertEquals(Ops.Zernike.Phase.NAME, 179.92297037263532, ((RealType<?>) ops.run(
+			DefaultPhaseFeature.class, ellipse, 4, 2)).getRealDouble(), EPSILON);
+		assertEquals(Ops.Zernike.Phase.NAME, 0.0802239034925816, ((RealType<?>) ops.run(
+			DefaultPhaseFeature.class, rotatedEllipse, 4, 2)).getRealDouble(), EPSILON);
 	}
 	
 	@Test 
@@ -63,9 +65,9 @@ public class ZernikeFeatureTest extends AbstractFeatureTest {
 		double v2 = ((RealType<?>) ops.run(DefaultMagnitudeFeature.class,
 			rotatedEllipse, 4, 2)).getRealDouble();
 	
-		assertEquals(Ops.Zernike.Magnitude.NAME, 0.16684211008, v1, 1e-3);
+		assertEquals(Ops.Zernike.Magnitude.NAME, 0.10985876611295191, v1, EPSILON);
 		
-		// magnitude should be the same after rotating the image
+		// magnitude is the same after rotating the image
 		assertEquals(Ops.Zernike.Magnitude.NAME, v1, v2, 1e-3);
 	}
 


### PR DESCRIPTION
This PR is part of https://github.com/imagej/imagej-ops/issues/449.

The Zernike implementation puts the input-region on a disk with the smallest possible radius. Beforehand the radius was to big in the rectangular case. Also the number of pixel in the disk, which is used to normalize the moments, was wrong. 

Code cleanup removes "_" in front of variables and reduces computation steps. 