### PR TITLE
CentroidII: remove unecessary array allocations

### DIFF
--- a/src/main/java/net/imagej/ops/geom/CentroidII.java
+++ b/src/main/java/net/imagej/ops/geom/CentroidII.java
@@ -57,9 +57,9 @@ public class CentroidII
 		int numDimensions = input.numDimensions();
 		double[] output = new double[numDimensions];
 		Cursor<?> c = input.localizingCursor();
+		double[] pos = new double[numDimensions];
 		while (c.hasNext()) {
 			c.fwd();
-			double[] pos = new double[numDimensions];
 			c.localize(pos);
 			for (int i = 0; i < output.length; i++) {
 				output[i] += pos[i];


### PR DESCRIPTION
We don't allocate a new array in every iteration.