### PR TITLE
Fix normalized central moment tests

### DIFF
--- a/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment2.java
+++ b/src/main/java/net/imagej/ops/imagemoments/hu/DefaultHuMoment2.java
@@ -76,6 +76,6 @@ public class DefaultHuMoment2<I extends RealType<I>, O extends RealType<O>>
 		double n20 = normalizedCentralMoment20Func.calculate(input).getRealDouble();
 		double n02 = normalizedCentralMoment02Func.calculate(input).getRealDouble();
 
-		output.setReal(Math.pow(n20 - n02, 2) - 4 * (Math.pow(n11, 2)));
+		output.setReal(Math.pow(n20 - n02, 2) + 4 * (Math.pow(n11, 2)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment02<I extends RealType<I>, O extends R
 		double centralMoment02 = centralMoment02Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment02 /
-			Math.pow(centralMoment00, 1 + ((0 + 2) / 2)));
+			Math.pow(centralMoment00, 1 + ((0 + 2) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment03<I extends RealType<I>, O extends R
 		double centralMoment03 = centralMoment03Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment03 /
-			Math.pow(centralMoment00, 1 + ((0 + 3) / 2)));
+			Math.pow(centralMoment00, 1 + ((0 + 3) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment11<I extends RealType<I>, O extends R
 		double centralMoment11 = centralMoment11Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment11 /
-			Math.pow(centralMoment00, 1 + ((1 + 1) / 2)));
+			Math.pow(centralMoment00, 1 + ((1 + 1) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment12<I extends RealType<I>, O extends R
 		double centralMoment12 = centralMoment12Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment12 /
-			Math.pow(centralMoment00, 1 + ((1 + 2) / 2)));
+			Math.pow(centralMoment00, 1 + ((1 + 2) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment20<I extends RealType<I>, O extends R
 		double centralMoment20 = centralMoment20Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment20 /
-			Math.pow(centralMoment00, 1 + ((2 + 0) / 2)));
+			Math.pow(centralMoment00, 1 + ((2 + 0) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment21<I extends RealType<I>, O extends R
 		double centralMoment21 = centralMoment21Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment21 /
-			Math.pow(centralMoment00, 1 + ((2 + 1) / 2)));
+			Math.pow(centralMoment00, 1 + ((2 + 1) / 2.0)));
 	}
 }

--- a/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
+++ b/src/main/java/net/imagej/ops/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
@@ -70,6 +70,6 @@ public class DefaultNormalizedCentralMoment30<I extends RealType<I>, O extends R
 		double centralMoment30 = centralMoment30Func.calculate(input).getRealDouble();
 
 		output.setReal(centralMoment30 /
-			Math.pow(centralMoment00, 1 + ((3 + 0) / 2)));
+			Math.pow(centralMoment00, 1 + ((3 + 0) / 2.0)));
 	}
 }

--- a/src/test/java/net/imagej/ops/imagemoments/ImageMomentsTest.java
+++ b/src/test/java/net/imagej/ops/imagemoments/ImageMomentsTest.java
@@ -36,36 +36,10 @@ import java.util.Random;
 
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.Ops;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment02;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment03;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment11;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment12;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment20;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment21;
-import net.imagej.ops.Ops.ImageMoments.CentralMoment30;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment1;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment2;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment3;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment4;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment5;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment6;
-import net.imagej.ops.imagemoments.hu.DefaultHuMoment7;
-import net.imagej.ops.imagemoments.moments.DefaultMoment00;
-import net.imagej.ops.imagemoments.moments.DefaultMoment01;
-import net.imagej.ops.imagemoments.moments.DefaultMoment10;
-import net.imagej.ops.imagemoments.moments.DefaultMoment11;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment02;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment03;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment11;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment12;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment20;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment21;
-import net.imagej.ops.imagemoments.normalizedcentralmoments.DefaultNormalizedCentralMoment30;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
-import net.imglib2.type.numeric.real.DoubleType;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,6 +51,7 @@ import org.junit.Test;
  */
 public class ImageMomentsTest extends AbstractOpTest {
 
+	private static final double EPSILON = 1e-8;
 	private static Img<UnsignedByteType> img;
 
 	@BeforeClass
@@ -100,14 +75,14 @@ public class ImageMomentsTest extends AbstractOpTest {
 	@Test
 	public void testMoments() {
 
-		assertEquals(Ops.ImageMoments.Moment00.NAME, 1277534.0, ((DoubleType) ops.run(DefaultMoment00.class, img))
-			.getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.Moment10.NAME, 6.3018047E7, ((DoubleType) ops.run(DefaultMoment10.class, img))
-			.getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.Moment01.NAME, 6.3535172E7, ((DoubleType) ops.run(DefaultMoment01.class, img))
-			.getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.Moment11.NAME, 3.12877962E9, ((DoubleType) ops.run(DefaultMoment11.class, img))
-			.getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.Moment00.NAME, 1277534.0, ops.imagemoments().moment00(img)
+			.getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.Moment10.NAME, 6.3018047E7, ops.imagemoments().moment10(img)
+			.getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.Moment01.NAME, 6.3535172E7, ops.imagemoments().moment01(img)
+			.getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.Moment11.NAME, 3.12877962E9, ops.imagemoments().moment11(img)
+			.getRealDouble(), EPSILON);
 	}
 
 	/**
@@ -115,20 +90,20 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testCentralMoments() {
-		assertEquals(Ops.ImageMoments.CentralMoment11.NAME, -5275876.956702232, ((DoubleType) ops
-			.run(CentralMoment11.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment02.NAME, 1.0694469880269928E9, ((DoubleType) ops
-			.run(CentralMoment02.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment20.NAME, 1.0585772432642083E9, ((DoubleType) ops
-			.run(CentralMoment20.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment12.NAME, 5478324.271270752, ((DoubleType) ops
-			.run(CentralMoment12.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment21.NAME, -2.1636455685491943E8, ((DoubleType) ops
-				.run(CentralMoment21.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment30.NAME, 1.735560232991333E8, ((DoubleType) ops
-			.run(CentralMoment30.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.CentralMoment03.NAME, -4.0994213161157227E8, ((DoubleType) ops
-				.run(CentralMoment03.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.CentralMoment11.NAME, -5275876.956702709, ops.imagemoments()
+			.centralMoment11(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.CentralMoment02.NAME, 1.0694469880269902E9, ops.imagemoments()
+			.centralMoment02(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.CentralMoment20.NAME, 1.0585772432642114E9, ops.imagemoments()
+			.centralMoment20(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.CentralMoment12.NAME, 5478324.271281097, ops.imagemoments()
+			.centralMoment12(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.CentralMoment21.NAME, -2.1636455685489437E8, ops
+			.imagemoments().centralMoment21(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.CentralMoment30.NAME, 1.7355602329912126E8, ops.imagemoments()
+			.centralMoment30(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.CentralMoment03.NAME, -4.099421316116555E8, ops
+			.imagemoments().centralMoment03(img).getRealDouble(), EPSILON);
 	}
 
 	/**
@@ -136,33 +111,26 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testNormalizedCentralMoments() {
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment11.NAME,
-			-3.2325832933879204E-6, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment11.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment11.NAME, -3.2325832933879204E-6, ops
+			.imagemoments().normalizedCentralMoment11(img).getRealDouble(), EPSILON);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment02.NAME,
-			6.552610106398286E-4, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment02.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment02.NAME, 6.552610106398286E-4, ops
+			.imagemoments().normalizedCentralMoment02(img).getRealDouble(), EPSILON);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment20.NAME,
-			6.486010078361372E-4, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment20.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment20.NAME, 6.486010078361372E-4, ops
+			.imagemoments().normalizedCentralMoment20(img).getRealDouble(), EPSILON);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment12.NAME,
-			2.969727272701925E-9, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment12.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment12.NAME, 2.969727272701925E-9, ops
+			.imagemoments().normalizedCentralMoment12(img).getRealDouble(), EPSILON);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment21.NAME,
-			-1.1728837022440002E-7, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment21.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment21.NAME, -1.1728837022440002E-7, ops
+			.imagemoments().normalizedCentralMoment21(img).getRealDouble(), EPSILON);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment30.NAME,
-			9.408242926327751E-8, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment30.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment30.NAME, 9.408242926327751E-8, ops
+			.imagemoments().normalizedCentralMoment30(img).getRealDouble(), EPSILON);
 
-		assertEquals(Ops.ImageMoments.NormalizedCentralMoment03.NAME,
-			-2.22224218245127E-7, ((DoubleType) ops.run(
-				DefaultNormalizedCentralMoment03.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.NormalizedCentralMoment03.NAME, -2.22224218245127E-7, ops
+			.imagemoments().normalizedCentralMoment03(img).getRealDouble(), EPSILON);
 	}
 
 	/**
@@ -170,20 +138,20 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testHuMoments() {
-		assertEquals(Ops.ImageMoments.HuMoment1.NAME, 0.001303862018475966, ((DoubleType) ops
-			.run(DefaultHuMoment1.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment2.NAME, 8.615401633994056e-11, ((DoubleType) ops
-			.run(DefaultHuMoment2.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment3.NAME, 2.406124306990366e-14, ((DoubleType) ops
-			.run(DefaultHuMoment3.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment4.NAME, 1.246879188175627e-13, ((DoubleType) ops
-			.run(DefaultHuMoment4.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment5.NAME, -6.610443880647384e-27, ((DoubleType) ops
-			.run(DefaultHuMoment5.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment6.NAME, 1.131019166855569e-18, ((DoubleType) ops
-			.run(DefaultHuMoment6.class, img)).getRealDouble(), 1e-3);
-		assertEquals(Ops.ImageMoments.HuMoment7.NAME, 1.716256940536518e-27, ((DoubleType) ops
-			.run(DefaultHuMoment7.class, img)).getRealDouble(), 1e-3);
+		assertEquals(Ops.ImageMoments.HuMoment1.NAME, 0.001303862018475966, ops.imagemoments()
+			.huMoment1(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.HuMoment2.NAME, 8.615401633994056e-11, ops.imagemoments()
+			.huMoment2(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.HuMoment3.NAME, 2.406124306990366e-14, ops.imagemoments()
+			.huMoment3(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.HuMoment4.NAME, 1.246879188175627e-13, ops.imagemoments()
+			.huMoment4(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.HuMoment5.NAME, -6.610443880647384e-27, ops.imagemoments()
+			.huMoment5(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.HuMoment6.NAME, 1.131019166855569e-18, ops.imagemoments()
+			.huMoment6(img).getRealDouble(), EPSILON);
+		assertEquals(Ops.ImageMoments.HuMoment7.NAME, 1.716256940536518e-27, ops.imagemoments()
+			.huMoment7(img).getRealDouble(), EPSILON);
 	}
 
 }


### PR DESCRIPTION
I reviewed this PR https://github.com/imagej/imagej-ops/pull/301. Everything looks fine, I just had to update the test-values since a bug got fixed in the implementation. Thanks to @djniles. 

@ctrueden I am not quite sure if this is how a PR from a fork is reviewed if some commits have to be added. 