### PR TITLE
Add Outline op

### DIFF
--- a/src/main/java/net/imagej/ops/morphology/MorphologyNamespace.java
+++ b/src/main/java/net/imagej/ops/morphology/MorphologyNamespace.java
@@ -42,6 +42,7 @@ import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.Type;
+import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
@@ -271,6 +272,29 @@ public class MorphologyNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	@OpMethod(op = net.imagej.ops.morphology.outline.Outline.class)
+	public <B extends BooleanType<B>> RandomAccessibleInterval<BitType> outline(
+		final RandomAccessibleInterval<BitType> out,
+		final RandomAccessibleInterval<B> in, final Boolean excludeEdges)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<BitType> result =
+			(RandomAccessibleInterval<BitType>) ops().run(
+				net.imagej.ops.Ops.Morphology.Outline.class, out, in, excludeEdges);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.morphology.outline.Outline.class)
+	public <B extends BooleanType<B>> RandomAccessibleInterval<BitType> outline(
+		final RandomAccessibleInterval<B> in, final Boolean excludeEdges)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<BitType> result =
+			(RandomAccessibleInterval<BitType>) ops().run(
+				net.imagej.ops.Ops.Morphology.Outline.class, in, excludeEdges);
+		return result;
+	}
+
 	@OpMethod(op = net.imagej.ops.morphology.topHat.ListTopHat.class)
 	public <T extends RealType<T>> IterableInterval<T> topHat(
 		final RandomAccessibleInterval<T> in1, final List<Shape> in2)
@@ -353,7 +377,7 @@ public class MorphologyNamespace extends AbstractNamespace {
 				.run(net.imagej.ops.morphology.fillHoles.DefaultFillHoles.class, out, in, structElement);
 		return result;
 	}
-	
+
 	@OpMethod(op = net.imagej.ops.morphology.floodFill.DefaultFloodFill.class)
 	public <T extends Type<T> & Comparable<T>> RandomAccessibleInterval<T>
 		floodFill(final RandomAccessibleInterval<T> out,

--- a/src/main/java/net/imagej/ops/morphology/outline/Outline.java
+++ b/src/main/java/net/imagej/ops/morphology/outline/Outline.java
@@ -1,0 +1,148 @@
+
+package net.imagej.ops.morphology.outline;
+
+import java.util.Arrays;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
+import net.imglib2.Cursor;
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.outofbounds.OutOfBounds;
+import net.imglib2.roi.labeling.BoundingBox;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.util.Util;
+import net.imglib2.view.ExtendedRandomAccessibleInterval;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * The Op creates an output interval where the objects are hollow versions from
+ * the input. Rectangles become outlines, solid cubes become surfaces etc.
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+@Plugin(type = Ops.Morphology.Outline.class)
+public class Outline<B extends BooleanType<B>> extends
+	AbstractBinaryHybridCF<RandomAccessibleInterval<B>, Boolean, RandomAccessibleInterval<BitType>>
+	implements Ops.Morphology.Outline
+{
+
+	@Override
+	public RandomAccessibleInterval<BitType> createOutput(
+		final RandomAccessibleInterval<B> input, final Boolean input2)
+	{
+		final long[] dims = new long[input.numDimensions()];
+		input.dimensions(dims);
+		final FinalDimensions dimensions = new FinalDimensions(dims);
+		return ops().create().img(dimensions, new BitType());
+	}
+
+	/**
+	 * Copies the outlines of the objects in the input interval into the output
+	 *
+	 * @param input a binary interval
+	 * @param excludeEdges are elements on stack edges outline or not
+	 *          <p>
+	 *          For example, a 2D square:<br>
+	 *          0 0 0 0<br>
+	 *          1 1 1 0<br>
+	 *          E 1 1 0<br>
+	 *          1 1 1 0<br>
+	 *          0 0 0 0<br>
+	 *          Element E is removed if parameter true, kept if false
+	 *          </p>
+	 * @param output outlines of the objects in interval
+	 */
+	@Override
+	public void compute(final RandomAccessibleInterval<B> input,
+		final Boolean excludeEdges,
+		final RandomAccessibleInterval<BitType> output)
+	{
+		final Cursor<B> inputCursor = Views.iterable(input).localizingCursor();
+		final long[] coordinates = new long[input.numDimensions()];
+		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> extendedInput =
+			extendInterval(input);
+		final RandomAccess<BitType> outputAccess = output.randomAccess();
+		while (inputCursor.hasNext()) {
+			inputCursor.fwd();
+			inputCursor.localize(coordinates);
+			if (isOutline(extendedInput, coordinates)) {
+				outputAccess.setPosition(coordinates);
+				outputAccess.get().set(inputCursor.get().get());
+			}
+		}
+	}
+
+	// region -- Helper methods --
+	private ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>>
+		extendInterval(RandomAccessibleInterval<B> interval)
+	{
+		final B type = Util.getTypeFromInterval(interval).createVariable();
+		type.set(in2());
+		return Views.extendValue(interval, type);
+	}
+
+	/**
+	 * Creates a view that spans from (x-1, y-1, ... i-1) to (x+1, y+1, ... i+1)
+	 * around the given coordinates
+	 *
+	 * @param interval the space of the coordinates
+	 * @param coordinates coordinates (x, y, ... i)
+	 * @return a view of a neighbourhood in the space
+	 */
+	private IntervalView<B> neighbourhoodInterval(
+		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> interval,
+		final long[] coordinates)
+	{
+		final int dimensions = interval.numDimensions();
+		final BoundingBox box = new BoundingBox(dimensions);
+		final long[] minBounds = Arrays.stream(coordinates).map(c -> c - 1)
+			.toArray();
+		final long[] maxBounds = Arrays.stream(coordinates).map(c -> c + 1)
+			.toArray();
+		box.update(minBounds);
+		box.update(maxBounds);
+		return Views.offsetInterval(interval, box);
+	}
+
+	/** Checks if any element in the neighbourhood is background */
+	private boolean isAnyBackground(final IntervalView<B> neighbourhood) {
+		final Cursor<B> cursor = neighbourhood.cursor();
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			if (!cursor.get().get()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks if an element is part of the outline of an object
+	 *
+	 * @param source the location of the element
+	 * @param coordinates coordinates of the element
+	 * @return true if element is foreground and has at least one background
+	 *         neighbour
+	 */
+	private boolean isOutline(
+		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> source,
+		final long[] coordinates)
+	{
+		final OutOfBounds<B> access = source.randomAccess();
+		access.setPosition(coordinates);
+		if (!access.get().get()) {
+			return false;
+		}
+
+		final IntervalView<B> neighbourhood = neighbourhoodInterval(source,
+			coordinates);
+		return isAnyBackground(neighbourhood);
+	}
+	// endregion
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -308,6 +308,7 @@ namespaces = ```
 		[name: "fillHoles",                      iface: "FillHoles"],
 		[name: "floodFill",                      iface: "FloodFill"],
 		[name: "open",                           iface: "Open"],
+		[name: "outline",                        iface: "Outline"],
 		[name: "thin",                           iface: "Thin"],
 		[name: "topHat",                         iface: "TopHat"],
 	]],

--- a/src/test/java/net/imagej/ops/morphology/outline/OutlineTest.java
+++ b/src/test/java/net/imagej/ops/morphology/outline/OutlineTest.java
@@ -1,0 +1,239 @@
+
+package net.imagej.ops.morphology.outline;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+
+/**
+ * Tests for the {@link Outline} op
+ *
+ * @author Richard Domander (Royal Veterinary College, London)
+ */
+public class OutlineTest extends AbstractOpTest {
+
+	/** Test basic properties of the op's output */
+	@Test
+	public void testOutput() throws Exception {
+		// SETUP
+		final long[] inputDims = { 3, 3, 3 };
+		final Img<BitType> img = ArrayImgs.bits(inputDims);
+
+		// EXECUTE
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertNotNull(result);
+		final long[] outputDims = new long[result.numDimensions()];
+		result.dimensions(outputDims);
+		assertArrayEquals(inputDims, outputDims);
+	}
+
+	/** Test the op with an interval that's full of background elements */
+	@Test
+	public void testAllBackground() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(3, 3, 3);
+
+		// EXECUTE
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertEquals("Output should contain no foreground", 0, countForeground(
+			result));
+	}
+
+	/** Test the op with an interval that's full of foreground elements */
+	@Test
+	public void testAllForeground() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(3, 3, 3);
+		img.forEach(BitType::setOne);
+
+		// EXECUTE
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertEquals("Output should contain no foreground", 0, countForeground(
+			result));
+	}
+
+	/** Test the op with a 2x2 square. The square is in the middle of a 4x4 img */
+	@Test
+	public void testSquare() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(4, 4);
+		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
+			1, 1 }, new long[] { 2, 2 });
+		square.cursor().forEachRemaining(BitType::setOne);
+
+		// EXECUTE
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertEquals("Wrong number of foreground elements in interval", 4,
+			countForeground(result));
+		final IntervalView<BitType> resultSquare = Views.offsetInterval(result,
+			new long[] { 1, 1 }, new long[] { 2, 2 });
+		assertTrue("Wrong number of foreground elements in object", allForeground(
+			resultSquare));
+	}
+
+	/**
+	 * Test the op with a 3x3 square with a hole in the middle. The square is in
+	 * the middle of a 5x5 img
+	 */
+	@Test
+	public void testOutlineSquare() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(5, 5);
+		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
+			1, 1 }, new long[] { 3, 3 });
+		square.cursor().forEachRemaining(BitType::setOne);
+		final RandomAccess<BitType> access = square.randomAccess();
+		access.setPosition(new long[] { 1, 1 });
+		access.get().setZero();
+
+		// EXECUTION
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertEquals("Wrong number of foreground elements in interval", 8,
+			countForeground(result));
+		final IntervalView<BitType> resultSquare = Views.offsetInterval(result,
+			new long[] { 1, 1 }, new long[] { 3, 3 });
+		assertEquals("Wrong number of foreground elements in object", 8,
+			countForeground(resultSquare));
+		assertPositionBackground(result, new long[] { 2, 2 });
+	}
+
+	/**
+	 * Test the op with a 3x3 square starting from (0,1) in a 5x5 img
+	 *
+	 * @see Outline#compute(RandomAccessibleInterval, Boolean,
+	 *      RandomAccessibleInterval)
+	 * @see #testEdgeSquare()
+	 */
+	@Test
+	public void testEdgeSquare() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(5, 5);
+		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
+			0, 1 }, new long[] { 3, 3 });
+		square.cursor().forEachRemaining(BitType::setOne);
+
+		// EXECUTION
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertEquals("Wrong number of foreground elements in interval", 7,
+			countForeground(result));
+		final IntervalView<BitType> resultSquare = Views.offsetInterval(result,
+			new long[] { 0, 1 }, new long[] { 3, 3 });
+		assertEquals("Wrong number of foreground elements in object", 7,
+			countForeground(resultSquare));
+		assertPositionBackground(result, new long[] { 0, 2 });
+		assertPositionBackground(result, new long[] { 1, 2 });
+	}
+
+	/**
+	 * Test the op with a 3x3 square starting from (0,1) in a 5x5 img without
+	 * excluding edges
+	 *
+	 * @see Outline#compute(RandomAccessibleInterval, Boolean,
+	 *      RandomAccessibleInterval)
+	 * @see #testEdgeSquare()
+	 */
+	@Test
+	public void testEdgeSquareExcludeEdgesFalse() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(5, 5);
+		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
+			0, 1 }, new long[] { 3, 3 });
+		square.cursor().forEachRemaining(BitType::setOne);
+
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.FALSE);
+
+		assertEquals("Wrong number of foreground elements in interval", 8,
+			countForeground(result));
+		final IntervalView<BitType> resultSquare = Views.offsetInterval(result,
+			new long[] { 0, 1 }, new long[] { 3, 3 });
+		assertEquals("Wrong number of foreground elements in object", 8,
+			countForeground(resultSquare));
+		assertPositionBackground(result, new long[] { 1, 2 });
+	}
+
+	/**
+	 * Test the op with a 3x3x3x3 hypercube. The cube is in the middle of a
+	 * 5x5x5x5 img
+	 */
+	@Test
+	public void testHyperCube() throws Exception {
+		// SETUP
+		final Img<BitType> img = ArrayImgs.bits(5, 5, 5, 5);
+		final IntervalView<BitType> hyperCube = Views.offsetInterval(img,
+			new long[] { 1, 1, 1, 1 }, new long[] { 3, 3, 3, 3 });
+		hyperCube.cursor().forEachRemaining(BitType::setOne);
+
+		// EXECUTE
+		final Img<BitType> result = (Img<BitType>) ops.morphology().outline(img,
+			Boolean.TRUE);
+
+		// VERIFY
+		assertEquals("Wrong number of foreground elements in interval", 80,
+			countForeground(result));
+		final IntervalView<BitType> resultHyperCube = Views.offsetInterval(result,
+			new long[] { 1, 1, 1, 1 }, new long[] { 3, 3, 3, 3 });
+		assertEquals("Wrong number of foreground elements in object", 80,
+			countForeground(resultHyperCube));
+		assertPositionBackground(result, new long[] { 2, 2, 2, 2 });
+	}
+
+	// region -- Helper methods --
+	private boolean allForeground(final IterableInterval<BitType> interval) {
+		for (final BitType element : interval) {
+			if (!element.get()) {
+				return Boolean.FALSE;
+			}
+		}
+		return Boolean.TRUE;
+	}
+
+	private int countForeground(final IterableInterval<BitType> interval) {
+		int count = 0;
+		for (final BitType element : interval) {
+			count = count + element.getInteger();
+		}
+		return count;
+	}
+
+	private void assertPositionBackground(
+		final RandomAccessibleInterval<BitType> interval, final long[] position)
+	{
+		final RandomAccess<BitType> access = interval.randomAccess();
+		access.setPosition(position);
+		assertFalse("Element should be background", access.get().get());
+	}
+	// endregion
+}


### PR DESCRIPTION
Add an op that copies the outlines of objects into output. It creates "hollow" versions of objects with only the surface voxels. It works in n-dimensions.