### PR TITLE
Don't ignore OutOfBorderFactory when calculating difference of gaussian

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -670,24 +670,6 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.filter.dog.DefaultDoG.class)
-	public <T extends NumericType<T> & NativeType<T>> RandomAccessibleInterval<T>
-		dog(final RandomAccessibleInterval<T> out,
-			final RandomAccessibleInterval<T> in,
-			final UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> gauss1,
-			final UnaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> gauss2,
-			final UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> outputCreator,
-			final UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> tmpCreator,
-			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> fac)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<T> result =
-			(RandomAccessibleInterval<T>) ops().run(
-				net.imagej.ops.filter.dog.DefaultDoG.class, out, in, gauss1, gauss2,
-				outputCreator, tmpCreator, fac);
-		return result;
-	}
-
 	@OpMethod(op = net.imagej.ops.filter.dog.DoGVaryingSigmas.class)
 	public <T extends RealType<T>, V extends RealType<V>>
 		RandomAccessibleInterval<V> dog(final RandomAccessibleInterval<V> out,

--- a/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DefaultDoG.java
@@ -73,22 +73,11 @@ public class DefaultDoG<T extends NumericType<T> & NativeType<T>> extends
 	@Parameter
 	private UnaryFunctionOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> tmpCreator;
 
-	@Parameter(required = false)
-	private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> fac;
-
 	@Override
 	public RandomAccessibleInterval<T> createOutput(
 		final RandomAccessibleInterval<T> input)
 	{
 		return outputCreator.calculate(input);
-	}
-
-	@Override
-	public void initialize() {
-		if (fac == null) {
-			fac = new OutOfBoundsMirrorFactory<>(
-				Boundary.SINGLE);
-		}
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/filter/dog/DoGVaryingSigmas.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DoGVaryingSigmas.java
@@ -79,8 +79,7 @@ public class DoGVaryingSigmas<T extends NumericType<T> & NativeType<T>> extends
 			RAIs.computer(ops(), Ops.Filter.Gauss.class, t, sigmas1, fac), //
 			RAIs.computer(ops(), Ops.Filter.Gauss.class, t, sigmas2, fac), //
 			RAIs.function(ops(), Ops.Create.Img.class, t), //
-			RAIs.function(ops(), Ops.Create.Img.class, t, type), //
-			fac);
+			RAIs.function(ops(), Ops.Create.Img.class, t, type));
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ops/filter/dog/DoGVaryingSigmas.java
+++ b/src/main/java/net/imagej/ops/filter/dog/DoGVaryingSigmas.java
@@ -76,8 +76,8 @@ public class DoGVaryingSigmas<T extends NumericType<T> & NativeType<T>> extends
 	{
 		final T type = Util.getTypeFromInterval(t);
 		return RAIs.hybrid(ops(), Ops.Filter.DoG.class, t, //
-			RAIs.computer(ops(), Ops.Filter.Gauss.class, t, sigmas1), //
-			RAIs.computer(ops(), Ops.Filter.Gauss.class, t, sigmas2), //
+			RAIs.computer(ops(), Ops.Filter.Gauss.class, t, sigmas1, fac), //
+			RAIs.computer(ops(), Ops.Filter.Gauss.class, t, sigmas2, fac), //
 			RAIs.function(ops(), Ops.Create.Img.class, t), //
 			RAIs.function(ops(), Ops.Create.Img.class, t, type), //
 			fac);


### PR DESCRIPTION
Previously the given OutOfBorderFactory was not used for the calculation of the gaussian filters.