### PR TITLE
Fix Map Op Bugs with Cursors

### DIFF
--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplace.java
@@ -65,6 +65,6 @@ public class MapIIAndIIInplace<EA> extends
 	public void mutate2(final IterableInterval<EA> in,
 		final IterableInterval<EA> arg)
 	{
-		Maps.inplace(arg, in, getOp());
+		Maps.inplace(in, arg, getOp());
 	}
 }

--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -135,13 +135,15 @@ public class Maps {
 		final NullaryComputerOp<O> op, final int startIndex, final int stepSize,
 		final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<O> aCursor = a.cursor();
+
 		aCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			op.compute(aCursor.get());
+		op.compute(aCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(stepSize);
-			ctr++;
+			op.compute(aCursor.get());
 		}
 	}
 
@@ -288,16 +290,18 @@ public class Maps {
 		final IterableInterval<O> b, final UnaryComputerOp<I, O> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<I> aCursor = a.cursor();
 		final Cursor<O> bCursor = b.cursor();
+
 		aCursor.jumpFwd(startIndex + 1);
 		bCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			op.compute(aCursor.get(), bCursor.get());
+		op.compute(aCursor.get(), bCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(stepSize);
 			bCursor.jumpFwd(stepSize);
-			ctr++;
+			op.compute(aCursor.get(), bCursor.get());
 		}
 	}
 
@@ -305,15 +309,18 @@ public class Maps {
 		final RandomAccessibleInterval<O> b, final UnaryComputerOp<I, O> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<I> aCursor = a.localizingCursor();
 		final RandomAccess<O> bAccess = b.randomAccess();
+
 		aCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		bAccess.setPosition(aCursor);
+		op.compute(aCursor.get(), bAccess.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			aCursor.jumpFwd(stepSize);
 			bAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bAccess.get());
-			aCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -321,15 +328,18 @@ public class Maps {
 		final IterableInterval<O> b, final UnaryComputerOp<I, O> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final RandomAccess<I> aAccess = a.randomAccess();
 		final Cursor<O> bCursor = b.localizingCursor();
+
 		bCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		aAccess.setPosition(bCursor);
+		op.compute(aAccess.get(), bCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			bCursor.jumpFwd(stepSize);
 			aAccess.setPosition(bCursor);
 			op.compute(aAccess.get(), bCursor.get());
-			bCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -340,19 +350,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.cursor();
 		final Cursor<I2> bCursor = b.cursor();
 		final Cursor<O> cCursor = c.cursor();
+
 		aCursor.jumpFwd(startIndex + 1);
 		bCursor.jumpFwd(startIndex + 1);
 		cCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			op.compute(aCursor.get(), bCursor.get(), cCursor.get());
+		op.compute(aCursor.get(), bCursor.get(), cCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(stepSize);
 			bCursor.jumpFwd(stepSize);
 			cCursor.jumpFwd(stepSize);
-			ctr++;
+			op.compute(aCursor.get(), bCursor.get(), cCursor.get());
 		}
 	}
 
@@ -361,18 +373,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.localizingCursor();
 		final Cursor<I2> bCursor = b.cursor();
 		final RandomAccess<O> cAccess = c.randomAccess();
+
 		aCursor.jumpFwd(startIndex + 1);
 		bCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			cAccess.setPosition(aCursor);
-			op.compute(aCursor.get(), bCursor.get(), cAccess.get());
+		cAccess.setPosition(aCursor);
+		op.compute(aCursor.get(), bCursor.get(), cAccess.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(stepSize);
 			bCursor.jumpFwd(stepSize);
-			ctr++;
+			cAccess.setPosition(aCursor);
+			op.compute(aCursor.get(), bCursor.get(), cAccess.get());
 		}
 	}
 
@@ -381,18 +396,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.localizingCursor();
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final Cursor<O> cCursor = c.cursor();
+
 		aCursor.jumpFwd(startIndex + 1);
 		cCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			bAccess.setPosition(aCursor);
-			op.compute(aCursor.get(), bAccess.get(), cCursor.get());
+		bAccess.setPosition(aCursor);
+		op.compute(aCursor.get(), bAccess.get(), cCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(stepSize);
 			cCursor.jumpFwd(stepSize);
-			ctr++;
+			bAccess.setPosition(aCursor);
+			op.compute(aCursor.get(), bAccess.get(), cCursor.get());
 		}
 	}
 
@@ -401,18 +419,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final RandomAccess<I1> aAccess = a.randomAccess();
 		final Cursor<I2> bCursor = b.localizingCursor();
 		final Cursor<O> cCursor = c.cursor();
+
 		bCursor.jumpFwd(startIndex + 1);
 		cCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			aAccess.setPosition(bCursor);
-			op.compute(aAccess.get(), bCursor.get(), cCursor.get());
+		aAccess.setPosition(bCursor);
+		op.compute(aAccess.get(), bCursor.get(), cCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			bCursor.jumpFwd(stepSize);
 			cCursor.jumpFwd(stepSize);
-			ctr++;
+			aAccess.setPosition(bCursor);
+			op.compute(aAccess.get(), bCursor.get(), cCursor.get());
 		}
 	}
 
@@ -421,17 +442,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.localizingCursor();
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final RandomAccess<O> cAccess = c.randomAccess();
+
 		aCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		bAccess.setPosition(aCursor);
+		cAccess.setPosition(aCursor);
+		op.compute(aCursor.get(), bAccess.get(), cAccess.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			aCursor.jumpFwd(stepSize);
 			bAccess.setPosition(aCursor);
 			cAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bAccess.get(), cAccess.get());
-			aCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -440,17 +465,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final RandomAccess<I1> aAccess = a.randomAccess();
 		final Cursor<I2> bCursor = b.localizingCursor();
 		final RandomAccess<O> cAccess = c.randomAccess();
+
 		bCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		aAccess.setPosition(bCursor);
+		cAccess.setPosition(bCursor);
+		op.compute(aAccess.get(), bCursor.get(), cAccess.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			bCursor.jumpFwd(stepSize);
 			aAccess.setPosition(bCursor);
 			cAccess.setPosition(bCursor);
 			op.compute(aAccess.get(), bCursor.get(), cAccess.get());
-			bCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -459,17 +488,21 @@ public class Maps {
 		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
 		final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final RandomAccess<I1> aAccess = a.randomAccess();
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final Cursor<O> cCursor = c.localizingCursor();
+
 		cCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		aAccess.setPosition(cCursor);
+		bAccess.setPosition(cCursor);
+		op.compute(aAccess.get(), bAccess.get(), cCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			cCursor.jumpFwd(stepSize);
 			aAccess.setPosition(cCursor);
 			bAccess.setPosition(cCursor);
 			op.compute(aAccess.get(), bAccess.get(), cCursor.get());
-			cCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -486,13 +519,15 @@ public class Maps {
 		final UnaryInplaceOp<I, O> op, final int startIndex, final int stepSize,
 		final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<O> argCursor = arg.cursor();
+
 		argCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			op.mutate(argCursor.get());
+		op.mutate(argCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			argCursor.jumpFwd(stepSize);
-			ctr++;
+			op.mutate(argCursor.get());
 		}
 	}
 
@@ -538,16 +573,18 @@ public class Maps {
 		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<I> inCursor = in.cursor();
+
 		argCursor.jumpFwd(startIndex + 1);
 		inCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			op.mutate1(argCursor.get(), inCursor.get());
+		op.mutate1(argCursor.get(), inCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			argCursor.jumpFwd(stepSize);
 			inCursor.jumpFwd(stepSize);
-			ctr++;
+			op.mutate1(argCursor.get(), inCursor.get());
 		}
 	}
 
@@ -555,15 +592,18 @@ public class Maps {
 		final RandomAccessibleInterval<I> in, final BinaryInplace1Op<A, I, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<A> argCursor = arg.localizingCursor();
 		final RandomAccess<I> inAccess = in.randomAccess();
+
 		argCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		inAccess.setPosition(argCursor);
+		op.mutate1(argCursor.get(), inAccess.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			argCursor.jumpFwd(stepSize);
 			inAccess.setPosition(argCursor);
 			op.mutate1(argCursor.get(), inAccess.get());
-			argCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -571,15 +611,18 @@ public class Maps {
 		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final RandomAccess<A> argAccess = arg.randomAccess();
 		final Cursor<I> inCursor = in.localizingCursor();
+
 		inCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
+		argAccess.setPosition(inCursor);
+		op.mutate1(argAccess.get(), inCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
+			inCursor.jumpFwd(stepSize);
 			argAccess.setPosition(inCursor);
 			op.mutate1(argAccess.get(), inCursor.get());
-			inCursor.jumpFwd(stepSize);
-			ctr++;
 		}
 	}
 
@@ -597,17 +640,18 @@ public class Maps {
 		final IterableInterval<A> in, final BinaryInplaceOp<A, A> op,
 		final int startIndex, final int stepSize, final int numSteps)
 	{
+		if (numSteps <= 0) return;
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<A> inCursor = in.cursor();
+
 		argCursor.jumpFwd(startIndex + 1);
 		inCursor.jumpFwd(startIndex + 1);
-		int ctr = 0;
-		while (ctr < numSteps) {
-			op.mutate2(argCursor.get(), inCursor.get());
+		op.mutate2(argCursor.get(), inCursor.get());
+
+		for (int ctr = 1; ctr < numSteps; ctr++) {
 			argCursor.jumpFwd(stepSize);
 			inCursor.jumpFwd(stepSize);
-			ctr++;
+			op.mutate2(argCursor.get(), inCursor.get());
 		}
 	}
-
 }

--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -44,7 +44,7 @@ import net.imglib2.util.Intervals;
 
 /**
  * Utility class for {@link MapOp}s.
- * 
+ *
  * @author Leon Yang
  */
 public class Maps {
@@ -83,23 +83,23 @@ public class Maps {
 	public static <I1, I2, O> boolean compatible(final IterableInterval<I1> a,
 		final IterableInterval<I2> b, final RandomAccessibleInterval<O> c)
 	{
-		return a.iterationOrder().equals(b.iterationOrder()) && Intervals
-			.contains(c, a);
+		return a.iterationOrder().equals(b.iterationOrder()) && Intervals.contains(
+			c, a);
 	}
 
 	public static <I1, I2, O> boolean compatible(final IterableInterval<I1> a,
 		final RandomAccessibleInterval<I2> b, final IterableInterval<O> c)
 	{
-		return a.iterationOrder().equals(c.iterationOrder()) && Intervals
-			.contains(b, a);
+		return a.iterationOrder().equals(c.iterationOrder()) && Intervals.contains(
+			b, a);
 	}
 
 	public static <I1, I2, O> boolean compatible(
 		final RandomAccessibleInterval<I1> a, final IterableInterval<I2> b,
 		final IterableInterval<O> c)
 	{
-		return b.iterationOrder().equals(c.iterationOrder()) && Intervals
-			.contains(a, b);
+		return b.iterationOrder().equals(c.iterationOrder()) && Intervals.contains(
+			a, b);
 	}
 
 	public static <I1, I2, O> boolean compatible(final IterableInterval<I1> a,
@@ -127,7 +127,7 @@ public class Maps {
 	public static <O> void map(final Iterable<O> a,
 		final NullaryComputerOp<O> op)
 	{
-		for (O e : a)
+		for (final O e : a)
 			op.compute(e);
 	}
 

--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -138,11 +138,8 @@ public class Maps {
 		if (numSteps <= 0) return;
 		final Cursor<O> aCursor = a.cursor();
 
-		aCursor.jumpFwd(startIndex + 1);
-		op.compute(aCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			aCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			op.compute(aCursor.get());
 		}
 	}
@@ -294,13 +291,10 @@ public class Maps {
 		final Cursor<I> aCursor = a.cursor();
 		final Cursor<O> bCursor = b.cursor();
 
-		aCursor.jumpFwd(startIndex + 1);
-		bCursor.jumpFwd(startIndex + 1);
-		op.compute(aCursor.get(), bCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
-			bCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			aCursor.jumpFwd(m);
+			bCursor.jumpFwd(m);
 			op.compute(aCursor.get(), bCursor.get());
 		}
 	}
@@ -313,12 +307,8 @@ public class Maps {
 		final Cursor<I> aCursor = a.localizingCursor();
 		final RandomAccess<O> bAccess = b.randomAccess();
 
-		aCursor.jumpFwd(startIndex + 1);
-		bAccess.setPosition(aCursor);
-		op.compute(aCursor.get(), bAccess.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			aCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			bAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bAccess.get());
 		}
@@ -332,12 +322,8 @@ public class Maps {
 		final RandomAccess<I> aAccess = a.randomAccess();
 		final Cursor<O> bCursor = b.localizingCursor();
 
-		bCursor.jumpFwd(startIndex + 1);
-		aAccess.setPosition(bCursor);
-		op.compute(aAccess.get(), bCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			bCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			bCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			aAccess.setPosition(bCursor);
 			op.compute(aAccess.get(), bCursor.get());
 		}
@@ -355,15 +341,11 @@ public class Maps {
 		final Cursor<I2> bCursor = b.cursor();
 		final Cursor<O> cCursor = c.cursor();
 
-		aCursor.jumpFwd(startIndex + 1);
-		bCursor.jumpFwd(startIndex + 1);
-		cCursor.jumpFwd(startIndex + 1);
-		op.compute(aCursor.get(), bCursor.get(), cCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
-			bCursor.jumpFwd(stepSize);
-			cCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			aCursor.jumpFwd(m);
+			bCursor.jumpFwd(m);
+			cCursor.jumpFwd(m);
 			op.compute(aCursor.get(), bCursor.get(), cCursor.get());
 		}
 	}
@@ -378,14 +360,10 @@ public class Maps {
 		final Cursor<I2> bCursor = b.cursor();
 		final RandomAccess<O> cAccess = c.randomAccess();
 
-		aCursor.jumpFwd(startIndex + 1);
-		bCursor.jumpFwd(startIndex + 1);
-		cAccess.setPosition(aCursor);
-		op.compute(aCursor.get(), bCursor.get(), cAccess.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
-			bCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			aCursor.jumpFwd(m);
+			bCursor.jumpFwd(m);
 			cAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bCursor.get(), cAccess.get());
 		}
@@ -401,14 +379,10 @@ public class Maps {
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final Cursor<O> cCursor = c.cursor();
 
-		aCursor.jumpFwd(startIndex + 1);
-		cCursor.jumpFwd(startIndex + 1);
-		bAccess.setPosition(aCursor);
-		op.compute(aCursor.get(), bAccess.get(), cCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
-			cCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			aCursor.jumpFwd(m);
+			cCursor.jumpFwd(m);
 			bAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bAccess.get(), cCursor.get());
 		}
@@ -424,14 +398,10 @@ public class Maps {
 		final Cursor<I2> bCursor = b.localizingCursor();
 		final Cursor<O> cCursor = c.cursor();
 
-		bCursor.jumpFwd(startIndex + 1);
-		cCursor.jumpFwd(startIndex + 1);
-		aAccess.setPosition(bCursor);
-		op.compute(aAccess.get(), bCursor.get(), cCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			bCursor.jumpFwd(stepSize);
-			cCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			bCursor.jumpFwd(m);
+			cCursor.jumpFwd(m);
 			aAccess.setPosition(bCursor);
 			op.compute(aAccess.get(), bCursor.get(), cCursor.get());
 		}
@@ -447,13 +417,8 @@ public class Maps {
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final RandomAccess<O> cAccess = c.randomAccess();
 
-		aCursor.jumpFwd(startIndex + 1);
-		bAccess.setPosition(aCursor);
-		cAccess.setPosition(aCursor);
-		op.compute(aCursor.get(), bAccess.get(), cAccess.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			aCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			aCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			bAccess.setPosition(aCursor);
 			cAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bAccess.get(), cAccess.get());
@@ -470,13 +435,8 @@ public class Maps {
 		final Cursor<I2> bCursor = b.localizingCursor();
 		final RandomAccess<O> cAccess = c.randomAccess();
 
-		bCursor.jumpFwd(startIndex + 1);
-		aAccess.setPosition(bCursor);
-		cAccess.setPosition(bCursor);
-		op.compute(aAccess.get(), bCursor.get(), cAccess.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			bCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			bCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			aAccess.setPosition(bCursor);
 			cAccess.setPosition(bCursor);
 			op.compute(aAccess.get(), bCursor.get(), cAccess.get());
@@ -493,13 +453,8 @@ public class Maps {
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final Cursor<O> cCursor = c.localizingCursor();
 
-		cCursor.jumpFwd(startIndex + 1);
-		aAccess.setPosition(cCursor);
-		bAccess.setPosition(cCursor);
-		op.compute(aAccess.get(), bAccess.get(), cCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			cCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			cCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			aAccess.setPosition(cCursor);
 			bAccess.setPosition(cCursor);
 			op.compute(aAccess.get(), bAccess.get(), cCursor.get());
@@ -522,11 +477,8 @@ public class Maps {
 		if (numSteps <= 0) return;
 		final Cursor<O> argCursor = arg.cursor();
 
-		argCursor.jumpFwd(startIndex + 1);
-		op.mutate(argCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			argCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			argCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			op.mutate(argCursor.get());
 		}
 	}
@@ -577,13 +529,10 @@ public class Maps {
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<I> inCursor = in.cursor();
 
-		argCursor.jumpFwd(startIndex + 1);
-		inCursor.jumpFwd(startIndex + 1);
-		op.mutate1(argCursor.get(), inCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			argCursor.jumpFwd(stepSize);
-			inCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			argCursor.jumpFwd(m);
+			inCursor.jumpFwd(m);
 			op.mutate1(argCursor.get(), inCursor.get());
 		}
 	}
@@ -596,12 +545,8 @@ public class Maps {
 		final Cursor<A> argCursor = arg.localizingCursor();
 		final RandomAccess<I> inAccess = in.randomAccess();
 
-		argCursor.jumpFwd(startIndex + 1);
-		inAccess.setPosition(argCursor);
-		op.mutate1(argCursor.get(), inAccess.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			argCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			argCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			inAccess.setPosition(argCursor);
 			op.mutate1(argCursor.get(), inAccess.get());
 		}
@@ -615,12 +560,8 @@ public class Maps {
 		final RandomAccess<A> argAccess = arg.randomAccess();
 		final Cursor<I> inCursor = in.localizingCursor();
 
-		inCursor.jumpFwd(startIndex + 1);
-		argAccess.setPosition(inCursor);
-		op.mutate1(argAccess.get(), inCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			inCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			inCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			argAccess.setPosition(inCursor);
 			op.mutate1(argAccess.get(), inCursor.get());
 		}
@@ -644,13 +585,10 @@ public class Maps {
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<A> inCursor = in.cursor();
 
-		argCursor.jumpFwd(startIndex + 1);
-		inCursor.jumpFwd(startIndex + 1);
-		op.mutate2(argCursor.get(), inCursor.get());
-
-		for (int ctr = 1; ctr < numSteps; ctr++) {
-			argCursor.jumpFwd(stepSize);
-			inCursor.jumpFwd(stepSize);
+		for (int ctr = 0; ctr < numSteps; ctr++) {
+			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+			argCursor.jumpFwd(m);
+			inCursor.jumpFwd(m);
 			op.mutate2(argCursor.get(), inCursor.get());
 		}
 	}

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -47,6 +47,8 @@ import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -142,20 +144,34 @@ public abstract class AbstractOpTest {
 		return ArrayImgs.unsignedBytes(array, dims);
 	}
 
-	public ArrayImg<FloatType, FloatArray> generateFloatArrayTestImg(
-		final boolean fill, final long... dims)
+	public CellImg<ByteType, ?> generateByteTestCellImg(final boolean fill,
+		final long... dims)
 	{
-		final float[] array = new float[(int) Intervals.numElements(
-			new FinalInterval(dims))];
+		final CellImg<ByteType, ?> img = new CellImgFactory<ByteType>().create(dims,
+			new ByteType());
 
 		if (fill) {
-			seed = 17;
-			for (int i = 0; i < array.length; i++) {
-				array[i] = (float) pseudoRandom() / (float) Integer.MAX_VALUE;
-			}
+			final Cursor<ByteType> c = img.cursor();
+			while (c.hasNext())
+				c.next().set((byte) pseudoRandom());
 		}
 
-		return ArrayImgs.floats(array, dims);
+		return img;
+	}
+
+	public CellImg<ByteType, ?> generateByteTestCellImg(final boolean fill,
+		final int[] cellDims, final long... dims)
+	{
+		final CellImg<ByteType, ?> img = new CellImgFactory<ByteType>(cellDims)
+			.create(dims, new ByteType());
+
+		if (fill) {
+			final Cursor<ByteType> c = img.cursor();
+			while (c.hasNext())
+				c.next().set((byte) pseudoRandom());
+		}
+
+		return img;
 	}
 
 	public Img<UnsignedByteType>
@@ -172,6 +188,22 @@ public abstract class AbstractOpTest {
 		}
 
 		return img;
+	}
+
+	public ArrayImg<FloatType, FloatArray> generateFloatArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		final float[] array = new float[(int) Intervals.numElements(
+			new FinalInterval(dims))];
+
+		if (fill) {
+			seed = 17;
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (float) pseudoRandom() / (float) Integer.MAX_VALUE;
+			}
+		}
+
+		return ArrayImgs.floats(array, dims);
 	}
 
 	public Img<FloatType> openFloatImg(final String resourcePath) {

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -64,7 +64,7 @@ import org.scijava.plugin.Parameter;
  * <i>All</i> {@link Op} unit tests need to have an {@link OpService} instance.
  * Following the DRY principle, we should implement it only once. Here.
  * </p>
- * 
+ *
  * @author Johannes Schindelin
  * @author Curtis Rueden
  */
@@ -110,11 +110,11 @@ public abstract class AbstractOpTest {
 		return seed = 3170425 * seed + 132102;
 	}
 
-	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(final boolean fill,
-		final long... dims)
+	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(
+		final boolean fill, final long... dims)
 	{
-		final byte[] array =
-			new byte[(int) Intervals.numElements(new FinalInterval(dims))];
+		final byte[] array = new byte[(int) Intervals.numElements(new FinalInterval(
+			dims))];
 
 		if (fill) {
 			seed = 17;
@@ -126,11 +126,11 @@ public abstract class AbstractOpTest {
 		return ArrayImgs.bytes(array, dims);
 	}
 
-	public ArrayImg<UnsignedByteType, ByteArray> generateUnsignedByteArrayTestImg(final boolean fill,
-		final long... dims)
+	public ArrayImg<UnsignedByteType, ByteArray> generateUnsignedByteArrayTestImg(
+		final boolean fill, final long... dims)
 	{
-		final byte[] array =
-			new byte[(int) Intervals.numElements(new FinalInterval(dims))];
+		final byte[] array = new byte[(int) Intervals.numElements(new FinalInterval(
+			dims))];
 
 		if (fill) {
 			seed = 17;
@@ -145,8 +145,8 @@ public abstract class AbstractOpTest {
 	public ArrayImg<FloatType, FloatArray> generateFloatArrayTestImg(
 		final boolean fill, final long... dims)
 	{
-		final float[] array =
-			new float[(int) Intervals.numElements(new FinalInterval(dims))];
+		final float[] array = new float[(int) Intervals.numElements(
+			new FinalInterval(dims))];
 
 		if (fill) {
 			seed = 17;
@@ -160,12 +160,12 @@ public abstract class AbstractOpTest {
 
 	public Img<UnsignedByteType>
 		generateRandomlyFilledUnsignedByteTestImgWithSeed(final long[] dims,
-			long tempSeed)
+			final long tempSeed)
 	{
 
-		Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(dims);
+		final Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(dims);
 
-		Random rand = new Random(tempSeed);
+		final Random rand = new Random(tempSeed);
 		final Cursor<UnsignedByteType> cursor = img.cursor();
 		while (cursor.hasNext()) {
 			cursor.next().set(rand.nextInt((int) img.firstElement().getMaxValue()));
@@ -185,12 +185,13 @@ public abstract class AbstractOpTest {
 		return IO.openFloatImgs(url.getPath()).get(0).getImg();
 	}
 
-	public static Img<UnsignedByteType> openUnsignedByteType(final Class<?> c, 
-			final String resourcePath) {
+	public static Img<UnsignedByteType> openUnsignedByteType(final Class<?> c,
+		final String resourcePath)
+	{
 		final URL url = c.getResource(resourcePath);
 		return IO.openUnsignedByteImgs(url.getPath()).get(0).getImg();
 	}
-	
+
 	public <T> void assertIterationsEqual(final Iterable<T> expected,
 		final Iterable<T> actual)
 	{

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -132,7 +132,7 @@ public class MapTest extends AbstractOpTest {
 	}
 
 	@Test
-	public void testIIInplaceParallal() {
+	public void testIIInplaceParallel() {
 		final Img<ByteType> arg = generateByteArrayTestImg(true, 10, 10);
 		final Img<ByteType> argCopy = arg.copy();
 
@@ -165,6 +165,51 @@ public class MapTest extends AbstractOpTest {
 		ops.run(MapIterableToIterable.class, out, in, sub);
 
 		assertImgSubOneEquals(in, out);
+	}
+
+	// -- Test with CellImg --
+
+	@Test
+	public void testIICellImg() {
+		final Img<ByteType> in = generateByteTestCellImg(true, 40, 20);
+
+		final Op nullary = Computers.nullary(ops, Ops.Math.Zero.class,
+			ByteType.class);
+		ops.run(MapNullaryII.class, in, nullary);
+
+		for (final ByteType ps : in)
+			assertEquals(ps.get(), 0);
+	}
+
+	@Test
+	public void testIIAndIIInplaceParallelCellImg() {
+		final Img<ByteType> first = generateByteTestCellImg(true, 40, 20);
+		final Img<ByteType> firstCopy = first.copy();
+		final Img<ByteType> second = generateByteTestCellImg(false, 40, 20);
+		for (final ByteType px : second)
+			px.set((byte) 1);
+		final Img<ByteType> secondCopy = second.copy();
+
+		sub = Inplaces.binary(ops, Ops.Math.Subtract.class, ByteType.class);
+		final BinaryInplaceOp<? super Img<ByteType>, Img<ByteType>> map = Inplaces
+			.binary(ops, MapIIAndIIInplaceParallel.class, firstCopy, second, sub);
+		map.run(firstCopy, second, firstCopy);
+		map.run(first, secondCopy, secondCopy);
+
+		assertImgSubEquals(first, second, firstCopy);
+		assertImgSubEquals(first, second, secondCopy);
+	}
+
+	@Test
+	public void testIIInplaceParallelCellImg() {
+		final Img<ByteType> arg = generateByteTestCellImg(true, 40, 20);
+		final Img<ByteType> argCopy = arg.copy();
+
+		sub = Inplaces.unary(ops, Ops.Math.Subtract.class, ByteType.class,
+			new ByteType((byte) 1));
+		ops.run(MapIIInplaceParallel.class, argCopy, sub);
+
+		assertImgSubOneEquals(arg, argCopy);
 	}
 
 	// -- helper methods --

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -63,10 +63,11 @@ public class MapTest extends AbstractOpTest {
 	public void testIterable() {
 		final Img<ByteType> in = generateByteArrayTestImg(true, 10, 10);
 
-		Op nullary = Computers.nullary(ops, Ops.Math.Zero.class, ByteType.class);
+		final Op nullary = Computers.nullary(ops, Ops.Math.Zero.class,
+			ByteType.class);
 		ops.run(MapNullaryIterable.class, in, nullary);
 
-		for (ByteType ps : in)
+		for (final ByteType ps : in)
 			assertEquals(ps.get(), 0);
 	}
 
@@ -74,10 +75,11 @@ public class MapTest extends AbstractOpTest {
 	public void testII() {
 		final Img<ByteType> in = generateByteArrayTestImg(true, 10, 10);
 
-		Op nullary = Computers.nullary(ops, Ops.Math.Zero.class, ByteType.class);
+		final Op nullary = Computers.nullary(ops, Ops.Math.Zero.class,
+			ByteType.class);
 		ops.run(MapNullaryII.class, in, nullary);
 
-		for (ByteType ps : in)
+		for (final ByteType ps : in)
 			assertEquals(ps.get(), 0);
 	}
 
@@ -86,7 +88,7 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> first = generateByteArrayTestImg(true, 10, 10);
 		final Img<ByteType> firstCopy = first.copy();
 		final Img<ByteType> second = generateByteArrayTestImg(false, 10, 10);
-		for (ByteType px : second)
+		for (final ByteType px : second)
 			px.set((byte) 1);
 		final Img<ByteType> secondCopy = second.copy();
 		final Img<ByteType> secondDiffDims = generateByteArrayTestImg(false, 10, 10,
@@ -111,7 +113,7 @@ public class MapTest extends AbstractOpTest {
 		final Img<ByteType> first = generateByteArrayTestImg(true, 10, 10);
 		final Img<ByteType> firstCopy = first.copy();
 		final Img<ByteType> second = generateByteArrayTestImg(false, 10, 10);
-		for (ByteType px : second)
+		for (final ByteType px : second)
 			px.set((byte) 1);
 		final Img<ByteType> secondCopy = second.copy();
 		final Img<ByteType> secondDiffDims = generateByteArrayTestImg(false, 10, 10,
@@ -214,8 +216,8 @@ public class MapTest extends AbstractOpTest {
 
 	// -- helper methods --
 
-	private static void assertImgSubEquals(Img<ByteType> in1, Img<ByteType> in2,
-		Img<ByteType> out)
+	private static void assertImgSubEquals(final Img<ByteType> in1,
+		final Img<ByteType> in2, final Img<ByteType> out)
 	{
 		final Cursor<ByteType> in1Cursor = in1.cursor();
 		final Cursor<ByteType> in2Cursor = in2.cursor();
@@ -227,8 +229,8 @@ public class MapTest extends AbstractOpTest {
 		}
 	}
 
-	private static void assertImgSubOneEquals(Img<ByteType> in,
-		Img<ByteType> out)
+	private static void assertImgSubOneEquals(final Img<ByteType> in,
+		final Img<ByteType> out)
 	{
 		final Cursor<ByteType> in1Cursor = in.cursor();
 		final Cursor<ByteType> outCursor = out.cursor();

--- a/src/test/java/net/imagej/ops/map/MapTest.java
+++ b/src/test/java/net/imagej/ops/map/MapTest.java
@@ -94,7 +94,7 @@ public class MapTest extends AbstractOpTest {
 
 		sub = Inplaces.binary(ops, Ops.Math.Subtract.class, ByteType.class);
 		final BinaryInplaceOp<? super Img<ByteType>, Img<ByteType>> map = Inplaces
-			.binary(ops, MapIIAndIIInplaceParallel.class, firstCopy, second, sub);
+			.binary(ops, MapIIAndIIInplace.class, firstCopy, second, sub);
 		map.run(firstCopy, second, firstCopy);
 		map.run(first, secondCopy, secondCopy);
 
@@ -128,7 +128,7 @@ public class MapTest extends AbstractOpTest {
 
 		// Expect exception when in2 has different dimensions
 		thrown.expect(IllegalArgumentException.class);
-		ops.op(MapIIAndIIInplace.class, first, secondDiffDims, sub);
+		ops.op(MapIIAndIIInplaceParallel.class, first, secondDiffDims, sub);
 	}
 
 	@Test

--- a/src/test/templates/net/imagej/ops/convert/ConvertImagesTest.vm
+++ b/src/test/templates/net/imagej/ops/convert/ConvertImagesTest.vm
@@ -32,11 +32,15 @@ package net.imagej.ops.convert;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Random;
+
 import net.imagej.ops.AbstractOpTest;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.type.numeric.ComplexType;
+
 #set ($imports = [])
 #foreach ($op in $ops)
 #set($result = $imports.add($op.type))
@@ -52,6 +56,7 @@ Credit to Martin Gamulin for the idea: http://stackoverflow.com/a/7672699
 import $import;
 #end
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -68,6 +73,19 @@ public class ConvertImagesTest extends AbstractOpTest {
 		-6.4, 0.0, 56.1, 34.7, //
 		108.0, 1.4, 0.7, 0.0 //
 	};
+
+	private static Img<DoubleType> cellImg;
+
+	@BeforeClass
+	public static void setup() {
+		cellImg = new CellImgFactory<DoubleType>().create(new long[] { 10, 42 }, new DoubleType());
+		final int seed = 12;
+		final Random rand = new Random(seed);
+		final Cursor<DoubleType> c = cellImg.cursor();
+		while (c.hasNext())
+			c.next().set(rand.nextDouble());
+	}
+
 #foreach ($op in $ops)
 #set ($opType = $op.name)
 #set ($dot = $op.type.lastIndexOf(".") + 1)
@@ -92,5 +110,23 @@ public class ConvertImagesTest extends AbstractOpTest {
 		}
 	}
 #end
+
+## Only need one test with CellImg since all conversions call the same Map Op
+	@Test
+	public <C extends ComplexType<C>> void testCellImgUint32() {
+		@SuppressWarnings("unchecked")
+		final Img<UnsignedIntType> out = (Img<UnsignedIntType>) ops.run(ConvertImages.Uint32.class,
+			cellImg);
+
+		final Cursor<DoubleType> ci = cellImg.cursor();
+		final Cursor<UnsignedIntType> co = out.cursor();
+
+		while (ci.hasNext()) {
+			final DoubleType inEl = ci.next();
+			final UnsignedIntType actual = co.next();
+			final UnsignedIntType expected = ops.convert().uint32(inEl);
+			assertEquals("Value mismatch: " + inEl, expected, actual);
+		}
+	}
 
 }

--- a/src/test/templates/net/imagej/ops/map/MapBinaryComputersTest.vm
+++ b/src/test/templates/net/imagej/ops/map/MapBinaryComputersTest.vm
@@ -67,6 +67,9 @@ public class MapBinaryComputersTest extends AbstractOpTest {
 	private Img<ByteType> in1;
 	private Img<ByteType> in2;
 	private Img<ByteType> out;
+	private Img<ByteType> cellIn1;
+	private Img<ByteType> cellIn2;
+	private Img<ByteType> cellOut;
 	private Op add;
 
 	@Before
@@ -76,6 +79,9 @@ public class MapBinaryComputersTest extends AbstractOpTest {
 		for (ByteType px : in2)
 			px.set((byte) 1);
 		out = generateByteArrayTestImg(false, 10, 10);
+		cellIn1 = generateByteTestCellImg(true, 20, 10);
+		cellIn2 = generateByteTestCellImg(true, 20, 10);
+		cellOut = generateByteTestCellImg(false, 20, 10);
 		add = Computers.binary(ops, Ops.Math.Add.class, ByteType.class,
 			ByteType.class, ByteType.class);
 	}
@@ -95,6 +101,23 @@ public class MapBinaryComputersTest extends AbstractOpTest {
 	}
 
 #end
+#end
+#set ($count = $count - 1)
+#end
+#end
+#end
+#set ($count = 7)
+#foreach ($in1Type in $types)
+#foreach ($in2Type in $types)
+#foreach ($outType in $types)
+#if ($count > 0)
+#set ($className = "${in1Type}And${in2Type}To${outType}Parallel")
+	@Test
+	public void test${className}CellImg() {
+		ops.run(${className}.class, cellOut, cellIn1, cellIn2, add);
+		assertImgAddEquals(cellIn1, cellIn2, cellOut);
+	}
+
 #end
 #set ($count = $count - 1)
 #end

--- a/src/test/templates/net/imagej/ops/map/MapBinaryInplace1sTest.vm
+++ b/src/test/templates/net/imagej/ops/map/MapBinaryInplace1sTest.vm
@@ -58,6 +58,8 @@ public class MapBinaryInplace1sTest extends AbstractOpTest {
 	private Img<ByteType> in1;
 	private Img<ByteType> in2;
 	private Op add;
+	private Img<ByteType> cellIn1;
+	private Img<ByteType> cellIn2;
 
 	@Before
 	public void initImg() {
@@ -65,6 +67,8 @@ public class MapBinaryInplace1sTest extends AbstractOpTest {
 		in2 = generateByteArrayTestImg(false, 10, 10);
 		for (ByteType px : in2)
 			px.set((byte) 1);
+		cellIn1 = generateByteTestCellImg(true, 20, 10);
+		cellIn2 = generateByteTestCellImg(true, 20, 10);
 		add = Computers.binary(ops, Ops.Math.Add.class, ByteType.class,
 			ByteType.class, ByteType.class);
 	}
@@ -84,6 +88,22 @@ public class MapBinaryInplace1sTest extends AbstractOpTest {
 	}
 
 #end
+#end
+#set ($count = $count - 1)
+#end
+#end
+#set ($count = 3)
+#foreach ($argType in $types)
+#foreach ($inType in $types)
+#if ($count > 0)
+#set ($className = "${argType}And${inType}Parallel")
+	@Test
+	public void test${className}CellImg() {
+		final Img<ByteType> in1Copy = cellIn1.copy();
+		ops.run(${className}.class, in1Copy, cellIn2, add);
+		assertImgAddEquals(cellIn1, cellIn2, in1Copy);
+	}
+
 #end
 #set ($count = $count - 1)
 #end

--- a/src/test/templates/net/imagej/ops/map/MapUnaryComputersTest.vm
+++ b/src/test/templates/net/imagej/ops/map/MapUnaryComputersTest.vm
@@ -60,11 +60,15 @@ public class MapUnaryComputersTest extends AbstractOpTest {
 	private Img<ByteType> in;
 	private Img<ByteType> out;
 	private Op add;
+	private Img<ByteType> cellIn;
+	private Img<ByteType> cellOut;
 
 	@Before
 	public void initImg() {
 		in = generateByteArrayTestImg(true, 10, 10);
 		out = generateByteArrayTestImg(false, 10, 10);
+		cellIn = generateByteTestCellImg(true, 20, 10);
+		cellOut = generateByteTestCellImg(false, 20, 10);
 		add = Computers.unary(ops, Ops.Math.Add.class, ByteType.class, ByteType.class,
 			new ByteType((byte) 1));
 	}
@@ -83,6 +87,21 @@ public class MapUnaryComputersTest extends AbstractOpTest {
 	}
 
 #end
+#end
+#set ($count = $count - 1)
+#end
+#end
+#set ($count = 3)
+#foreach ($inType in $types)
+#foreach ($outType in $types)
+#if ($count > 0)
+#set ($className = "${inType}To${outType}Parallel")
+	@Test
+	public void test${className}CellImg() {
+		ops.run(${className}.class, cellOut, cellIn, add);
+		assertImgAddOneEquals(cellIn, cellOut);
+	}
+
 #end
 #set ($count = $count - 1)
 #end


### PR DESCRIPTION
Hello!

These changes fix a couple of issues I noticed with the Map Ops.
* Fixes `Maps` methods to always call the cursor first and then compute the result. This avoids bounds issues since different cursors have different bound behaviors ([see](https://github.com/imglib/imglib2/issues/170) for more details)
* Fixes `MapIIandIIInplace` `mutate2(...)` to mutate the second operand instead of the first

I've also added tests for these fixes. The tests are using `CellImg`s instead of `ArrayImg`s, which have different cursor bound behaviors. In general, the only affected methods were regarding parallel ops so I only added tests with `CellImgs` for those specific operations. Additionally, I added one test to `ConvertImagesTest` since I initially encountered this problem trying to convert between `CellImg` types. Only one test was needed since they all call the same `map(...)` method.

All commits compile with passing tests. Please feel free to let me know if you have any questions or if any changes are needed.

Thanks, 

Alison