### PR TITLE
UnaryComputerOp: make compute arguments final

### DIFF
--- a/src/main/java/net/imagej/ops/special/computer/UnaryComputerOp.java
+++ b/src/main/java/net/imagej/ops/special/computer/UnaryComputerOp.java
@@ -62,7 +62,7 @@ public interface UnaryComputerOp<I, O> extends UnaryOp<I, O>,
 	 * @param output Object where the computation's result will be stored, which
 	 * <em>must be non-null and a different object than {@code input}</em>
 	 */
-	void compute(I input, O output);
+	void compute(final I input, final O output);
 
 	// -- UnaryOp methods --
 


### PR DESCRIPTION
I wrote an `AbstractUnaryHybridCF` class that always returned zero as output because I could do something like this: 
```
@Override
public void compute(RandomAccessibleInterval<T> input, T output) {
	// ..
	output = value;
}
```
.. instead of this:
```
@Override
public void compute(final RandomAccessibleInterval<T> input, final T output) {
	// ..
	output.set(value);
}
```
The non-final version was automatically created based on `UnaryComputerOp` so I think this should be a solution? `mvn test` did not return any errors.