### PR TITLE
Fix Bug in CachedOpEnvironment Hash Code Calculation

### DIFF
--- a/src/main/java/net/imagej/ops/cached/CachedOpEnvironment.java
+++ b/src/main/java/net/imagej/ops/cached/CachedOpEnvironment.java
@@ -32,6 +32,7 @@ package net.imagej.ops.cached;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -290,13 +291,7 @@ public class CachedOpEnvironment extends CustomOpEnvironment {
 		private final int hash;
 
 		public Hash(final Object o1, final Object o2, final Object[] args) {
-			long h = o1.hashCode() ^ o2.getClass().getSimpleName().hashCode();
-
-			for (final Object o : args) {
-				h ^= Objects.hashCode(o);
-			}
-
-			hash = (int) h;
+			hash = Objects.hash(o1, o2.getClass(), Arrays.hashCode(args));
 		}
 
 		@Override

--- a/src/main/java/net/imagej/ops/cached/CachedOpEnvironment.java
+++ b/src/main/java/net/imagej/ops/cached/CachedOpEnvironment.java
@@ -33,6 +33,7 @@ package net.imagej.ops.cached;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 
 import net.imagej.ops.AbstractOp;
 import net.imagej.ops.CustomOpEnvironment;
@@ -292,7 +293,7 @@ public class CachedOpEnvironment extends CustomOpEnvironment {
 			long h = o1.hashCode() ^ o2.getClass().getSimpleName().hashCode();
 
 			for (final Object o : args) {
-				h ^= o.hashCode();
+				h ^= Objects.hashCode(o);
 			}
 
 			hash = (int) h;


### PR DESCRIPTION
I couldn't use `CachedOpEnvironment` to cache the gauss filter op, because it has an optional parameter, which I left unset. This resulted in a `NullPointerException` when calculating the hash for the optional parameter.