### PR TITLE
Improve invert ii

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>18.1.0</version>
+		<version>19.1.1</version>
 		<relativePath />
 	</parent>
 
@@ -194,8 +194,6 @@
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
-
-		<scijava-common.version>2.69.0</scijava-common.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -262,6 +262,30 @@ public class ImageNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	/** Executes the "invert" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O>
+		invert(final IterableInterval<O> out, final IterableInterval<I> in,
+			final I min)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
+			net.imagej.ops.Ops.Image.Invert.class, out, in, min);
+		return result;
+	}
+
+	/** Executes the "invert" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O>
+		invert(final IterableInterval<O> out, final IterableInterval<I> in,
+			final I min, final I max)
+	{
+		@SuppressWarnings("unchecked")
+		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
+			net.imagej.ops.Ops.Image.Invert.class, out, in, min, max);
+		return result;
+	}
+
 	// -- normalize --
 
 	@OpMethod(op = net.imagej.ops.image.normalize.NormalizeIIComputer.class)

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -39,6 +39,7 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.histogram.Histogram1d;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.Type;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
@@ -108,7 +109,7 @@ public class ImageNamespace extends AbstractNamespace {
 				.run(Ops.Image.DistanceTransform.class, in, out);
 		return result;
 	}
-	
+
 	/** Executes the "distancetransform" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.image.distancetransform.DefaultDistanceTransform.class,
 			net.imagej.ops.image.distancetransform.DistanceTransform2D.class,
@@ -252,7 +253,8 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- invert --
 
 	/** Executes the "invert" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
+	@OpMethod(ops = {net.imagej.ops.image.invert.InvertII.class,
+									net.imagej.ops.image.invert.InvertIIInteger.class})
 	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
 			final IterableInterval<O> out, final IterableInterval<I> in) {
 		@SuppressWarnings("unchecked")
@@ -262,27 +264,47 @@ public class ImageNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "invert" operation on the given arguments. */
+	/** Executes the "invert" operation on the given arguments, given a {@link RealType} minimum. */
 	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O>
-		invert(final IterableInterval<O> out, final IterableInterval<I> in,
-			final I min)
-	{
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
+			final IterableInterval<O> out, final IterableInterval<I> in, final RealType<I> min) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-			net.imagej.ops.Ops.Image.Invert.class, out, in, min);
+				net.imagej.ops.Ops.Image.Invert.class, out,
+				in);
 		return result;
 	}
 
-	/** Executes the "invert" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O>
-		invert(final IterableInterval<O> out, final IterableInterval<I> in,
-			final I min, final I max)
-	{
+	/** Executes the "invert" operation on the given arguments, given a {@link IntegerType} minimum. */
+	@OpMethod(op = net.imagej.ops.image.invert.InvertIIInteger.class)
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
+			final IterableInterval<O> out, final IterableInterval<I> in, final IntegerType min) {
 		@SuppressWarnings("unchecked")
 		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-			net.imagej.ops.Ops.Image.Invert.class, out, in, min, max);
+				net.imagej.ops.Ops.Image.Invert.class, out,
+				in);
+		return result;
+	}
+
+	/** Executes the "invert" operation on the given arguments, given a {@link RealType} minimum. */
+	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
+			final IterableInterval<O> out, final IterableInterval<I> in, final RealType<I> min, final RealType<I> max) {
+		@SuppressWarnings("unchecked")
+		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
+				net.imagej.ops.Ops.Image.Invert.class, out,
+				in);
+		return result;
+	}
+
+	/** Executes the "invert" operation on the given arguments, given a {@link IntegerType} minimum. */
+	@OpMethod(op =	net.imagej.ops.image.invert.InvertIIInteger.class)
+	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
+			final IterableInterval<O> out, final IterableInterval<I> in, final IntegerType min, final IntegerType max) {
+		@SuppressWarnings("unchecked")
+		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
+				net.imagej.ops.Ops.Image.Invert.class, out,
+				in);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/image/invert/InvertII.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertII.java
@@ -29,6 +29,8 @@
 
 package net.imagej.ops.image.invert;
 
+import java.math.BigDecimal;
+
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
@@ -76,7 +78,9 @@ public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
 
 					@Override
 					public void compute(I in, O out) {
-							out.setReal(minMax - in.getRealDouble());
+						if(in.getRealDouble() >= out.getMaxValue() || (minMax - in.getRealDouble()) <= out.getMinValue()) out.setReal(out.getMinValue());
+						else if(in.getRealDouble() <= out.getMinValue() || (minMax - in.getRealDouble()) >= out.getMaxValue()) out.setReal(out.getMaxValue());
+						else 	out.setReal(minMax - in.getRealDouble());
 					}
 				});
 		}

--- a/src/main/java/net/imagej/ops/image/invert/InvertII.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertII.java
@@ -48,6 +48,7 @@ import org.scijava.plugin.Plugin;
 
 /**
  * @author Martin Horn (University of Konstanz)
+ * @author Gabe Selzer
  */
 @Plugin(type = Ops.Image.Invert.class, priority = Priority.NORMAL_PRIORITY)
 public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
@@ -79,10 +80,10 @@ public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
 
 					@Override
 					public void compute(I in, O out) {
-						if (in.getRealDouble() >= out.getMaxValue() || (minMax - in
+						if ((minMax - in
 							.getRealDouble()) <= out.getMinValue()) out.setReal(out
 								.getMinValue());
-						else if (in.getRealDouble() <= out.getMinValue() || (minMax - in
+						else if ((minMax - in
 							.getRealDouble()) >= out.getMaxValue()) out.setReal(out
 								.getMaxValue());
 						else out.setReal(minMax - in.getRealDouble());

--- a/src/main/java/net/imagej/ops/image/invert/InvertIIInteger.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertIIInteger.java
@@ -87,8 +87,8 @@ public class InvertIIInteger<I extends IntegerType<I>, O extends IntegerType<O>>
 					public void compute(I in, O out) {
 						BigInteger inverted = minMax.subtract(in.getBigInteger());	
 						
-						if(in.getBigInteger().compareTo(maxValue(out).getBigInteger()) >= 0 || inverted.compareTo(minValue(out).getBigInteger()) <= 0) out.set(minValue(out));
-						else if(in.getBigInteger().compareTo(minValue(out).getBigInteger()) <= 0 || (inverted.compareTo(maxValue(out).getBigInteger())) >= 0) out.set(maxValue(out));
+						if( inverted.compareTo(minValue(out).getBigInteger()) <= 0) out.set(minValue(out));
+						else if(inverted.compareTo(maxValue(out).getBigInteger()) >= 0) out.set(maxValue(out));
 						else out.setBigInteger(inverted);
 						
 						

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -50,12 +50,26 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.img.cell.CellImg;
 import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
@@ -66,6 +80,7 @@ import org.junit.Before;
 import org.scijava.Context;
 import org.scijava.cache.CacheService;
 import org.scijava.plugin.Parameter;
+import org.scijava.util.MersenneTwisterFast;
 
 /**
  * Base class for {@link Op} unit testing.
@@ -115,12 +130,69 @@ public abstract class AbstractOpTest {
 
 	private int seed;
 
+
 	private int pseudoRandom() {
 		return seed = 3170425 * seed + 132102;
 	}
 
-	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(
+	public ArrayImg<BitType, LongArray> generateBitArrayTestImg(final boolean fill,
+		final long... dims)
+	{
+		ArrayImg<BitType, LongArray> bits = ArrayImgs.bits(dims);
+		
+		if (fill) {
+			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
+			for (BitType b : bits) {
+				b.set(betterRNG.nextBoolean());
+			}
+		}
+		return bits;
+	}
+	
+	public ArrayImg<Unsigned2BitType, LongArray> generateUnsigned2BitArrayTestImg(
 		final boolean fill, final long... dims)
+	{
+		ArrayImg<Unsigned2BitType, LongArray> bits = ArrayImgs.unsigned2Bits(dims);
+
+		if (fill) {
+			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
+			for (Unsigned2BitType b : bits) {
+				b.set(betterRNG.nextLong());
+			}
+		}
+		return bits;
+	}
+	
+	public ArrayImg<Unsigned4BitType, LongArray> generateUnsigned4BitArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		ArrayImg<Unsigned4BitType, LongArray> bits = ArrayImgs.unsigned4Bits(dims);
+
+		if (fill) {
+			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
+			for (Unsigned4BitType b : bits) {
+				b.set(betterRNG.nextLong());
+			}
+		}
+		return bits;
+	}
+	
+	public ArrayImg<Unsigned12BitType, LongArray> generateUnsigned12BitArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		ArrayImg<Unsigned12BitType, LongArray> bits = ArrayImgs.unsigned12Bits(dims);
+
+		if (fill) {
+			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
+			for (Unsigned12BitType b : bits) {
+				b.set(betterRNG.nextLong());
+			}
+		}
+		return bits;
+	}
+	
+	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(final boolean fill,
+		final long... dims)
 	{
 		final byte[] array = new byte[(int) Intervals.numElements(new FinalInterval(
 			dims))];
@@ -149,6 +221,32 @@ public abstract class AbstractOpTest {
 		}
 
 		return ArrayImgs.unsignedBytes(array, dims);
+	}
+	
+	public ArrayImg<IntType, IntArray> generateIntArrayTestImg(final boolean fill, final long... dims){
+		final int[] array = new int[(int) Intervals.numElements(new FinalInterval(dims))];
+		
+		if(fill) {
+			seed = 17;
+			for(int i = 0; i < array.length; i++){
+				array[i] = (int) pseudoRandom() / (int) Integer.MAX_VALUE;
+			}
+		}
+		
+		return ArrayImgs.ints(array, dims);
+	}
+	
+	public ArrayImg<UnsignedIntType, IntArray> generateUnsignedIntArrayTestImg(final boolean fill, final long... dims){
+		final int[] array = new int[(int) Intervals.numElements(new FinalInterval(dims))];
+		
+		if(fill) {
+			seed = 17;
+			for(int i = 0; i < array.length; i++){
+				array[i] = (int) pseudoRandom() / (int) Integer.MAX_VALUE;
+			}
+		}
+		
+		return ArrayImgs.unsignedInts(array, dims);
 	}
 
 	public CellImg<ByteType, ?> generateByteTestCellImg(final boolean fill,
@@ -179,6 +277,74 @@ public abstract class AbstractOpTest {
 		}
 
 		return img;
+	}
+	
+	public ArrayImg<DoubleType, DoubleArray> generateDoubleArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		final double[] array =
+			new double[(int) Intervals.numElements(new FinalInterval(dims))];
+
+		if (fill) {
+			seed = 17;
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (double) pseudoRandom() / (double) Integer.MAX_VALUE;
+			}
+		}
+
+		return ArrayImgs.doubles(array, dims);
+	}
+	
+	public ArrayImg<LongType, LongArray> generateLongArrayTestImg(final boolean fill, final long... dims){
+		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(dims))];
+		
+		if(fill) {
+			seed = 17;
+			for(int i = 0; i < array.length; i++){
+				array[i] =  (long) (pseudoRandom() /  Integer.MAX_VALUE);
+			}
+		}
+		
+		return ArrayImgs.longs(array, dims);
+	}
+	
+	public ArrayImg<UnsignedLongType, LongArray> generateUnsignedLongArrayTestImg(final boolean fill, final long... dims){
+		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(dims))];
+		
+		if(fill) {
+			seed = 17;
+			for(int i = 0; i < array.length; i++){
+				array[i] =  (long) (pseudoRandom() /  Integer.MAX_VALUE);
+			}
+		}
+		
+		return ArrayImgs.unsignedLongs(array, dims);
+	}
+	
+	public ArrayImg<ShortType, ShortArray> generateShortArrayTestImg(final boolean fill, final long... dims){
+		final short[] array = new short[(int) Intervals.numElements(new FinalInterval(dims))];
+		
+		if(fill) {
+			seed = 17;
+			for(int i = 0; i < array.length; i++){
+				array[i] =  (short) (pseudoRandom() /  Integer.MAX_VALUE);
+			}
+		}
+		
+		return ArrayImgs.shorts(array, dims);
+	}
+	
+	public ArrayImg<UnsignedShortType, ShortArray> generateUnsignedShortArrayTestImg(final boolean fill, final long... dims){
+		final short[] array = new short[(int) Intervals.numElements(new FinalInterval(dims))];
+		
+		if(fill) {
+			seed = 17;
+			for(int i = 0; i < array.length; i++){
+				array[i] =  (short) (pseudoRandom() /  Integer.MAX_VALUE);
+			}
+		}
+		
+		return ArrayImgs.unsignedShorts(array, dims);
 	}
 
 	public Img<UnsignedByteType>

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -397,7 +397,7 @@ public abstract class AbstractOpTest {
 		if (fill) {
 			seed = 17;
 			for (int i = 0; i < array.length; i++) {
-				array[i] = (long) (pseudoRandom() / Integer.MAX_VALUE);
+				array[i] = (long) (((pseudoRandom() / Integer.MAX_VALUE)) % (Math.pow(2, nbits))) ;
 			}
 		}
 

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -35,11 +35,13 @@ import static org.junit.Assert.assertTrue;
 
 import io.scif.img.IO;
 
+import java.math.BigInteger;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.stream.StreamSupport;
 
+import net.imagej.types.UnboundedIntegerType;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.IterableInterval;
@@ -57,12 +59,15 @@ import net.imglib2.img.basictypeaccess.array.LongArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.img.cell.CellImg;
 import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.img.list.ListImgFactory;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
 import net.imglib2.type.numeric.integer.Unsigned12BitType;
 import net.imglib2.type.numeric.integer.Unsigned2BitType;
 import net.imglib2.type.numeric.integer.Unsigned4BitType;
@@ -70,6 +75,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
@@ -130,16 +136,15 @@ public abstract class AbstractOpTest {
 
 	private int seed;
 
-
 	private int pseudoRandom() {
 		return seed = 3170425 * seed + 132102;
 	}
 
-	public ArrayImg<BitType, LongArray> generateBitArrayTestImg(final boolean fill,
-		final long... dims)
+	public ArrayImg<BitType, LongArray> generateBitArrayTestImg(
+		final boolean fill, final long... dims)
 	{
 		ArrayImg<BitType, LongArray> bits = ArrayImgs.bits(dims);
-		
+
 		if (fill) {
 			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
 			for (BitType b : bits) {
@@ -148,7 +153,7 @@ public abstract class AbstractOpTest {
 		}
 		return bits;
 	}
-	
+
 	public ArrayImg<Unsigned2BitType, LongArray> generateUnsigned2BitArrayTestImg(
 		final boolean fill, final long... dims)
 	{
@@ -162,7 +167,7 @@ public abstract class AbstractOpTest {
 		}
 		return bits;
 	}
-	
+
 	public ArrayImg<Unsigned4BitType, LongArray> generateUnsigned4BitArrayTestImg(
 		final boolean fill, final long... dims)
 	{
@@ -176,11 +181,12 @@ public abstract class AbstractOpTest {
 		}
 		return bits;
 	}
-	
-	public ArrayImg<Unsigned12BitType, LongArray> generateUnsigned12BitArrayTestImg(
-		final boolean fill, final long... dims)
+
+	public ArrayImg<Unsigned12BitType, LongArray>
+		generateUnsigned12BitArrayTestImg(final boolean fill, final long... dims)
 	{
-		ArrayImg<Unsigned12BitType, LongArray> bits = ArrayImgs.unsigned12Bits(dims);
+		ArrayImg<Unsigned12BitType, LongArray> bits = ArrayImgs.unsigned12Bits(
+			dims);
 
 		if (fill) {
 			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
@@ -190,9 +196,25 @@ public abstract class AbstractOpTest {
 		}
 		return bits;
 	}
-	
-	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(final boolean fill,
-		final long... dims)
+
+	public ArrayImg<Unsigned128BitType, LongArray>
+		generateUnsigned128BitArrayTestImg(final boolean fill, final long... dims)
+	{
+		ArrayImg<Unsigned128BitType, LongArray> bits = ArrayImgs.unsigned128Bits(
+			dims);
+
+		if (fill) {
+			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
+			for (Unsigned128BitType b : bits) {
+				BigInteger big = BigInteger.valueOf(betterRNG.nextLong());
+				b.set(big);
+			}
+		}
+		return bits;
+	}
+
+	public ArrayImg<ByteType, ByteArray> generateByteArrayTestImg(
+		final boolean fill, final long... dims)
 	{
 		final byte[] array = new byte[(int) Intervals.numElements(new FinalInterval(
 			dims))];
@@ -222,30 +244,36 @@ public abstract class AbstractOpTest {
 
 		return ArrayImgs.unsignedBytes(array, dims);
 	}
-	
-	public ArrayImg<IntType, IntArray> generateIntArrayTestImg(final boolean fill, final long... dims){
-		final int[] array = new int[(int) Intervals.numElements(new FinalInterval(dims))];
-		
-		if(fill) {
+
+	public ArrayImg<IntType, IntArray> generateIntArrayTestImg(final boolean fill,
+		final long... dims)
+	{
+		final int[] array = new int[(int) Intervals.numElements(new FinalInterval(
+			dims))];
+
+		if (fill) {
 			seed = 17;
-			for(int i = 0; i < array.length; i++){
+			for (int i = 0; i < array.length; i++) {
 				array[i] = (int) pseudoRandom() / (int) Integer.MAX_VALUE;
 			}
 		}
-		
+
 		return ArrayImgs.ints(array, dims);
 	}
-	
-	public ArrayImg<UnsignedIntType, IntArray> generateUnsignedIntArrayTestImg(final boolean fill, final long... dims){
-		final int[] array = new int[(int) Intervals.numElements(new FinalInterval(dims))];
-		
-		if(fill) {
+
+	public ArrayImg<UnsignedIntType, IntArray> generateUnsignedIntArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		final int[] array = new int[(int) Intervals.numElements(new FinalInterval(
+			dims))];
+
+		if (fill) {
 			seed = 17;
-			for(int i = 0; i < array.length; i++){
+			for (int i = 0; i < array.length; i++) {
 				array[i] = (int) pseudoRandom() / (int) Integer.MAX_VALUE;
 			}
 		}
-		
+
 		return ArrayImgs.unsignedInts(array, dims);
 	}
 
@@ -278,12 +306,12 @@ public abstract class AbstractOpTest {
 
 		return img;
 	}
-	
+
 	public ArrayImg<DoubleType, DoubleArray> generateDoubleArrayTestImg(
 		final boolean fill, final long... dims)
 	{
-		final double[] array =
-			new double[(int) Intervals.numElements(new FinalInterval(dims))];
+		final double[] array = new double[(int) Intervals.numElements(
+			new FinalInterval(dims))];
 
 		if (fill) {
 			seed = 17;
@@ -294,57 +322,113 @@ public abstract class AbstractOpTest {
 
 		return ArrayImgs.doubles(array, dims);
 	}
-	
-	public ArrayImg<LongType, LongArray> generateLongArrayTestImg(final boolean fill, final long... dims){
-		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(dims))];
-		
-		if(fill) {
+
+	public ArrayImg<LongType, LongArray> generateLongArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(
+			dims))];
+
+		if (fill) {
 			seed = 17;
-			for(int i = 0; i < array.length; i++){
-				array[i] =  (long) (pseudoRandom() /  Integer.MAX_VALUE);
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (long) (pseudoRandom() / Integer.MAX_VALUE);
 			}
 		}
-		
+
 		return ArrayImgs.longs(array, dims);
 	}
-	
-	public ArrayImg<UnsignedLongType, LongArray> generateUnsignedLongArrayTestImg(final boolean fill, final long... dims){
-		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(dims))];
-		
-		if(fill) {
+
+	public ArrayImg<UnsignedLongType, LongArray> generateUnsignedLongArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(
+			dims))];
+
+		if (fill) {
 			seed = 17;
-			for(int i = 0; i < array.length; i++){
-				array[i] =  (long) (pseudoRandom() /  Integer.MAX_VALUE);
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (long) (pseudoRandom() / Integer.MAX_VALUE);
 			}
 		}
-		
+
 		return ArrayImgs.unsignedLongs(array, dims);
 	}
-	
-	public ArrayImg<ShortType, ShortArray> generateShortArrayTestImg(final boolean fill, final long... dims){
-		final short[] array = new short[(int) Intervals.numElements(new FinalInterval(dims))];
-		
-		if(fill) {
+
+	public ArrayImg<ShortType, ShortArray> generateShortArrayTestImg(
+		final boolean fill, final long... dims)
+	{
+		final short[] array = new short[(int) Intervals.numElements(
+			new FinalInterval(dims))];
+
+		if (fill) {
 			seed = 17;
-			for(int i = 0; i < array.length; i++){
-				array[i] =  (short) (pseudoRandom() /  Integer.MAX_VALUE);
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (short) (pseudoRandom() / Integer.MAX_VALUE);
 			}
 		}
-		
+
 		return ArrayImgs.shorts(array, dims);
 	}
-	
-	public ArrayImg<UnsignedShortType, ShortArray> generateUnsignedShortArrayTestImg(final boolean fill, final long... dims){
-		final short[] array = new short[(int) Intervals.numElements(new FinalInterval(dims))];
-		
-		if(fill) {
+
+	public ArrayImg<UnsignedShortType, ShortArray>
+		generateUnsignedShortArrayTestImg(final boolean fill, final long... dims)
+	{
+		final short[] array = new short[(int) Intervals.numElements(
+			new FinalInterval(dims))];
+
+		if (fill) {
 			seed = 17;
-			for(int i = 0; i < array.length; i++){
-				array[i] =  (short) (pseudoRandom() /  Integer.MAX_VALUE);
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (short) (pseudoRandom() / Integer.MAX_VALUE);
 			}
 		}
-		
+
 		return ArrayImgs.unsignedShorts(array, dims);
+	}
+
+	public ArrayImg<UnsignedVariableBitLengthType, LongArray>
+		generateUnsignedVariableBitLengthTypeArrayTestImg(final boolean fill,
+			final int nbits, final long... dims)
+	{
+		final long[] array = new long[(int) Intervals.numElements(new FinalInterval(
+			dims))];
+
+		if (fill) {
+			seed = 17;
+			for (int i = 0; i < array.length; i++) {
+				array[i] = (long) (pseudoRandom() / Integer.MAX_VALUE);
+			}
+		}
+
+		final LongArray l = new LongArray(array);
+
+		return ArrayImgs.unsignedVariableBitLengths(l, nbits, dims);
+	}
+
+	public ListImg<UnboundedIntegerType> generateUnboundedIntegerTypeListTestImg(
+		final boolean fill, final long... dims)
+	{
+
+		final ListImg<UnboundedIntegerType> l =
+			new ListImgFactory<UnboundedIntegerType>().create(dims,
+				new UnboundedIntegerType());
+
+		final BigInteger[] array = new BigInteger[(int) Intervals.numElements(
+			dims)];
+
+		RandomAccess<UnboundedIntegerType> ra = l.randomAccess();
+
+		if (fill) {
+			MersenneTwisterFast betterRNG = new MersenneTwisterFast(0xf1eece);
+			for (int i = 0; i < Intervals.numElements(dims); i++) {
+				BigInteger val = BigInteger.valueOf(betterRNG.nextLong());
+				ra.get().set(val);
+				ra.fwd(0);
+			}
+		}
+
+		return l;
 	}
 
 	public Img<UnsignedByteType>

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,14 +31,22 @@ package net.imagej.ops.image.invert;
 
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigInteger;
+
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Ops;
+import net.imagej.types.UnboundedIntegerType;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
 import net.imglib2.type.numeric.integer.Unsigned12BitType;
 import net.imglib2.type.numeric.integer.Unsigned2BitType;
 import net.imglib2.type.numeric.integer.Unsigned4BitType;
@@ -46,9 +54,9 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedIntType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Pair;
 
 import org.junit.Test;
 
@@ -60,191 +68,347 @@ public class InvertTest extends AbstractOpTest {
 
 	@Test
 	public void testBitTypeInvert() {
-		Img<BitType> inBitType = generateBitArrayTestImg(true, 10, 10);
-		Img<BitType> outBitType = inBitType.factory().create(inBitType,
+		final Img<BitType> inBitType = generateBitArrayTestImg(true, 10, 10);
+		final Img<BitType> outBitType = inBitType.factory().create(inBitType,
 			new BitType());
-		assertInvertDefault(inBitType, outBitType);
-		assertInvertMinMaxProvided(inBitType, outBitType, new BitType(false),
+		assertDefaultInvert(inBitType, outBitType);
+		assertDefaultInvertMinMaxProvided(inBitType, outBitType, new BitType(false),
 			new BitType(true));
-		assertInvertMinMaxProvided(inBitType, outBitType, new BitType(false),
+		assertDefaultInvertMinMaxProvided(inBitType, outBitType, new BitType(false),
 			new BitType(false));
 	}
-	
+
 	@Test
 	public void testByteTypeInvert() {
-		Img<ByteType> inByteType = generateByteArrayTestImg(true, 5, 5);
-		Img<ByteType> outByteType = inByteType.factory().create(inByteType,
+		final Img<ByteType> inByteType = generateByteArrayTestImg(true, 5, 5);
+		final Img<ByteType> outByteType = inByteType.factory().create(inByteType,
 			new ByteType());
-		assertInvertDefault(inByteType, outByteType);
-		assertInvertMinMaxProvided(inByteType, outByteType, new ByteType((byte) 0),
-			new ByteType((byte) 0));
-		assertInvertMinMaxProvided(inByteType, outByteType, new ByteType((byte) 20),
-			new ByteType((byte) 10));
-		assertInvertMinMaxProvided(inByteType, outByteType, new ByteType((byte) 256),
-			new ByteType((byte) 256));
+		assertDefaultInvert(inByteType, outByteType);
+		assertDefaultInvertMinMaxProvided(inByteType, outByteType, new ByteType(
+			(byte) 0), new ByteType((byte) 0));
+		assertDefaultInvertMinMaxProvided(inByteType, outByteType, new ByteType(
+			(byte) 20), new ByteType((byte) 10));
+		assertDefaultInvertMinMaxProvided(inByteType, outByteType, new ByteType(
+			(byte) 256), new ByteType((byte) 256));
 	}
-	
+
 	@Test
 	public void testUnsigned2BitTypeInvert() {
-		Img<Unsigned2BitType> inUnsigned2BitType = generateUnsigned2BitArrayTestImg(true, 5, 5);
-		Img<Unsigned2BitType> outUnsigned2BitType = inUnsigned2BitType.factory().create(inUnsigned2BitType,
-			new Unsigned2BitType());
-		assertInvertDefault(inUnsigned2BitType, outUnsigned2BitType);
-		assertInvertMinMaxProvided(inUnsigned2BitType, outUnsigned2BitType, new Unsigned2BitType(2), new Unsigned2BitType(3));
+		final Img<Unsigned2BitType> inUnsigned2BitType =
+			generateUnsigned2BitArrayTestImg(true, 5, 5);
+		final Img<Unsigned2BitType> outUnsigned2BitType = inUnsigned2BitType
+			.factory().create(inUnsigned2BitType, new Unsigned2BitType());
+		assertDefaultInvert(inUnsigned2BitType, outUnsigned2BitType);
+		assertDefaultInvertMinMaxProvided(inUnsigned2BitType, outUnsigned2BitType,
+			new Unsigned2BitType(2), new Unsigned2BitType(3));
 	}
-	
+
 	@Test
 	public void testUnsigned4BitTypeInvert() {
-		Img<Unsigned4BitType> inUnsigned4BitType = generateUnsigned4BitArrayTestImg(true, 5, 5);
-		Img<Unsigned4BitType> outUnsigned4BitType = inUnsigned4BitType.factory().create(inUnsigned4BitType,
-			new Unsigned4BitType());
-		assertInvertDefault(inUnsigned4BitType, outUnsigned4BitType);
-		assertInvertMinMaxProvided(inUnsigned4BitType, outUnsigned4BitType, new Unsigned4BitType(14), new Unsigned4BitType(15));
+		final Img<Unsigned4BitType> inUnsigned4BitType =
+			generateUnsigned4BitArrayTestImg(true, 5, 5);
+		final Img<Unsigned4BitType> outUnsigned4BitType = inUnsigned4BitType
+			.factory().create(inUnsigned4BitType, new Unsigned4BitType());
+		assertDefaultInvert(inUnsigned4BitType, outUnsigned4BitType);
+		assertDefaultInvertMinMaxProvided(inUnsigned4BitType, outUnsigned4BitType,
+			new Unsigned4BitType(14), new Unsigned4BitType(15));
 	}
-	
+
 	@Test
 	public void testUnsigned12BitTypeInvert() {
-		Img<Unsigned12BitType> inUnsigned12BitType = generateUnsigned12BitArrayTestImg(true, 5, 5);
-		Img<Unsigned12BitType> outUnsigned12BitType = inUnsigned12BitType.factory().create(inUnsigned12BitType,
-			new Unsigned12BitType());
-		assertInvertDefault(inUnsigned12BitType, outUnsigned12BitType);
-		assertInvertMinMaxProvided(inUnsigned12BitType, outUnsigned12BitType, new Unsigned12BitType(3025), new Unsigned12BitType(3846));
+		final Img<Unsigned12BitType> inUnsigned12BitType =
+			generateUnsigned12BitArrayTestImg(true, 5, 5);
+		final Img<Unsigned12BitType> outUnsigned12BitType = inUnsigned12BitType
+			.factory().create(inUnsigned12BitType, new Unsigned12BitType());
+		assertDefaultInvert(inUnsigned12BitType, outUnsigned12BitType);
+		assertDefaultInvertMinMaxProvided(inUnsigned12BitType, outUnsigned12BitType,
+			new Unsigned12BitType(3025), new Unsigned12BitType(3846));
 	}
-	
+
 	@Test
 	public void testUnsignedByteTypeInvert() {
-		Img<UnsignedByteType> inUnsignedByteType = generateUnsignedByteArrayTestImg(
-			true, 5, 5);
-		Img<UnsignedByteType> outUnsignedByteType = inUnsignedByteType.factory()
-			.create(inUnsignedByteType, new UnsignedByteType());
-		assertInvertDefault(inUnsignedByteType, outUnsignedByteType);
-		assertInvertMinMaxProvided(inUnsignedByteType, outUnsignedByteType,
+		final Img<UnsignedByteType> inUnsignedByteType =
+			generateUnsignedByteArrayTestImg(true, 5, 5);
+		final Img<UnsignedByteType> outUnsignedByteType = inUnsignedByteType
+			.factory().create(inUnsignedByteType, new UnsignedByteType());
+		assertDefaultInvert(inUnsignedByteType, outUnsignedByteType);
+		assertDefaultInvertMinMaxProvided(inUnsignedByteType, outUnsignedByteType,
 			new UnsignedByteType((byte) 127), new UnsignedByteType((byte) 127));
-		assertInvertMinMaxProvided(inUnsignedByteType, outUnsignedByteType,
+		assertDefaultInvertMinMaxProvided(inUnsignedByteType, outUnsignedByteType,
 			new UnsignedByteType((byte) -12), new UnsignedByteType((byte) -10));
 	}
-	
+
 	@Test
 	public void testDoubleTypeInvert() {
-		Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(true, 5, 5);
-		Img<DoubleType> outDoubleType = inDoubleType.factory().create(inDoubleType,
-			new DoubleType());
-		assertInvertDefault(inDoubleType, outDoubleType);
-		assertInvertMinMaxProvided(inDoubleType, outDoubleType, new DoubleType(437d), new DoubleType(8008d));
-		assertInvertMinMaxProvided(inDoubleType, outDoubleType, new DoubleType(5d), new DoubleType(Double.MAX_VALUE));
+		final Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(true, 5, 5);
+		final Img<DoubleType> outDoubleType = inDoubleType.factory().create(
+			inDoubleType, new DoubleType());
+		assertDefaultInvert(inDoubleType, outDoubleType);
+		assertDefaultInvertMinMaxProvided(inDoubleType, outDoubleType,
+			new DoubleType(437d), new DoubleType(8008d));
+		assertDefaultInvertMinMaxProvided(inDoubleType, outDoubleType,
+			new DoubleType(5d), new DoubleType(Double.MAX_VALUE));
 	}
-	
+
+	@Test
+	public void testDoubleTypeCustomInvert() {
+		final Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(false, 5,
+			5);
+		final Img<DoubleType> outDoubleType = inDoubleType.factory().create(
+			inDoubleType, new DoubleType());
+
+		// set this array of doubles to be the pixel values.
+		final double[] nums = new double[] { Double.MAX_VALUE, Double.MIN_VALUE, 1d,
+			-1d, 0d, Double.MAX_VALUE + 1, -Double.MAX_VALUE - 1, Math.PI, Math.E, Math
+				.sqrt(Math.PI), Math.pow(25, 25), 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
+			Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
+		final Cursor<DoubleType> c = inDoubleType.localizingCursor();
+		for (double i : nums) {
+			c.next();
+			c.get().set(i);
+		}
+		assertDefaultInvert(inDoubleType, outDoubleType);
+		assertDefaultInvertMinMaxProvided(inDoubleType, outDoubleType,
+			new DoubleType(437d), new DoubleType(8008d));
+	}
+
 	@Test
 	public void testFloatTypeInvert() {
-		Img<FloatType> inFloatType = generateFloatArrayTestImg(true, 5, 5);
-		Img<FloatType> outFloatType = inFloatType.factory().create(inFloatType,
-			new FloatType());
-		assertInvertDefault(inFloatType, outFloatType);
- 		assertInvertMinMaxProvided(inFloatType, outFloatType, new FloatType(0f), new FloatType(1f));
+		final Img<FloatType> inFloatType = generateFloatArrayTestImg(true, 5, 5);
+		final Img<FloatType> outFloatType = inFloatType.factory().create(
+			inFloatType, new FloatType());
+		assertDefaultInvert(inFloatType, outFloatType);
+		assertDefaultInvertMinMaxProvided(inFloatType, outFloatType, new FloatType(
+			0f), new FloatType(1f));
 	}
-	
+
 	@Test
 	public void testIntTypeInvert() {
-		Img<IntType> inIntType = generateIntArrayTestImg(true, 5, 5);
-		Img<IntType> outIntType = inIntType.factory().create(inIntType,
+		final Img<IntType> inIntType = generateIntArrayTestImg(true, 5, 5);
+		final Img<IntType> outIntType = inIntType.factory().create(inIntType,
 			new IntType());
-		assertInvertDefault(inIntType, outIntType);
-		assertInvertMinMaxProvided(inIntType, outIntType, new IntType(10),
+		assertDefaultInvert(inIntType, outIntType);
+		assertDefaultInvertMinMaxProvided(inIntType, outIntType, new IntType(10),
 			new IntType(40));
-		assertInvertMinMaxProvided(inIntType, outIntType, new IntType(Integer.MIN_VALUE),
-			new IntType(-10));
+		assertDefaultInvertMinMaxProvided(inIntType, outIntType, new IntType(
+			Integer.MIN_VALUE), new IntType(-10));
 	}
-	
+
 	@Test
 	public void testUnsignedIntTypeInvert() {
-		Img<UnsignedIntType> inUnsignedIntType = generateUnsignedIntArrayTestImg(
-			true, 5, 5);
-		Img<UnsignedIntType> outUnsignedIntType = inUnsignedIntType.factory()
+		final Img<UnsignedIntType> inUnsignedIntType =
+			generateUnsignedIntArrayTestImg(true, 5, 5);
+		final Img<UnsignedIntType> outUnsignedIntType = inUnsignedIntType.factory()
 			.create(inUnsignedIntType, new UnsignedIntType());
-		assertInvertDefault(inUnsignedIntType, outUnsignedIntType);
-		assertInvertMinMaxProvided(inUnsignedIntType, outUnsignedIntType,
+		assertDefaultInvert(inUnsignedIntType, outUnsignedIntType);
+		assertDefaultInvertMinMaxProvided(inUnsignedIntType, outUnsignedIntType,
 			new UnsignedIntType(237), new UnsignedIntType(257));
-		assertInvertMinMaxProvided(inUnsignedIntType, outUnsignedIntType,
+		assertDefaultInvertMinMaxProvided(inUnsignedIntType, outUnsignedIntType,
 			new UnsignedIntType(10), new UnsignedIntType(-10));
 	}
-	
-//	@Test
-//	public void testLongTypeInvert() {
-//		Img<LongType> inLongType = generateLongArrayTestImg(true, 5, 5);
-//		Img<LongType> outLongType = inLongType.factory().create(inLongType,
-//			new LongType());
-//		assertInvertDefault(inLongType, outLongType);
-//		assertBigInvertMinMaxProvided(inLongType, outLongType, new LongType(3025),
-//			new LongType(3846));
-//	}
-	
-//	@Test
-//	public void testUnsignedLongTypeInvert() {
-//		Img<UnsignedLongType> inUnsignedLongType = generateUnsignedLongArrayTestImg(
-//			true, 5, 5);
-//		Img<UnsignedLongType> outUnsignedLongType = inUnsignedLongType.factory()
-//			.create(inUnsignedLongType, new UnsignedLongType());
-//		assertInvertDefault(inUnsignedLongType, outUnsignedLongType);
-//		assertBigInvertMinMaxProvided(inUnsignedLongType, outUnsignedLongType,
-//			new UnsignedLongType(3025), new UnsignedLongType(3846));
-//	}
-	
+
+	@Test
+	public void testLongTypeInvert() {
+		final Img<LongType> inLongType = generateLongArrayTestImg(true, 5, 5);
+		final Img<LongType> outLongType = inLongType.factory().create(inLongType,
+			new LongType());
+		assertIntegerInvert(inLongType, outLongType);
+		assertIntegerInvertMinMaxProvided(inLongType, outLongType, new LongType(
+			3025), new LongType(3846));
+	}
+
+	@Test
+	public void testUnsignedLongTypeInvert() {
+		final Img<UnsignedLongType> inUnsignedLongType =
+			generateUnsignedLongArrayTestImg(true, 5, 5);
+		final Img<UnsignedLongType> outUnsignedLongType = inUnsignedLongType
+			.factory().create(inUnsignedLongType, new UnsignedLongType());
+		assertIntegerInvert(inUnsignedLongType, outUnsignedLongType);
+		assertIntegerInvertMinMaxProvided(inUnsignedLongType, outUnsignedLongType,
+			new UnsignedLongType(3025), new UnsignedLongType(3846));
+	}
+
+	@Test
+	public void testUnsigned128ByteTypeInvert() {
+		final Img<Unsigned128BitType> inUnsigned128BitType =
+			generateUnsigned128BitArrayTestImg(true, 5, 5);
+		final Img<Unsigned128BitType> outUnsigned128BitType = inUnsigned128BitType
+			.factory().create(inUnsigned128BitType, new Unsigned128BitType());
+		assertIntegerInvert(inUnsigned128BitType, outUnsigned128BitType);
+		assertIntegerInvertMinMaxProvided(inUnsigned128BitType,
+			outUnsigned128BitType, new Unsigned128BitType(BigInteger.valueOf(3025)),
+			new Unsigned128BitType(BigInteger.valueOf(3468)));
+	}
+
 	@Test
 	public void testShortTypeInvert() {
-		Img<ShortType> inShortType = generateShortArrayTestImg(true, 5, 5);
-		Img<ShortType> outShortType = inShortType.factory().create(inShortType,
-			new ShortType());
-		assertInvertDefault(inShortType, outShortType);
-		assertInvertMinMaxProvided(inShortType, outShortType,
-			new ShortType((short)(Short.MIN_VALUE)), new ShortType((short)(Short.MIN_VALUE + 1)));
-		assertInvertMinMaxProvided(inShortType, outShortType,
-			new ShortType((short)(Short.MAX_VALUE)), new ShortType((short)(Short.MAX_VALUE - 1)));
+		final Img<ShortType> inShortType = generateShortArrayTestImg(true, 5, 5);
+		final Img<ShortType> outShortType = inShortType.factory().create(
+			inShortType, new ShortType());
+		assertDefaultInvert(inShortType, outShortType);
+		assertDefaultInvertMinMaxProvided(inShortType, outShortType, new ShortType(
+			(Short.MIN_VALUE)), new ShortType((short) (Short.MIN_VALUE + 1)));
+		assertDefaultInvertMinMaxProvided(inShortType, outShortType, new ShortType(
+			(Short.MAX_VALUE)), new ShortType((short) (Short.MAX_VALUE - 1)));
+		assertDefaultInvertMinMaxProvided(inShortType, outShortType, new ShortType(
+			(Short.MAX_VALUE)), new ShortType((short) (Short.MAX_VALUE)));
 	}
-	
+
 	@Test
 	public void testUnsignedShortTypeInvert() {
-		Img<UnsignedShortType> inUnsignedShortType =
-				generateUnsignedShortArrayTestImg(true, 5, 5);
-			Img<UnsignedShortType> outUnsignedShortType = inUnsignedShortType.factory()
-				.create(inUnsignedShortType, new UnsignedShortType());
-			assertInvertDefault(inUnsignedShortType, outUnsignedShortType);
-			assertInvertMinMaxProvided(inUnsignedShortType, outUnsignedShortType,
-				new UnsignedShortType((short) 437), new UnsignedShortType((short) 8008));
+		final Img<UnsignedShortType> inUnsignedShortType =
+			generateUnsignedShortArrayTestImg(true, 5, 5);
+		final Img<UnsignedShortType> outUnsignedShortType = inUnsignedShortType
+			.factory().create(inUnsignedShortType, new UnsignedShortType());
+		assertDefaultInvert(inUnsignedShortType, outUnsignedShortType);
+		assertDefaultInvertMinMaxProvided(inUnsignedShortType, outUnsignedShortType,
+			new UnsignedShortType((short) 437), new UnsignedShortType((short) 8008));
 	}
-	
-	private <T extends RealType<T>> void assertInvertMinMaxProvided(Img<T> in,
-		Img<T> out, RealType<T> min, RealType<T> max)
+
+	@Test
+	public void testUnboundedIntegerTypeInvert() {
+		final Img<UnboundedIntegerType> inUnboundedIntegerType =
+			generateUnboundedIntegerTypeListTestImg(true, 5, 5);
+		final Img<UnboundedIntegerType> outUnboundedIntegerType =
+			inUnboundedIntegerType.factory().create(inUnboundedIntegerType,
+				new UnboundedIntegerType());
+		assertDefaultInvert(inUnboundedIntegerType, outUnboundedIntegerType);
+		assertDefaultInvertMinMaxProvided(inUnboundedIntegerType,
+			outUnboundedIntegerType, new UnboundedIntegerType(437),
+			new UnboundedIntegerType(8008));
+		assertDefaultInvertMinMaxProvided(inUnboundedIntegerType,
+			outUnboundedIntegerType, new UnboundedIntegerType(0),
+			new UnboundedIntegerType(1));
+	}
+
+	@Test
+	public void testUnsignedVariableBitLengthTypeInvert() {
+		final Img<UnsignedVariableBitLengthType> inUnsignedVariableBitLengthType =
+			generateUnsignedVariableBitLengthTypeArrayTestImg(true, 64, 5, 5);
+		final Img<UnsignedVariableBitLengthType> outUnsignedVariableBitLengthType =
+			inUnsignedVariableBitLengthType.factory().create(
+				inUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(1,
+					64));
+		assertIntegerInvert(inUnsignedVariableBitLengthType,
+			outUnsignedVariableBitLengthType);
+		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
+			outUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(
+				100000, 32), new UnsignedVariableBitLengthType(100101, 32));
+		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
+			outUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(
+				123456789, 64), new UnsignedVariableBitLengthType(123456790, 64));
+		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
+			outUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(4,
+				12), new UnsignedVariableBitLengthType(6, 12));
+		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
+			outUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(0, 6),
+			new UnsignedVariableBitLengthType(1, 6));
+	}
+
+	private <T extends RealType<T>> void assertDefaultInvert(final Img<T> in,
+		final Img<T> out)
 	{
 
-		// unsigned type test
+		final T type = in.firstElement();
+		final T min = type.copy();
+		min.setReal(type.getMinValue());
+		final T max = type.copy();
+		max.setReal(type.getMaxValue());
+		ops.run(InvertII.class, out, in);
+
+		defaultCompare(in, out, min, max);
+	}
+
+	private <T extends RealType<T>> void assertDefaultInvertMinMaxProvided(
+		final Img<T> in, final Img<T> out, final RealType<T> min,
+		final RealType<T> max)
+	{
 
 		ops.run(InvertII.class, out, in, (min), (max));
 
-		RealType<T> firstIn = in.firstElement();
-		RealType<T> firstOut = out.firstElement();
-		
-		double minMax = min.getRealDouble() + max.getRealDouble();
+		defaultCompare(in, out, (T) min, (T) max);
+	}
 
-		minMax -= firstIn.getRealDouble();
+	private <T extends RealType<T>> void defaultCompare(final Img<T> in,
+		final Img<T> out, final T min, final T max)
+	{
+		final Cursor<T> inAccess = in.localizingCursor();
+		final RandomAccess<T> outAccess = out.randomAccess();
+		while (inAccess.hasNext()) {
+			final T inVal = inAccess.next();
+			outAccess.setPosition(inAccess);
+			final T outVal = outAccess.get();
+			final double bigIn = inVal.getRealDouble();
+			final double minMax = min.getRealDouble() + max.getRealDouble() - bigIn;
+			final double bigOut = outVal.getRealDouble();
+			if (bigIn >= inVal.getMaxValue() || minMax <= inVal.getMinValue())
+				assertEquals(inVal.getMinValue(), bigOut, 0.00005);
+			else if (bigIn <= inVal.getMinValue() || minMax >= inVal.getMaxValue())
+				assertEquals(inVal.getMaxValue(), bigOut, 0.00005);
+			else {
 
-		if(firstIn.getRealDouble() >= firstIn.getMaxValue() || minMax <= firstIn.getMinValue()) assertEquals(firstIn.getMinValue(), firstOut.getRealDouble(), 0.00005);
-		else if(firstIn.getRealDouble() <= firstIn.getMinValue() || minMax >= firstIn.getMaxValue()) assertEquals(firstIn.getMaxValue(), firstOut.getRealDouble(), 0.00005);
-		else {
+				assertEquals(minMax, bigOut, 0.00005);
 
-		assertEquals(minMax, firstOut.getRealDouble(), 0.00005);
-		
+			}
 		}
 	}
 
-	private <T extends RealType<T>> void assertInvertDefault(Img<T> in, Img<T> out) {
+	private <T extends IntegerType<T>> void assertIntegerInvertMinMaxProvided(
+		final Img<T> in, final Img<T> out, final T min, final T max)
+	{
 
-		RealType<T> type = (RealType<T>) in.firstElement();
-		ops.run(InvertII.class, out, in);
+		// unsigned type test
+		ops.run(Ops.Image.Invert.class, out, in, min, max);
 
-		RealType<T> firstIn = in.firstElement();
-		RealType<T> firstOut = out.firstElement();
+		integerCompare(in, out, min, max);
 
-		assertEquals((type.getMinValue() + type.getMaxValue()) - firstIn
-			.getRealDouble(), firstOut.getRealDouble(), 0);
+	}
+
+	private <T extends IntegerType<T>> void assertIntegerInvert(final Img<T> in,
+		final Img<T> out)
+	{
+
+		ops.run(Ops.Image.Invert.class, out, in);
+
+		integerCompare(in, out, null, null);
+	}
+
+	private <T extends IntegerType<T>> void integerCompare(final Img<T> in,
+		final Img<T> out, final IntegerType<T> min, final IntegerType<T> max)
+	{
+
+		// Get min/max for the output type.
+		final BigInteger minOut = InvertIIInteger.minValue(out.firstElement())
+			.getBigInteger();
+		final BigInteger maxOut = InvertIIInteger.maxValue(out.firstElement())
+			.getBigInteger();
+		BigInteger minMax = BigInteger.ZERO;
+
+		if (min == null && max == null) {
+			minMax = minOut.add(maxOut); // min + max
+		}
+		else {
+			minMax = min.getBigInteger().add(max.getBigInteger());
+		}
+
+		final Cursor<T> inAccess = in.localizingCursor();
+		final RandomAccess<T> outAccess = out.randomAccess();
+		while (inAccess.hasNext()) {
+			final T inVal = inAccess.next();
+			outAccess.setPosition(inAccess);
+			final T outVal = outAccess.get();
+			final BigInteger bigIn = inVal.getBigInteger();
+			final BigInteger bigOut = outVal.getBigInteger();
+			final BigInteger calcOut = minMax.subtract(bigIn);
+			if (bigIn.compareTo(maxOut) >= 0 || calcOut.compareTo(minOut) <= 0)
+				assertEquals(minOut, bigOut);
+			else if (bigIn.compareTo(minOut) <= 0 || calcOut.compareTo(maxOut) >= 0)
+				assertEquals(maxOut, bigOut);
+			else {
+
+				assertEquals(calcOut, bigOut);
+
+			}
+		}
 	}
 }

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -32,73 +32,219 @@ package net.imagej.ops.image.invert;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
-import net.imglib2.Cursor;
-import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Pair;
 
 import org.junit.Test;
 
 /**
  * @author Martin Horn (University of Konstanz)
+ * @author Gabe Selzer
  */
 public class InvertTest extends AbstractOpTest {
 
 	@Test
-	public void testInvert() {
-
-		// signed type test
-		Img<ByteType> in = generateByteArrayTestImg(true, 5, 5);
-		Img<ByteType> out = in.factory().create(in, new ByteType());
-
-		ByteType type = in.firstElement();
-		ops.run(InvertII.class, out, in);
-
-		ByteType firstIn = in.firstElement();
-		ByteType firstOut = out.firstElement();
-
-		assertEquals(((int) type.getMinValue() + (int) type.getMaxValue()) - firstIn.getInteger(), firstOut
-			.getInteger());
-
-	}
-
-	@Test
-	public void testInvertMinMaxProvided() {
-
-		// unsigned type test
-		Img<UnsignedByteType> in = generateUnsignedByteArrayTestImg(true, 5, 5);
-		Img<UnsignedByteType> out = in.factory().create(in, new UnsignedByteType());
-		
-		UnsignedByteType min = new UnsignedByteType(10);
-		UnsignedByteType max = new UnsignedByteType(40);
-
-		ops.run(InvertII.class, out, in, min, max);
-
-		Pair<UnsignedByteType, UnsignedByteType> minMax = ops.stats().minMax(in);
-		UnsignedByteType firstIn = in.firstElement();
-		UnsignedByteType firstOut = out.firstElement();
-
-		assertEquals((min.getInteger() + max.getInteger()) - firstIn.getInteger(), firstOut
-			.getInteger());
-
+	public void testBitTypeInvert() {
+		Img<BitType> inBitType = generateBitArrayTestImg(true, 10, 10);
+		Img<BitType> outBitType = inBitType.factory().create(inBitType,
+			new BitType());
+		assertInvertDefault(inBitType, outBitType);
+		assertInvertMinMaxProvided(inBitType, outBitType, new BitType(false),
+			new BitType(true));
+		assertInvertMinMaxProvided(inBitType, outBitType, new BitType(false),
+			new BitType(false));
 	}
 	
 	@Test
-	public void testInvertTypeBased() {
+	public void testByteTypeInvert() {
+		Img<ByteType> inByteType = generateByteArrayTestImg(true, 5, 5);
+		Img<ByteType> outByteType = inByteType.factory().create(inByteType,
+			new ByteType());
+		assertInvertDefault(inByteType, outByteType);
+		assertInvertMinMaxProvided(inByteType, outByteType, new ByteType((byte) 0),
+			new ByteType((byte) 0));
+		assertInvertMinMaxProvided(inByteType, outByteType, new ByteType((byte) 20),
+			new ByteType((byte) 10));
+		assertInvertMinMaxProvided(inByteType, outByteType, new ByteType((byte) 256),
+			new ByteType((byte) 256));
+	}
+	
+	@Test
+	public void testUnsigned2BitTypeInvert() {
+		Img<Unsigned2BitType> inUnsigned2BitType = generateUnsigned2BitArrayTestImg(true, 5, 5);
+		Img<Unsigned2BitType> outUnsigned2BitType = inUnsigned2BitType.factory().create(inUnsigned2BitType,
+			new Unsigned2BitType());
+		assertInvertDefault(inUnsigned2BitType, outUnsigned2BitType);
+		assertInvertMinMaxProvided(inUnsigned2BitType, outUnsigned2BitType, new Unsigned2BitType(2), new Unsigned2BitType(3));
+	}
+	
+	@Test
+	public void testUnsigned4BitTypeInvert() {
+		Img<Unsigned4BitType> inUnsigned4BitType = generateUnsigned4BitArrayTestImg(true, 5, 5);
+		Img<Unsigned4BitType> outUnsigned4BitType = inUnsigned4BitType.factory().create(inUnsigned4BitType,
+			new Unsigned4BitType());
+		assertInvertDefault(inUnsigned4BitType, outUnsigned4BitType);
+		assertInvertMinMaxProvided(inUnsigned4BitType, outUnsigned4BitType, new Unsigned4BitType(14), new Unsigned4BitType(15));
+	}
+	
+	@Test
+	public void testUnsigned12BitTypeInvert() {
+		Img<Unsigned12BitType> inUnsigned12BitType = generateUnsigned12BitArrayTestImg(true, 5, 5);
+		Img<Unsigned12BitType> outUnsigned12BitType = inUnsigned12BitType.factory().create(inUnsigned12BitType,
+			new Unsigned12BitType());
+		assertInvertDefault(inUnsigned12BitType, outUnsigned12BitType);
+		assertInvertMinMaxProvided(inUnsigned12BitType, outUnsigned12BitType, new Unsigned12BitType(3025), new Unsigned12BitType(3846));
+	}
+	
+	@Test
+	public void testUnsignedByteTypeInvert() {
+		Img<UnsignedByteType> inUnsignedByteType = generateUnsignedByteArrayTestImg(
+			true, 5, 5);
+		Img<UnsignedByteType> outUnsignedByteType = inUnsignedByteType.factory()
+			.create(inUnsignedByteType, new UnsignedByteType());
+		assertInvertDefault(inUnsignedByteType, outUnsignedByteType);
+		assertInvertMinMaxProvided(inUnsignedByteType, outUnsignedByteType,
+			new UnsignedByteType((byte) 127), new UnsignedByteType((byte) 127));
+		assertInvertMinMaxProvided(inUnsignedByteType, outUnsignedByteType,
+			new UnsignedByteType((byte) -12), new UnsignedByteType((byte) -10));
+	}
+	
+	@Test
+	public void testDoubleTypeInvert() {
+		Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(true, 5, 5);
+		Img<DoubleType> outDoubleType = inDoubleType.factory().create(inDoubleType,
+			new DoubleType());
+		assertInvertDefault(inDoubleType, outDoubleType);
+		assertInvertMinMaxProvided(inDoubleType, outDoubleType, new DoubleType(437d), new DoubleType(8008d));
+		assertInvertMinMaxProvided(inDoubleType, outDoubleType, new DoubleType(5d), new DoubleType(Double.MAX_VALUE));
+	}
+	
+	@Test
+	public void testFloatTypeInvert() {
+		Img<FloatType> inFloatType = generateFloatArrayTestImg(true, 5, 5);
+		Img<FloatType> outFloatType = inFloatType.factory().create(inFloatType,
+			new FloatType());
+		assertInvertDefault(inFloatType, outFloatType);
+ 		assertInvertMinMaxProvided(inFloatType, outFloatType, new FloatType(0f), new FloatType(1f));
+	}
+	
+	@Test
+	public void testIntTypeInvert() {
+		Img<IntType> inIntType = generateIntArrayTestImg(true, 5, 5);
+		Img<IntType> outIntType = inIntType.factory().create(inIntType,
+			new IntType());
+		assertInvertDefault(inIntType, outIntType);
+		assertInvertMinMaxProvided(inIntType, outIntType, new IntType(10),
+			new IntType(40));
+		assertInvertMinMaxProvided(inIntType, outIntType, new IntType(Integer.MIN_VALUE),
+			new IntType(-10));
+	}
+	
+	@Test
+	public void testUnsignedIntTypeInvert() {
+		Img<UnsignedIntType> inUnsignedIntType = generateUnsignedIntArrayTestImg(
+			true, 5, 5);
+		Img<UnsignedIntType> outUnsignedIntType = inUnsignedIntType.factory()
+			.create(inUnsignedIntType, new UnsignedIntType());
+		assertInvertDefault(inUnsignedIntType, outUnsignedIntType);
+		assertInvertMinMaxProvided(inUnsignedIntType, outUnsignedIntType,
+			new UnsignedIntType(237), new UnsignedIntType(257));
+		assertInvertMinMaxProvided(inUnsignedIntType, outUnsignedIntType,
+			new UnsignedIntType(10), new UnsignedIntType(-10));
+	}
+	
+//	@Test
+//	public void testLongTypeInvert() {
+//		Img<LongType> inLongType = generateLongArrayTestImg(true, 5, 5);
+//		Img<LongType> outLongType = inLongType.factory().create(inLongType,
+//			new LongType());
+//		assertInvertDefault(inLongType, outLongType);
+//		assertBigInvertMinMaxProvided(inLongType, outLongType, new LongType(3025),
+//			new LongType(3846));
+//	}
+	
+//	@Test
+//	public void testUnsignedLongTypeInvert() {
+//		Img<UnsignedLongType> inUnsignedLongType = generateUnsignedLongArrayTestImg(
+//			true, 5, 5);
+//		Img<UnsignedLongType> outUnsignedLongType = inUnsignedLongType.factory()
+//			.create(inUnsignedLongType, new UnsignedLongType());
+//		assertInvertDefault(inUnsignedLongType, outUnsignedLongType);
+//		assertBigInvertMinMaxProvided(inUnsignedLongType, outUnsignedLongType,
+//			new UnsignedLongType(3025), new UnsignedLongType(3846));
+//	}
+	
+	@Test
+	public void testShortTypeInvert() {
+		Img<ShortType> inShortType = generateShortArrayTestImg(true, 5, 5);
+		Img<ShortType> outShortType = inShortType.factory().create(inShortType,
+			new ShortType());
+		assertInvertDefault(inShortType, outShortType);
+		assertInvertMinMaxProvided(inShortType, outShortType,
+			new ShortType((short)(Short.MIN_VALUE)), new ShortType((short)(Short.MIN_VALUE + 1)));
+		assertInvertMinMaxProvided(inShortType, outShortType,
+			new ShortType((short)(Short.MAX_VALUE)), new ShortType((short)(Short.MAX_VALUE - 1)));
+	}
+	
+	@Test
+	public void testUnsignedShortTypeInvert() {
+		Img<UnsignedShortType> inUnsignedShortType =
+				generateUnsignedShortArrayTestImg(true, 5, 5);
+			Img<UnsignedShortType> outUnsignedShortType = inUnsignedShortType.factory()
+				.create(inUnsignedShortType, new UnsignedShortType());
+			assertInvertDefault(inUnsignedShortType, outUnsignedShortType);
+			assertInvertMinMaxProvided(inUnsignedShortType, outUnsignedShortType,
+				new UnsignedShortType((short) 437), new UnsignedShortType((short) 8008));
+	}
+	
+	private <T extends RealType<T>> void assertInvertMinMaxProvided(Img<T> in,
+		Img<T> out, RealType<T> min, RealType<T> max)
+	{
 
 		// unsigned type test
-		Img<UnsignedByteType> in = generateUnsignedByteArrayTestImg(true, 5, 5);
-		Img<UnsignedByteType> out = in.factory().create(in, new UnsignedByteType());
 
-		UnsignedByteType type = in.firstElement();
+		ops.run(InvertII.class, out, in, (min), (max));
+
+		RealType<T> firstIn = in.firstElement();
+		RealType<T> firstOut = out.firstElement();
+		
+		double minMax = min.getRealDouble() + max.getRealDouble();
+
+		minMax -= firstIn.getRealDouble();
+
+		if(firstIn.getRealDouble() >= firstIn.getMaxValue() || minMax <= firstIn.getMinValue()) assertEquals(firstIn.getMinValue(), firstOut.getRealDouble(), 0.00005);
+		else if(firstIn.getRealDouble() <= firstIn.getMinValue() || minMax >= firstIn.getMaxValue()) assertEquals(firstIn.getMaxValue(), firstOut.getRealDouble(), 0.00005);
+		else {
+
+		assertEquals(minMax, firstOut.getRealDouble(), 0.00005);
+		
+		}
+	}
+
+	private <T extends RealType<T>> void assertInvertDefault(Img<T> in, Img<T> out) {
+
+		RealType<T> type = (RealType<T>) in.firstElement();
 		ops.run(InvertII.class, out, in);
 
-		UnsignedByteType firstIn = in.firstElement();
-		UnsignedByteType firstOut = out.firstElement();
+		RealType<T> firstIn = in.firstElement();
+		RealType<T> firstOut = out.firstElement();
 
-		assertEquals((int) type.getMaxValue() - firstIn.getInteger(), firstOut.getInteger());
-
+		assertEquals((type.getMinValue() + type.getMaxValue()) - firstIn
+			.getRealDouble(), firstOut.getRealDouble(), 0);
 	}
 }

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -126,6 +126,20 @@ public class InvertTest extends AbstractOpTest {
 	}
 
 	@Test
+	public void
+		testUnsigned12BitTypeInvertToUnsignedVariableBitLengthTypeInvert()
+	{
+		final Img<Unsigned12BitType> inUnsigned12BitType =
+			generateUnsigned12BitArrayTestImg(true, 5, 5);
+		final Img<UnsignedVariableBitLengthType> outUnsignedVariableBitLengthType =
+			generateUnsignedVariableBitLengthTypeArrayTestImg(false, 64, 5, 5);
+		assertIntegerInvert(inUnsigned12BitType, outUnsignedVariableBitLengthType);
+		assertIntegerInvertMinMaxProvided(inUnsigned12BitType,
+			outUnsignedVariableBitLengthType, new Unsigned12BitType(1),
+			new Unsigned12BitType(17));
+	}
+
+	@Test
 	public void testUnsignedByteTypeInvert() {
 		final Img<UnsignedByteType> inUnsignedByteType =
 			generateUnsignedByteArrayTestImg(true, 5, 5);
@@ -152,24 +166,31 @@ public class InvertTest extends AbstractOpTest {
 
 	@Test
 	public void testDoubleTypeCustomInvert() {
-		final Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(false, 5,
-			5);
+		final Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(true, 5, 5);
 		final Img<DoubleType> outDoubleType = inDoubleType.factory().create(
 			inDoubleType, new DoubleType());
 
 		// set this array of doubles to be the pixel values.
 		final double[] nums = new double[] { Double.MAX_VALUE, Double.MIN_VALUE, 1d,
-			-1d, 0d, Double.MAX_VALUE + 1, -Double.MAX_VALUE - 1, Math.PI, Math.E, Math
-				.sqrt(Math.PI), Math.pow(25, 25), 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
-			Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
+			-1d, 0d, Double.MAX_VALUE + 1, -Double.MAX_VALUE - 1, Math.PI, Math.E,
+			Math.sqrt(Math.PI), Math.pow(25, 25), 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
+			Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+			Double.NEGATIVE_INFINITY };
 		final Cursor<DoubleType> c = inDoubleType.localizingCursor();
-		for (double i : nums) {
+		for (final double i : nums) {
 			c.next();
 			c.get().set(i);
 		}
 		assertDefaultInvert(inDoubleType, outDoubleType);
 		assertDefaultInvertMinMaxProvided(inDoubleType, outDoubleType,
 			new DoubleType(437d), new DoubleType(8008d));
+	}
+
+	@Test
+	public void testDoubleTypeToIntTypeInvert() {
+		final Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(true, 5, 5);
+		final Img<IntType> outIntType = generateIntArrayTestImg(false, 5, 5);
+		assertDefaultInvert(inDoubleType, outIntType);
 	}
 
 	@Test
@@ -192,6 +213,26 @@ public class InvertTest extends AbstractOpTest {
 			new IntType(40));
 		assertDefaultInvertMinMaxProvided(inIntType, outIntType, new IntType(
 			Integer.MIN_VALUE), new IntType(-10));
+	}
+
+	@Test
+	public void testIntTypeToDoubleTypeInvert() {
+		final Img<IntType> inIntType = generateIntArrayTestImg(true, 5, 5);
+		final Img<DoubleType> outDoubleType = generateDoubleArrayTestImg(false, 5,
+			5);
+		assertDefaultInvert(inIntType, outDoubleType);
+		assertDefaultInvertMinMaxProvided(inIntType, outDoubleType, new IntType(
+			Integer.MAX_VALUE), new IntType(Integer.MAX_VALUE));
+	}
+
+	@Test
+	public void testIntTypeToUnboundedIntegerTypeInvert() {
+		final Img<IntType> inIntType = generateIntArrayTestImg(false, 5, 5);
+		final Img<UnboundedIntegerType> outUnboundedIntegerType =
+			generateUnboundedIntegerTypeListTestImg(true, 5, 5);
+		assertIntegerInvert(inIntType, outUnboundedIntegerType);
+		assertIntegerInvertMinMaxProvided(inIntType, outUnboundedIntegerType,
+			new IntType(Integer.MAX_VALUE - 1), new IntType(Integer.MAX_VALUE));
 	}
 
 	@Test
@@ -251,7 +292,19 @@ public class InvertTest extends AbstractOpTest {
 		assertDefaultInvertMinMaxProvided(inShortType, outShortType, new ShortType(
 			(Short.MAX_VALUE)), new ShortType((short) (Short.MAX_VALUE - 1)));
 		assertDefaultInvertMinMaxProvided(inShortType, outShortType, new ShortType(
-			(Short.MAX_VALUE)), new ShortType((short) (Short.MAX_VALUE)));
+			(Short.MAX_VALUE)), new ShortType((Short.MAX_VALUE)));
+	}
+
+	@Test
+	public void testShortTypeToUnsignedShortTypeInvert() {
+		final Img<ShortType> inShortType = generateShortArrayTestImg(true, 5, 5);
+		final Img<UnsignedShortType> outUnsignedShortType =
+			generateUnsignedShortArrayTestImg(false, 5, 5);
+		assertDefaultInvert(inShortType, outUnsignedShortType);
+		assertDefaultInvertMinMaxProvided(inShortType, outUnsignedShortType,
+			new ShortType((Short.MAX_VALUE)), new ShortType((Short.MAX_VALUE)));
+		assertDefaultInvertMinMaxProvided(inShortType, outUnsignedShortType,
+			new ShortType((short) (-5)), new ShortType((short) -3));
 	}
 
 	@Test
@@ -266,19 +319,41 @@ public class InvertTest extends AbstractOpTest {
 	}
 
 	@Test
+	public void testUnsignedShortTypeToShortTypeInvert() {
+		final Img<UnsignedShortType> inUnsignedShortType =
+			generateUnsignedShortArrayTestImg(true, 5, 5);
+		final Img<ShortType> outShortType = generateShortArrayTestImg(false, 5, 5);
+		assertDefaultInvert(inUnsignedShortType, outShortType);
+		assertDefaultInvertMinMaxProvided(inUnsignedShortType, outShortType,
+			new UnsignedShortType((short) 65540), new UnsignedShortType(
+				(short) 70000));
+	}
+
+	@Test
 	public void testUnboundedIntegerTypeInvert() {
 		final Img<UnboundedIntegerType> inUnboundedIntegerType =
 			generateUnboundedIntegerTypeListTestImg(true, 5, 5);
 		final Img<UnboundedIntegerType> outUnboundedIntegerType =
 			inUnboundedIntegerType.factory().create(inUnboundedIntegerType,
 				new UnboundedIntegerType());
-		assertDefaultInvert(inUnboundedIntegerType, outUnboundedIntegerType);
-		assertDefaultInvertMinMaxProvided(inUnboundedIntegerType,
+		assertIntegerInvert(inUnboundedIntegerType, outUnboundedIntegerType);
+		assertIntegerInvertMinMaxProvided(inUnboundedIntegerType,
 			outUnboundedIntegerType, new UnboundedIntegerType(437),
 			new UnboundedIntegerType(8008));
-		assertDefaultInvertMinMaxProvided(inUnboundedIntegerType,
+		assertIntegerInvertMinMaxProvided(inUnboundedIntegerType,
 			outUnboundedIntegerType, new UnboundedIntegerType(0),
 			new UnboundedIntegerType(1));
+	}
+
+	@Test
+	public void testUnboundedIntegerTypeToIntTypeInvert() {
+		final Img<UnboundedIntegerType> inUnboundedIntegerType =
+			generateUnboundedIntegerTypeListTestImg(true, 5, 5);
+		final Img<IntType> outIntType = generateIntArrayTestImg(false, 5, 5);
+		assertIntegerInvert(inUnboundedIntegerType, outIntType);
+		assertIntegerInvertMinMaxProvided(inUnboundedIntegerType, outIntType,
+			new UnboundedIntegerType(Integer.MAX_VALUE), new UnboundedIntegerType(
+				Integer.MAX_VALUE + 1));
 	}
 
 	@Test
@@ -293,7 +368,8 @@ public class InvertTest extends AbstractOpTest {
 			outUnsignedVariableBitLengthType);
 		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
 			outUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(
-				100000, 32), new UnsignedVariableBitLengthType(100101, 32));
+				((long) Math.pow(2, 64) - 1), 64), new UnsignedVariableBitLengthType(
+					((long) Math.pow(2, 64) - 1), 64));
 		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
 			outUnsignedVariableBitLengthType, new UnsignedVariableBitLengthType(
 				123456789, 64), new UnsignedVariableBitLengthType(123456790, 64));
@@ -305,56 +381,67 @@ public class InvertTest extends AbstractOpTest {
 			new UnsignedVariableBitLengthType(1, 6));
 	}
 
-	private <T extends RealType<T>> void assertDefaultInvert(final Img<T> in,
-		final Img<T> out)
+	@Test
+	public void testUnsignedVariableBitLengthTypeToUnsigned12BitTypeInvert() {
+		final Img<UnsignedVariableBitLengthType> inUnsignedVariableBitLengthType =
+			generateUnsignedVariableBitLengthTypeArrayTestImg(true, 64, 5, 5);
+		final Img<Unsigned12BitType> outUnsigned12BitType =
+			generateUnsigned12BitArrayTestImg(true, 5, 5);
+		assertIntegerInvert(inUnsignedVariableBitLengthType, outUnsigned12BitType);
+		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
+			outUnsigned12BitType, new UnsignedVariableBitLengthType(4100, 13),
+			new UnsignedVariableBitLengthType(4500, 13));
+	}
+
+	private <I extends RealType<I>, O extends RealType<O>> void
+		assertDefaultInvert(final Img<I> in, final Img<O> out)
 	{
 
-		final T type = in.firstElement();
-		final T min = type.copy();
+		final I type = in.firstElement();
+		final I min = type.copy();
 		min.setReal(type.getMinValue());
-		final T max = type.copy();
+		final I max = type.copy();
 		max.setReal(type.getMaxValue());
 		ops.run(InvertII.class, out, in);
 
 		defaultCompare(in, out, min, max);
 	}
 
-	private <T extends RealType<T>> void assertDefaultInvertMinMaxProvided(
-		final Img<T> in, final Img<T> out, final RealType<T> min,
-		final RealType<T> max)
+	private <I extends RealType<I>, O extends RealType<O>> void
+		assertDefaultInvertMinMaxProvided(final Img<I> in, final Img<O> out,
+			final RealType<I> min, final RealType<I> max)
 	{
 
 		ops.run(InvertII.class, out, in, (min), (max));
 
-		defaultCompare(in, out, (T) min, (T) max);
+		defaultCompare(in, out, (I) min, (I) max);
 	}
 
-	private <T extends RealType<T>> void defaultCompare(final Img<T> in,
-		final Img<T> out, final T min, final T max)
+	private <I extends RealType<I>, O extends RealType<O>> void defaultCompare(
+		final Img<I> in, final Img<O> out, final I min, final I max)
 	{
-		final Cursor<T> inAccess = in.localizingCursor();
-		final RandomAccess<T> outAccess = out.randomAccess();
+		final Cursor<I> inAccess = in.localizingCursor();
+		final RandomAccess<O> outAccess = out.randomAccess();
 		while (inAccess.hasNext()) {
-			final T inVal = inAccess.next();
+			final I inVal = inAccess.next();
 			outAccess.setPosition(inAccess);
-			final T outVal = outAccess.get();
+			final O outVal = outAccess.get();
 			final double bigIn = inVal.getRealDouble();
 			final double minMax = min.getRealDouble() + max.getRealDouble() - bigIn;
 			final double bigOut = outVal.getRealDouble();
-			if (bigIn >= inVal.getMaxValue() || minMax <= inVal.getMinValue())
-				assertEquals(inVal.getMinValue(), bigOut, 0.00005);
-			else if (bigIn <= inVal.getMinValue() || minMax >= inVal.getMaxValue())
-				assertEquals(inVal.getMaxValue(), bigOut, 0.00005);
-			else {
-
-				assertEquals(minMax, bigOut, 0.00005);
-
-			}
+			final O minMaxType = outVal.createVariable();
+			minMaxType.setReal(minMax);
+			if (minMax <= outVal.getMinValue()) assertEquals(outVal.getMinValue(),
+				bigOut, 0.00005);
+			else if (minMax >= outVal.getMaxValue()) assertEquals(outVal
+				.getMaxValue(), bigOut, 0.00005);
+			else assertEquals(minMaxType, outVal);
 		}
 	}
 
-	private <T extends IntegerType<T>> void assertIntegerInvertMinMaxProvided(
-		final Img<T> in, final Img<T> out, final T min, final T max)
+	private <I extends IntegerType<I>, O extends IntegerType<O>> void
+		assertIntegerInvertMinMaxProvided(final Img<I> in, final Img<O> out,
+			final I min, final I max)
 	{
 
 		// unsigned type test
@@ -364,8 +451,8 @@ public class InvertTest extends AbstractOpTest {
 
 	}
 
-	private <T extends IntegerType<T>> void assertIntegerInvert(final Img<T> in,
-		final Img<T> out)
+	private <I extends IntegerType<I>, O extends IntegerType<O>> void
+		assertIntegerInvert(final Img<I> in, final Img<O> out)
 	{
 
 		ops.run(Ops.Image.Invert.class, out, in);
@@ -373,8 +460,9 @@ public class InvertTest extends AbstractOpTest {
 		integerCompare(in, out, null, null);
 	}
 
-	private <T extends IntegerType<T>> void integerCompare(final Img<T> in,
-		final Img<T> out, final IntegerType<T> min, final IntegerType<T> max)
+	private <I extends IntegerType<I>, O extends IntegerType<O>> void
+		integerCompare(final Img<I> in, final Img<O> out, final IntegerType<I> min,
+			final IntegerType<I> max)
 	{
 
 		// Get min/max for the output type.
@@ -384,26 +472,26 @@ public class InvertTest extends AbstractOpTest {
 			.getBigInteger();
 		BigInteger minMax = BigInteger.ZERO;
 
+		// min + max
 		if (min == null && max == null) {
-			minMax = minOut.add(maxOut); // min + max
+			minMax = InvertIIInteger.minValue(in.firstElement()).getBigInteger().add(
+				InvertIIInteger.maxValue(in.firstElement()).getBigInteger());
 		}
 		else {
 			minMax = min.getBigInteger().add(max.getBigInteger());
 		}
 
-		final Cursor<T> inAccess = in.localizingCursor();
-		final RandomAccess<T> outAccess = out.randomAccess();
+		final Cursor<I> inAccess = in.localizingCursor();
+		final RandomAccess<O> outAccess = out.randomAccess();
 		while (inAccess.hasNext()) {
-			final T inVal = inAccess.next();
+			final I inVal = inAccess.next();
 			outAccess.setPosition(inAccess);
-			final T outVal = outAccess.get();
+			final O outVal = outAccess.get();
 			final BigInteger bigIn = inVal.getBigInteger();
 			final BigInteger bigOut = outVal.getBigInteger();
 			final BigInteger calcOut = minMax.subtract(bigIn);
-			if (bigIn.compareTo(maxOut) >= 0 || calcOut.compareTo(minOut) <= 0)
-				assertEquals(minOut, bigOut);
-			else if (bigIn.compareTo(minOut) <= 0 || calcOut.compareTo(maxOut) >= 0)
-				assertEquals(maxOut, bigOut);
+			if (calcOut.compareTo(minOut) <= 0) assertEquals(minOut, bigOut);
+			else if (calcOut.compareTo(maxOut) >= 0) assertEquals(maxOut, bigOut);
 			else {
 
 				assertEquals(calcOut, bigOut);

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -32,9 +32,12 @@ package net.imagej.ops.image.invert;
 import static org.junit.Assert.assertEquals;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Pair;
 
 import org.junit.Test;
 
@@ -44,35 +47,58 @@ import org.junit.Test;
 public class InvertTest extends AbstractOpTest {
 
 	@Test
-	public void testInvertSigned() {
+	public void testInvert() {
 
 		// signed type test
 		Img<ByteType> in = generateByteArrayTestImg(true, 5, 5);
 		Img<ByteType> out = in.factory().create(in, new ByteType());
 
+		ByteType type = in.firstElement();
 		ops.run(InvertII.class, out, in);
 
 		ByteType firstIn = in.firstElement();
 		ByteType firstOut = out.firstElement();
 
-		assertEquals(firstIn.get() * -1 - 1, firstOut.get());
+		assertEquals(((int) type.getMinValue() + (int) type.getMaxValue()) - firstIn.getInteger(), firstOut
+			.getInteger());
 
 	}
 
 	@Test
-	public void testInvertUnsigned() {
+	public void testInvertMinMaxProvided() {
+
+		// unsigned type test
+		Img<UnsignedByteType> in = generateUnsignedByteArrayTestImg(true, 5, 5);
+		Img<UnsignedByteType> out = in.factory().create(in, new UnsignedByteType());
+		
+		UnsignedByteType min = new UnsignedByteType(10);
+		UnsignedByteType max = new UnsignedByteType(40);
+
+		ops.run(InvertII.class, out, in, min, max);
+
+		Pair<UnsignedByteType, UnsignedByteType> minMax = ops.stats().minMax(in);
+		UnsignedByteType firstIn = in.firstElement();
+		UnsignedByteType firstOut = out.firstElement();
+
+		assertEquals((min.getInteger() + max.getInteger()) - firstIn.getInteger(), firstOut
+			.getInteger());
+
+	}
+	
+	@Test
+	public void testInvertTypeBased() {
 
 		// unsigned type test
 		Img<UnsignedByteType> in = generateUnsignedByteArrayTestImg(true, 5, 5);
 		Img<UnsignedByteType> out = in.factory().create(in, new UnsignedByteType());
 
+		UnsignedByteType type = in.firstElement();
 		ops.run(InvertII.class, out, in);
 
 		UnsignedByteType firstIn = in.firstElement();
 		UnsignedByteType firstOut = out.firstElement();
 
-		assertEquals((int) firstIn.getMaxValue() - firstIn.getInteger(), firstOut
-			.getInteger());
+		assertEquals((int) type.getMaxValue() - firstIn.getInteger(), firstOut.getInteger());
 
 	}
 }


### PR DESCRIPTION
This PR improves invert II to work for all supported `RealTypes` within ImageJ, as well as heterogeneous type conversion. The op has been tested with all data types and imaginable data values to ensure that it can work with whatever is needed. The fix contains two ops, one for smaller types (i.e. `DoubleType` and smaller) and the other for the larger types. The ops can be called with either a minimum and maximum, and the op will invert the data around the mean of the two numbers, or it can be called with no given minimum and maximum, where the data will be inverted around the center of the input image data type range.

This commit is ready for review but cannot be merged because it depends on a snapshot of ImgLib2. The dependency was changed due to a miscast `ShortType` operation and as such it cannot be merged to master until a new version of ImgLib2 is released.