### PR TITLE
Add Views.concatenate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>14.0.0</version>
+		<version>16.2.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/net/imagej/ops/transform/TransformNamespace.java
+++ b/src/main/java/net/imagej/ops/transform/TransformNamespace.java
@@ -45,6 +45,8 @@ import net.imagej.ops.transform.collapseRealView.DefaultCollapseReal2CompositeIn
 import net.imagej.ops.transform.collapseRealView.DefaultCollapseReal2CompositeView;
 import net.imagej.ops.transform.collapseView.DefaultCollapse2CompositeIntervalView;
 import net.imagej.ops.transform.collapseView.DefaultCollapse2CompositeView;
+import net.imagej.ops.transform.concatenateView.ConcatenateViewWithAccessMode;
+import net.imagej.ops.transform.concatenateView.DefaultConcatenateView;
 import net.imagej.ops.transform.dropSingletonDimensionsView.DefaultDropSingletonDimensionsView;
 import net.imagej.ops.transform.extendBorderView.DefaultExtendBorderView;
 import net.imagej.ops.transform.extendMirrorDoubleView.DefaultExtendMirrorDoubleView;
@@ -115,6 +117,7 @@ import org.scijava.plugin.Plugin;
 
 /**
  * @author Tim-Oliver Buchholz (University of Konstanz)
+ * @author Philipp Hanslovsky
  *
  * All method descriptions are from {@link net.imglib2.view.Views}.
  */
@@ -1024,6 +1027,53 @@ public class TransformNamespace extends AbstractNamespace {
 	@Override
 	public String getName() {
 		return "transform";
+	}
+
+	/**
+	 * Concatenate {@link List} of {@link RandomAccessibleInterval} along the
+	 * specified axis.
+	 *
+	 * @param input
+	 *            a list of <em>n</em>-dimensional
+	 *            {@link RandomAccessibleInterval} with same size in every
+	 *            dimension except for the concatenation dimension.
+	 * @param concatenationAxis
+	 *            Concatenate along this dimension.
+	 * @return <em>n</em>-dimensional {@link RandomAccessibleInterval}. The size
+	 *         of the concatenation dimension is the sum of sizes of all sources
+	 *         in that dimension.
+	 *
+	 */
+	@OpMethod( op = net.imagej.ops.transform.concatenateView.DefaultConcatenateView.class )
+	public < T extends Type< T > > RandomAccessibleInterval< T > concatenateView(
+			final List< ? extends RandomAccessibleInterval< T > > source,
+					final int concatenationAxis )
+	{
+		return ( RandomAccessibleInterval< T > ) ops().run( DefaultConcatenateView.class, source, concatenationAxis );
+	}
+
+	/**
+	 * Concatenate {@link List} of {@link RandomAccessibleInterval} along the
+	 * specified axis.
+	 *
+	 * @param input
+	 *            a list of <em>n</em>-dimensional
+	 *            {@link RandomAccessibleInterval} with same size in every
+	 *            dimension except for the concatenation dimension.
+	 * @param concatenationAxis
+	 *            Concatenate along this dimension.
+	 * @return <em>n</em>-dimensional {@link RandomAccessibleInterval}. The size
+	 *         of the concatenation dimension is the sum of sizes of all sources
+	 *         in that dimension.
+	 *
+	 */
+	@OpMethod( op = net.imagej.ops.transform.concatenateView.ConcatenateViewWithAccessMode.class )
+	public < T extends Type< T > > RandomAccessibleInterval< T > concatenateView(
+			final List< ? extends RandomAccessibleInterval< T > > source,
+					final int concatenationAxis,
+					final StackAccessMode mode )
+	{
+		return ( RandomAccessibleInterval< T > ) ops().run( ConcatenateViewWithAccessMode.class, source, concatenationAxis, mode );
 	}
 
 }

--- a/src/main/java/net/imagej/ops/transform/concatenateView/ConcatenateViewWithAccessMode.java
+++ b/src/main/java/net/imagej/ops/transform/concatenateView/ConcatenateViewWithAccessMode.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,30 +28,40 @@
  * #L%
  */
 
-package net.imagej.ops.transform.stackView;
+package net.imagej.ops.transform.concatenateView;
 
 import java.util.List;
 
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.view.StackView.StackAccessMode;
 import net.imglib2.view.Views;
 
 /**
- * Wraps the {@link Views#stack(List)} method.
+ * Wraps the {@link Views#concatenate(int, StackAccessMode, List)} method.
  *
- * @author Tim-Oliver Buchholz (University of Konstanz)
+ * @author Philipp Hanslovsky
  */
-@Plugin(type = Ops.Transform.StackView.class)
-public class DefaultStackView<T>
-		extends AbstractUnaryFunctionOp<List<RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>>
-		implements Ops.Transform.StackView {
+@Plugin( type = Ops.Transform.ConcatenateView.class )
+public class ConcatenateViewWithAccessMode<T>
+extends AbstractUnaryFunctionOp< List< ? extends RandomAccessibleInterval< T > >, RandomAccessibleInterval< T > >
+implements Ops.Transform.ConcatenateView
+{
+
+	@Parameter
+	private int concatenationAxis;
+
+	@Parameter
+	private StackAccessMode stackAccessMode;
 
 	@Override
-	public RandomAccessibleInterval<T> calculate(final List<RandomAccessibleInterval<T>> input) {
-		return Views.stack(input);
+	public RandomAccessibleInterval< T > calculate( final List< ? extends RandomAccessibleInterval< T > > input )
+	{
+		return Views.concatenate( concatenationAxis, stackAccessMode, input );
 	}
 
 }

--- a/src/main/java/net/imagej/ops/transform/concatenateView/DefaultConcatenateView.java
+++ b/src/main/java/net/imagej/ops/transform/concatenateView/DefaultConcatenateView.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,10 +28,11 @@
  * #L%
  */
 
-package net.imagej.ops.transform.stackView;
+package net.imagej.ops.transform.concatenateView;
 
 import java.util.List;
 
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import net.imagej.ops.Ops;
@@ -40,18 +41,23 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.view.Views;
 
 /**
- * Wraps the {@link Views#stack(List)} method.
+ * Wraps the {@link Views#concatenate(int, List)} method.
  *
- * @author Tim-Oliver Buchholz (University of Konstanz)
+ * @author Philipp Hanslovsky
  */
-@Plugin(type = Ops.Transform.StackView.class)
-public class DefaultStackView<T>
-		extends AbstractUnaryFunctionOp<List<RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>>
-		implements Ops.Transform.StackView {
+@Plugin( type = Ops.Transform.ConcatenateView.class )
+public class DefaultConcatenateView<T>
+		extends AbstractUnaryFunctionOp< List< ? extends RandomAccessibleInterval< T > >, RandomAccessibleInterval< T > >
+implements Ops.Transform.ConcatenateView
+{
+
+	@Parameter
+	private int concatenationAxis;
 
 	@Override
-	public RandomAccessibleInterval<T> calculate(final List<RandomAccessibleInterval<T>> input) {
-		return Views.stack(input);
+	public RandomAccessibleInterval< T > calculate( final List< ? extends RandomAccessibleInterval< T > > input )
+	{
+		return Views.concatenate( concatenationAxis, input );
 	}
 
 }

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -413,6 +413,7 @@ namespaces = ```
 		[name: "scaleView",                      iface: "ScaleView",                      aliases: ["resizeView"]],
 		[name: "shearView",                      iface: "ShearView"],
 		[name: "stackView",                      iface: "StackView"],
+		[name: "concatenateView",                iface: "ConcatenateView"],
 		[name: "subsampleView",                  iface: "SubsampleView"],
 		[name: "translateView",                  iface: "TranslateView"],
 		[name: "unshearView",                    iface: "UnshearView"],

--- a/src/test/java/net/imagej/ops/transform/concatenateView/ConcatenateViewTest.java
+++ b/src/test/java/net/imagej/ops/transform/concatenateView/ConcatenateViewTest.java
@@ -51,7 +51,7 @@ import net.imglib2.view.StackView.StackAccessMode;
 import net.imglib2.view.Views;
 
 /**
- * Tests {@link net.imagej.ops.Ops.Transform.CompositeView} ops.
+ * Tests {@link net.imagej.ops.Ops.Transform.ConcatenateView} ops.
  * <p>
  * This test only checks if the op call works with all parameters and that the
  * result is equal to that of the {@link Views} method call. It is not a

--- a/src/test/java/net/imagej/ops/transform/concatenateView/ConcatenateViewTest.java
+++ b/src/test/java/net/imagej/ops/transform/concatenateView/ConcatenateViewTest.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.ops.transform.concatenateView;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.operators.ValueEquals;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Pair;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.StackView.StackAccessMode;
+import net.imglib2.view.Views;
+
+/**
+ * Tests {@link net.imagej.ops.Ops.Transform.CompositeView} ops.
+ * <p>
+ * This test only checks if the op call works with all parameters and that the
+ * result is equal to that of the {@link Views} method call. It is not a
+ * correctness test of {@link Views} itself.
+ * </p>
+ *
+ * @author Philipp Hanslovsky
+ */
+public class ConcatenateViewTest extends AbstractOpTest {
+
+	private final long[] dim = { 3, 4, 5, 6 };
+
+	private final long divider = 3;
+
+	private final int axis = 3;final long numElements = Intervals.numElements( dim );
+	final Random rng = new Random();
+	final byte[] data = new byte[ ( int ) numElements ];
+	final ArrayImg< ByteType, ByteArray > img = ArrayImgs.bytes( data, dim );
+
+	@Before
+	public void fillData()
+	{
+		rng.nextBytes( data );
+	}
+
+	private < T > List< RandomAccessibleInterval< T > > createIntervals( final RandomAccessibleInterval< T > source, final long divider, final int axis )
+	{
+		final long[] min = Intervals.minAsLongArray( source );
+		final long[] max = Intervals.maxAsLongArray( source );
+		final long[] min1 = min.clone();
+		final long[] min2 = min.clone();
+		final long[] max1 = max.clone();
+		final long[] max2 = max.clone();
+		max1[ axis ] = divider;
+		min2[ axis ] = divider + 1;
+		final IntervalView< T > interval1 = Views.interval( source, min1, max1 );
+		final IntervalView< T > interval2 = Views.interval( source, min2, max2 );
+
+		return Arrays.asList( interval1, interval2 );
+	}
+
+	private static < T extends ValueEquals< T > > void testEqual( final RandomAccessibleInterval< T > rai1, final RandomAccessibleInterval< T > rai2 )
+	{
+		Assert.assertArrayEquals( Intervals.minAsLongArray( rai1 ), Intervals.minAsLongArray( rai2 ) );
+		Assert.assertArrayEquals( Intervals.maxAsLongArray( rai1 ), Intervals.maxAsLongArray( rai2 ) );
+		for ( final Pair< T, T > p : Views.interval( Views.pair( rai1, rai2 ), rai1 ) )
+			Assert.assertTrue( p.getA().valueEquals( p.getB() ) );
+	}
+
+	@Test
+	public void defaultConcatenateTest() {
+		final List< RandomAccessibleInterval< ByteType > > intervals = createIntervals( img, divider, axis );
+		final RandomAccessibleInterval< ByteType > cat1 = Views.concatenate( axis, intervals );
+		final RandomAccessibleInterval< ByteType > cat2 = ops.transform().concatenateView( intervals, axis );
+		testEqual( cat1, cat2 );
+
+	}
+
+	@Test
+	public void concatenateWithAccessModeTest() {
+		final List< RandomAccessibleInterval< ByteType > > intervals = createIntervals( img, divider, axis );
+		for ( final StackAccessMode mode : StackAccessMode.values() )
+		{
+			final RandomAccessibleInterval< ByteType > cat1 = Views.concatenate( axis, mode, intervals );
+			final RandomAccessibleInterval< ByteType > cat2 = ops.transform().concatenateView( intervals, axis, mode );
+			testEqual( cat1, cat2 );
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds the ConcatenateView op (see issue #500) and tests for its functionality.

This PR also bumps the parent pom to version 16.2.0 to use necessary concatenate operations from ImgLib2.