### PR TITLE
Bilateral Filter op

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -133,6 +133,28 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	/**
+	 * Executes a bilateral filter on the given arguments.
+	 * 
+	 * @param in
+	 * @param out
+	 * @param m_SigmaR
+	 * @param m_SigmaS
+	 * @param m_radius
+	 * @return
+	 */
+	@OpMethod(op = net.imagej.ops.filter.bilateral.DefaultBilateral.class)
+	public <I extends RealType<I>, O extends RealType<O>> RandomAccessibleInterval<O>
+		bilateral(final RandomAccessibleInterval<O> out,
+			final RandomAccessibleInterval<I> in, final double m_SigmaR,
+			final double m_SigmaS, final int m_radius)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result = (RandomAccessibleInterval<O>) ops().run(
+			Ops.Filter.Bilateral.class, out, in, m_SigmaR, m_SigmaS, m_radius);
+		return result;
+	}
+
 	// -- convolve --
 	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveFFTF.class,

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -138,20 +138,20 @@ public class FilterNamespace extends AbstractNamespace {
 	 * 
 	 * @param in
 	 * @param out
-	 * @param m_SigmaR
-	 * @param m_SigmaS
-	 * @param m_radius
+	 * @param sigmaR
+	 * @param sigmaS
+	 * @param radius
 	 * @return
 	 */
 	@OpMethod(op = net.imagej.ops.filter.bilateral.DefaultBilateral.class)
 	public <I extends RealType<I>, O extends RealType<O>> RandomAccessibleInterval<O>
 		bilateral(final RandomAccessibleInterval<O> out,
-			final RandomAccessibleInterval<I> in, final double m_SigmaR,
-			final double m_SigmaS, final int m_radius)
+			final RandomAccessibleInterval<I> in, final double sigmaR,
+			final double sigmaS, final int radius)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result = (RandomAccessibleInterval<O>) ops().run(
-			Ops.Filter.Bilateral.class, out, in, m_SigmaR, m_SigmaS, m_radius);
+			Ops.Filter.Bilateral.class, out, in, sigmaR, sigmaS, radius);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -42,6 +42,7 @@ import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodFactory;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
 import java.util.Arrays;
@@ -162,11 +163,6 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 
 	@Override
 	public boolean conforms() {
-		long dimsIn[] = new long[in().numDimensions()];
-		in().dimensions(dimsIn);
-		long dimsOut[] = new long[out().numDimensions()];
-		out().dimensions(dimsOut);
-		
-		return (in().numDimensions() == 2 && Arrays.equals(dimsIn, dimsOut));
+		return (in().numDimensions() == 2 && Intervals.equalDimensions(in(), out()));
 	}
 }

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -48,7 +48,12 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Performs a bilateral filter on an image
+ * Performs a bilateral filter on an image. The parameter m_SigmaS refers to the
+ * spatial smoothing parameter; the greater the sigma, the smoother the image.
+ * The parameter m_SigmaR refers to the range smoothing parameter. The greater
+ * the sigma, the greater the effect of intensity differences. The parameter
+ * m_radius refers to the square that is considered when doing the filter on
+ * each individual picture.
  *
  * @author Gabe Selzer
  * @param <I>

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -30,6 +30,7 @@
 
 package net.imagej.ops.filter.bilateral;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imglib2.Cursor;
@@ -59,7 +60,7 @@ import org.scijava.plugin.Plugin;
 public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 	extends
 	AbstractUnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
-	implements Ops.Filter.Bilateral
+	implements Ops.Filter.Bilateral, Contingent
 {
 
 	public final static int MIN_DIMS = 2;
@@ -96,9 +97,6 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 	public void compute(final RandomAccessibleInterval<I> input,
 		final RandomAccessibleInterval<O> output)
 	{
-		if (input.numDimensions() != 2) {
-			throw new IllegalArgumentException("Input must be two dimensional");
-		}
 
 		final long[] size = new long[input.numDimensions()];
 		input.dimensions(size);
@@ -113,6 +111,7 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 		final long mma2 = input.max(1);
 		Neighborhood<I> rn;
 		Cursor<I> cq;
+		final RectangleNeighborhoodFactory<I> fac = RectangleNeighborhood.factory();
 		while (cp.hasNext()) {
 			cp.fwd();
 			cp.localize(p);
@@ -124,8 +123,6 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 			ma[0] = Math.min(mma1, ma[0] + radius);
 			ma[1] = Math.min(mma2, ma[1] + radius);
 			final Interval in = new FinalInterval(mi, ma);
-			final RectangleNeighborhoodFactory<I> fac = RectangleNeighborhood
-				.factory();
 			rn = fac.create(p, mi, ma, in, input.randomAccess());
 			cq = rn.localizingCursor();
 			double s, v = 0.0;
@@ -150,5 +147,10 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 			cr.get().setReal(v / w);
 		}
 
+	}
+
+	@Override
+	public boolean conforms() {
+		return (in().numDimensions() == 2);
 	}
 }

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -48,12 +48,7 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Performs a bilateral filter on an image. The sigmaS parameter refers to the
- * spatial smoothing parameter; the greater the sigma, the smoother the image.
- * The sigmaR parameter refers to the range smoothing parameter. The greater the
- * sigma, the greater the effect of intensity differences. The radius parameter
- * refers to the square that is considered when doing the filter on each
- * individual picture.
+ * Performs a bilateral filter on an image.
  *
  * @author Gabe Selzer
  * @param <I>
@@ -71,12 +66,23 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 
 	public final static int MAX_DIMS = 2;
 
+	/**
+	 * refers to the range smoothing parameter; the greater the sigma, the greater
+	 * the effect of intensity differences.
+	 */
 	@Parameter
 	private double sigmaR;
 
+	/**
+	 * refers to the spatial smoothing parameter; the greater the sigma, the
+	 * smoother the image.
+	 */
 	@Parameter
 	private double sigmaS;
 
+	/**
+	 * refers to the square that is considered when doing the filter on each individual picture.
+	 */
 	@Parameter
 	private int radius;
 

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -1,0 +1,143 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.bilateral;
+
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.Neighborhood;
+import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
+import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodFactory;
+import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodSkipCenter;
+import net.imglib2.outofbounds.OutOfBoundsFactory;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import net.imagej.ops.Ops;
+
+/**
+ * Performs a bilateral filter on an image
+ * 
+ * @author Gabe Selzer
+ * @param <I>
+ * @param <O>
+ */
+
+@Plugin(type = Ops.Filter.Bilateral.class, priority = Priority.NORMAL_PRIORITY)
+public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractUnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
+	implements Ops.Filter.Bilateral
+{
+
+	public final static int MIN_DIMS = 2;
+
+	public final static int MAX_DIMS = 2;
+
+	@Parameter
+	private double m_sigmaR;
+
+	@Parameter
+	private double m_sigmaS;
+
+	@Parameter
+	private int m_radius;
+
+	private static double gauss(final double x, final double sigma) {
+		final double mu = 0.0;
+		return (1 / (sigma * Math.sqrt(2 * Math.PI))) * Math.exp((-0.5 * (x - mu) *
+			(x - mu)) / (sigma * sigma));
+	}
+
+	@Override
+	public void compute(final RandomAccessibleInterval<I> input,
+		final RandomAccessibleInterval<O> output)
+	{
+		if (input.numDimensions() != 2) {
+			throw new IllegalArgumentException("Input must be two dimensional");
+		}
+
+		final long[] size = new long[input.numDimensions()];
+		input.dimensions(size);
+
+		final RandomAccess<O> cr = output.randomAccess();
+		final Cursor<I> cp = Views.iterable(input).localizingCursor();
+		final long[] p = new long[input.numDimensions()];
+		final int[] q = new int[input.numDimensions()];
+		final long[] mi = new long[input.numDimensions()];
+		final long[] ma = new long[input.numDimensions()];
+		final long mma1 = input.max(0);
+		final long mma2 = input.max(1);
+		Neighborhood<I> rn;
+		Cursor<I> cq;
+		while (cp.hasNext()) {
+			cp.fwd();
+			cp.localize(p);
+			double d;
+			cp.localize(mi);
+			cp.localize(ma);
+			mi[0] = Math.max(0, mi[0] - m_radius);
+			mi[1] = Math.max(0, mi[1] - m_radius);
+			ma[0] = Math.min(mma1, ma[0] + m_radius);
+			ma[1] = Math.min(mma2, ma[1] + m_radius);
+			final Interval in = new FinalInterval(mi, ma);
+			RectangleNeighborhoodFactory<I> fac = RectangleNeighborhood.factory();
+			rn = fac.create(p, mi, ma, in, input.randomAccess());
+			cq = rn.localizingCursor();
+			double s, v = 0.0;
+			double w = 0.0;
+			do {
+				cq.fwd();
+				cq.localize(q);
+				d = ((p[0] - q[0] - mi[0]) * (p[0] - q[0] - mi[0])) + ((p[1] - q[1] -
+					mi[1]) * (p[1] - q[1] - mi[1]));
+				d = Math.sqrt(d);//distance between pixels
+				s = gauss(d, m_sigmaS);//spatial kernel
+
+				d = Math.abs(cp.get().getRealDouble() - cq.get().getRealDouble());//intensity difference
+				s *= gauss(d, m_sigmaR);//range kernel, then exponent addition
+
+				v += s * cq.get().getRealDouble();
+				w += s;
+			} while (cq.hasNext());
+			cr.setPosition(p);
+			cr.get().setReal(v / w);
+		}
+
+	}
+}

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -94,6 +94,20 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 		return (1 / (sigma * Math.sqrt(2 * Math.PI))) * Math.exp((-0.5 * (x - mu) *
 			(x - mu)) / (sigma * sigma));
 	}
+	
+	private double getDistance(long[] x, long[] y) {
+		double distance = 0;
+
+		for (int i = 0; i < x.length; i++) {
+			double separation = (x[i] - y[i]);
+			if (separation != 0) {
+				distance += (separation * separation);
+			}
+
+		}
+
+		return Math.sqrt(distance);
+	}
 
 	@Override
 	public void compute(final RandomAccessibleInterval<I> input,
@@ -130,11 +144,7 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 			do {
 				neighborhoodCursor.fwd();
 				neighborhoodCursor.localize(neighborhoodPos);
-				distance = ((currentPos[0] - neighborhoodPos[0] - neighborhoodMin[0])
-						* (currentPos[0] - neighborhoodPos[0] - neighborhoodMin[0]))
-						+ ((currentPos[1] - neighborhoodPos[1] - neighborhoodMin[1])
-								* (currentPos[1] - neighborhoodPos[1] - neighborhoodMin[1]));
-				distance = Math.sqrt(distance);// distance between pixels
+				distance = getDistance(currentPos, neighborhoodPos);
 				weight = gauss(distance, sigmaS);// spatial kernel
 
 				distance = Math.abs(inputCursor.get().getRealDouble() - neighborhoodCursor.get().getRealDouble());// intensity

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -163,6 +163,6 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 
 	@Override
 	public boolean conforms() {
-		return (in().numDimensions() == 2 && Intervals.equalDimensions(in(), out()));
+		return (Intervals.equalDimensions(in(), out()));
 	}
 }

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -48,12 +48,12 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Performs a bilateral filter on an image. The parameter m_SigmaS refers to the
+ * Performs a bilateral filter on an image. The sigmaS parameter refers to the
  * spatial smoothing parameter; the greater the sigma, the smoother the image.
- * The parameter m_SigmaR refers to the range smoothing parameter. The greater
- * the sigma, the greater the effect of intensity differences. The parameter
- * m_radius refers to the square that is considered when doing the filter on
- * each individual picture.
+ * The sigmaR parameter refers to the range smoothing parameter. The greater the
+ * sigma, the greater the effect of intensity differences. The radius parameter
+ * refers to the square that is considered when doing the filter on each
+ * individual picture.
  *
  * @author Gabe Selzer
  * @param <I>
@@ -72,13 +72,13 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 	public final static int MAX_DIMS = 2;
 
 	@Parameter
-	private double m_sigmaR;
+	private double sigmaR;
 
 	@Parameter
-	private double m_sigmaS;
+	private double sigmaS;
 
 	@Parameter
-	private int m_radius;
+	private int radius;
 
 	private static double gauss(final double x, final double sigma) {
 		final double mu = 0.0;
@@ -113,10 +113,10 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 			double d;
 			cp.localize(mi);
 			cp.localize(ma);
-			mi[0] = Math.max(0, mi[0] - m_radius);
-			mi[1] = Math.max(0, mi[1] - m_radius);
-			ma[0] = Math.min(mma1, ma[0] + m_radius);
-			ma[1] = Math.min(mma2, ma[1] + m_radius);
+			mi[0] = Math.max(0, mi[0] - radius);
+			mi[1] = Math.max(0, mi[1] - radius);
+			ma[0] = Math.min(mma1, ma[0] + radius);
+			ma[1] = Math.min(mma2, ma[1] + radius);
 			final Interval in = new FinalInterval(mi, ma);
 			final RectangleNeighborhoodFactory<I> fac = RectangleNeighborhood
 				.factory();
@@ -130,11 +130,11 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 				d = ((p[0] - q[0] - mi[0]) * (p[0] - q[0] - mi[0])) + ((p[1] - q[1] -
 					mi[1]) * (p[1] - q[1] - mi[1]));
 				d = Math.sqrt(d);// distance between pixels
-				s = gauss(d, m_sigmaS);// spatial kernel
+				s = gauss(d, sigmaS);// spatial kernel
 
 				d = Math.abs(cp.get().getRealDouble() - cq.get().getRealDouble());// intensity
 																																					// difference
-				s *= gauss(d, m_sigmaR);// range kernel, then exponent addition
+				s *= gauss(d, sigmaR);// range kernel, then exponent addition
 
 				v += s * cq.get().getRealDouble();
 				w += s;

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -30,18 +30,16 @@
 
 package net.imagej.ops.filter.bilateral;
 
+import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodFactory;
-import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodSkipCenter;
-import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
@@ -49,11 +47,9 @@ import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-import net.imagej.ops.Ops;
-
 /**
  * Performs a bilateral filter on an image
- * 
+ *
  * @author Gabe Selzer
  * @param <I>
  * @param <O>
@@ -61,7 +57,8 @@ import net.imagej.ops.Ops;
 
 @Plugin(type = Ops.Filter.Bilateral.class, priority = Priority.NORMAL_PRIORITY)
 public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
-	extends AbstractUnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
+	extends
+	AbstractUnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
 	implements Ops.Filter.Bilateral
 {
 
@@ -116,7 +113,8 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 			ma[0] = Math.min(mma1, ma[0] + m_radius);
 			ma[1] = Math.min(mma2, ma[1] + m_radius);
 			final Interval in = new FinalInterval(mi, ma);
-			RectangleNeighborhoodFactory<I> fac = RectangleNeighborhood.factory();
+			final RectangleNeighborhoodFactory<I> fac = RectangleNeighborhood
+				.factory();
 			rn = fac.create(p, mi, ma, in, input.randomAccess());
 			cq = rn.localizingCursor();
 			double s, v = 0.0;
@@ -126,15 +124,17 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 				cq.localize(q);
 				d = ((p[0] - q[0] - mi[0]) * (p[0] - q[0] - mi[0])) + ((p[1] - q[1] -
 					mi[1]) * (p[1] - q[1] - mi[1]));
-				d = Math.sqrt(d);//distance between pixels
-				s = gauss(d, m_sigmaS);//spatial kernel
+				d = Math.sqrt(d);// distance between pixels
+				s = gauss(d, m_sigmaS);// spatial kernel
 
-				d = Math.abs(cp.get().getRealDouble() - cq.get().getRealDouble());//intensity difference
-				s *= gauss(d, m_sigmaR);//range kernel, then exponent addition
+				d = Math.abs(cp.get().getRealDouble() - cq.get().getRealDouble());// intensity
+																																					// difference
+				s *= gauss(d, m_sigmaR);// range kernel, then exponent addition
 
 				v += s * cq.get().getRealDouble();
 				w += s;
-			} while (cq.hasNext());
+			}
+			while (cq.hasNext());
 			cr.setPosition(p);
 			cr.get().setReal(v / w);
 		}

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -30,6 +30,10 @@
 
 package net.imagej.ops.filter.bilateral;
 
+import org.scijava.Priority;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
@@ -45,12 +49,6 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
-import java.util.Arrays;
-
-import org.scijava.Priority;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-
 /**
  * Performs a bilateral filter on an image.
  *
@@ -61,10 +59,8 @@ import org.scijava.plugin.Plugin;
 
 @Plugin(type = Ops.Filter.Bilateral.class, priority = Priority.NORMAL_PRIORITY)
 public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
-	extends
-	AbstractUnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
-	implements Ops.Filter.Bilateral, Contingent
-{
+		extends AbstractUnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
+		implements Ops.Filter.Bilateral, Contingent {
 
 	public final static int MIN_DIMS = 2;
 
@@ -85,17 +81,17 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 	private double sigmaS;
 
 	/**
-	 * refers to the square that is considered when doing the filter on each individual picture.
+	 * refers to the square that is considered when doing the filter on each
+	 * individual picture.
 	 */
 	@Parameter
 	private int radius;
 
 	private static double gauss(final double x, final double sigma) {
 		final double mu = 0.0;
-		return (1 / (sigma * Math.sqrt(2 * Math.PI))) * Math.exp((-0.5 * (x - mu) *
-			(x - mu)) / (sigma * sigma));
+		return (1 / (sigma * Math.sqrt(2 * Math.PI))) * Math.exp((-0.5 * (x - mu) * (x - mu)) / (sigma * sigma));
 	}
-	
+
 	private double getDistance(long[] x, long[] y) {
 		double distance = 0;
 
@@ -111,9 +107,7 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 	}
 
 	@Override
-	public void compute(final RandomAccessibleInterval<I> input,
-		final RandomAccessibleInterval<O> output)
-	{
+	public void compute(final RandomAccessibleInterval<I> input, final RandomAccessibleInterval<O> output) {
 
 		final long[] size = new long[input.numDimensions()];
 		input.dimensions(size);

--- a/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
+++ b/src/main/java/net/imagej/ops/filter/bilateral/DefaultBilateral.java
@@ -44,6 +44,8 @@ import net.imglib2.algorithm.neighborhood.RectangleNeighborhoodFactory;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
+import java.util.Arrays;
+
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -151,6 +153,11 @@ public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 
 	@Override
 	public boolean conforms() {
-		return (in().numDimensions() == 2);
+		long dimsIn[] = new long[in().numDimensions()];
+		in().dimensions(dimsIn);
+		long dimsOut[] = new long[out().numDimensions()];
+		out().dimensions(dimsOut);
+		
+		return (in().numDimensions() == 2 && Arrays.equals(dimsIn, dimsOut));
 	}
 }

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -84,6 +84,7 @@ namespaces = ```
 	[name: "filter", iface: "Filter", ops: [
 		[name: "addNoise",                       iface: "AddNoise"],
 		[name: "addPoissonNoise",                iface: "AddPoissonNoise"],
+		[name: "bilateral",                      iface: "Bilateral"],
 		[name: "convolve",                       iface: "Convolve"],
 		[name: "correlate",                      iface: "Correlate"],
 		[name: "createFFTOutput",                iface: "CreateFFTOutput"],

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -42,6 +42,9 @@ import java.util.Random;
 
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
@@ -49,6 +52,7 @@ import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.img.cell.CellImg;
 import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -234,6 +238,18 @@ public abstract class AbstractOpTest {
 			assertEquals(e.next(), a.next());
 		}
 		assertFalse("More elements than expected", a.hasNext());
+	}
+
+	public <T extends RealType<T>> boolean areCongruent(final IterableInterval<T> in, final RandomAccessible<T> out){
+		Cursor<T> cin = in.localizingCursor();
+		RandomAccess<T> raOut = out.randomAccess();
+		
+		while(cin.hasNext()){
+			cin.fwd();
+			raOut.setPosition(cin);
+			if(cin.get().getRealDouble() != raOut.get().getRealDouble()) return false;
+		}
+		return true;
 	}
 
 	public static class NoOp extends AbstractOp {

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -247,7 +247,7 @@ public abstract class AbstractOpTest {
 		while(cin.hasNext()){
 			cin.fwd();
 			raOut.setPosition(cin);
-			if((cin.get().getRealDouble() - raOut.get().getRealDouble()) > epsilon) return false;
+			if(Math.abs(cin.get().getRealDouble() - raOut.get().getRealDouble()) > epsilon) return false;
 		}
 		return true;
 	}

--- a/src/test/java/net/imagej/ops/AbstractOpTest.java
+++ b/src/test/java/net/imagej/ops/AbstractOpTest.java
@@ -240,14 +240,14 @@ public abstract class AbstractOpTest {
 		assertFalse("More elements than expected", a.hasNext());
 	}
 
-	public <T extends RealType<T>> boolean areCongruent(final IterableInterval<T> in, final RandomAccessible<T> out){
+	public <T extends RealType<T>> boolean areCongruent(final IterableInterval<T> in, final RandomAccessible<T> out, final double epsilon){
 		Cursor<T> cin = in.localizingCursor();
 		RandomAccess<T> raOut = out.randomAccess();
 		
 		while(cin.hasNext()){
 			cin.fwd();
 			raOut.setPosition(cin);
-			if(cin.get().getRealDouble() != raOut.get().getRealDouble()) return false;
+			if((cin.get().getRealDouble() - raOut.get().getRealDouble()) > epsilon) return false;
 		}
 		return true;
 	}

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -2,6 +2,7 @@ package net.imagej.ops.filter;
 
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.ByteType;
 
 import static org.junit.Assert.assertEquals;
@@ -16,14 +17,10 @@ public class DefaultBilateralTest extends AbstractOpTest{
 	
 	@Test
 	public void testBigImage(){
-		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
-		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
-		Cursor<ByteType> cin = in.cursor();
 		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 		
-		for(byte b: data){
-			cin.next().set(b);
-		}
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		
 		final byte[] expected = {8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2};
@@ -36,13 +33,10 @@ public class DefaultBilateralTest extends AbstractOpTest{
 
 	@Test
 	public void testMath(){ 
-		final Img<ByteType> in = generateByteArrayTestImg(false, 2, 2);
-		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2);
-		Cursor<ByteType> cin = in.cursor();
 		final byte[] data = {7, 4, 9, 1};
-		for(byte b: data){
-			cin.next().set(b);
-		}
+		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 2);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2);
+
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 1);
 		
 		Cursor<ByteType> cout = out.cursor();
@@ -56,15 +50,12 @@ public class DefaultBilateralTest extends AbstractOpTest{
 
 	@Test
 	public void testArrayToCellImg(){
-		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+
+		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 		final Img<ByteType> cellOut = generateByteTestCellImg(false, 6, 6);
-		Cursor<ByteType> cin = in.localizingCursor();
-		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
-
-		for(byte b: data){
-			cin.next().set(b);
-		}
+		
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		ops.run(DefaultBilateral.class, cellOut, in, 15, 5, 2);
 
@@ -79,15 +70,11 @@ public class DefaultBilateralTest extends AbstractOpTest{
 
 	@Test
 	public void testGaussianVsBilateral(){
-		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> gaussOut = generateByteArrayTestImg(false, 6, 6);
 		final Img<ByteType> bilateralOut = generateByteTestCellImg(false, 6, 6);
-		Cursor<ByteType> cin = in.localizingCursor();
-		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
-
-		for(byte b: data){
-			cin.next().set(b);
-		}
+		
 		ops.run(DefaultBilateral.class, bilateralOut, in, 15, 5, 2);
 		final double sigma = 5;
 		ops.run(GaussRAISingleSigma.class, gaussOut, in, sigma);
@@ -96,14 +83,10 @@ public class DefaultBilateralTest extends AbstractOpTest{
 
 	@Test
 	public void testZeroes() {
-		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
-		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
-		Cursor<ByteType> cin = in.localizingCursor();
 		final byte[] data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 
-		for(byte b: data){
-			cin.next().set(b);
-		}
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 
 		Cursor<ByteType> cout = out.cursor();
@@ -115,14 +98,10 @@ public class DefaultBilateralTest extends AbstractOpTest{
 	
 	@Test
 	public void testNegatives() {
-		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
-		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
-		Cursor<ByteType> cin = in.localizingCursor();
 		final byte[] data = {-7, -8, -9, -1, -2, -3, -7, -9, -8, -1, -3, -2, -8, -7, -9, -2, -1, -3, -8, -9, -7, -2, -3, -1, -9, -7, -8, -3, -1, -2, -9, -8, -7, -3, -2, -1};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 
-		for(byte b: data){
-			cin.next().set(b);
-		}
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		
 		final byte[] expected = {-8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2};
@@ -135,14 +114,10 @@ public class DefaultBilateralTest extends AbstractOpTest{
 	
 	@Test(expected = IllegalArgumentException.class)
 	public void testTooManyDimensions() {
-		final Img<ByteType> in = generateByteArrayTestImg(false, 2, 2, 2);
-		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2, 2);
-		Cursor<ByteType> cin = in.localizingCursor();
 		final byte[] data = {2, 2, 2, 2, 2, 2, 2, 2};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 2);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2, 2);
 
-		for(byte b: data){
-			cin.next().set(b);
-		}
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		
 		final byte[] expected = {2, 2, 2, 2, 2, 2, 2, 2};
@@ -155,14 +130,10 @@ public class DefaultBilateralTest extends AbstractOpTest{
 	
 	@Test(expected = IllegalArgumentException.class)
 	public void testMismatchedDimensions() {
-		final Img<ByteType> in = generateByteArrayTestImg(false, 2, 3);
-		final Img<ByteType> out = generateByteArrayTestImg(false, 3, 2);
-		Cursor<ByteType> cin = in.localizingCursor();
 		final byte[] data = {1, 1, 1, 1, 1, 1};
+		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 3);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 3, 2);
 
-		for(byte b: data){
-			cin.next().set(b);
-		}
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		
 		final byte[] expected = {1, 1, 1, 1, 1, 1};

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -23,7 +23,7 @@ public class DefaultBilateralTest extends AbstractOpTest{
 		
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		
-		final byte[] expected = {8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2};
+		final byte[] expected = {8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2};
 		
 		Cursor<ByteType> cout = out.cursor();
 		for(int i = 0; i < expected.length; i++){
@@ -104,7 +104,7 @@ public class DefaultBilateralTest extends AbstractOpTest{
 
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		
-		final byte[] expected = {-8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2};
+		final byte[] expected = {-8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2};
 
 		Cursor<ByteType> cout = out.cursor();
 		for(int i = 0; i < expected.length; i++){

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -78,7 +78,7 @@ public class DefaultBilateralTest extends AbstractOpTest{
 		ops.run(DefaultBilateral.class, bilateralOut, in, 15, 5, 2);
 		final double sigma = 5;
 		ops.run(GaussRAISingleSigma.class, gaussOut, in, sigma);
-		assertEquals(areCongruent(gaussOut, bilateralOut), false);
+		assertEquals(areCongruent(gaussOut, bilateralOut, 0), false);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -13,68 +13,72 @@ import net.imagej.ops.filter.gauss.GaussRAISingleSigma;
 
 import org.junit.Test;
 
-public class DefaultBilateralTest extends AbstractOpTest{
-	
+public class DefaultBilateralTest extends AbstractOpTest {
+
 	@Test
-	public void testBigImage(){
-		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+	public void testBigImage() {
+		final byte[] data = { 7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2,
+				9, 8, 7, 3, 2, 1 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
-		
+
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
-		
-		final byte[] expected = {8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2};
-		
+
+		final byte[] expected = { 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3,
+				2, 8, 7, 6, 4, 3, 2 };
+
 		Cursor<ByteType> cout = out.cursor();
-		for(int i = 0; i < expected.length; i++){
+		for (int i = 0; i < expected.length; i++) {
 			assertEquals(cout.next().get(), expected[i]);
 		}
 	}
 
 	@Test
-	public void testMath(){ 
-		final byte[] data = {7, 4, 9, 1};
+	public void testMath() {
+		final byte[] data = { 7, 4, 9, 1 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 2);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2);
 
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 1);
-		
+
 		Cursor<ByteType> cout = out.cursor();
-		final byte[] expected = {5, 5, 5, 5};
+		final byte[] expected = { 5, 5, 5, 5 };
 		int counter = 0;
-		while(cout.hasNext()){
-			byte actual = cout.next().get(); 
+		while (cout.hasNext()) {
+			byte actual = cout.next().get();
 			assertEquals(expected[counter++], actual);
 		}
 	}
 
 	@Test
-	public void testArrayToCellImg(){
+	public void testArrayToCellImg() {
 
-		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+		final byte[] data = { 7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2,
+				9, 8, 7, 3, 2, 1 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 		final Img<ByteType> cellOut = generateByteTestCellImg(false, 6, 6);
-		
+
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 		ops.run(DefaultBilateral.class, cellOut, in, 15, 5, 2);
 
 		Cursor<ByteType> cout = out.cursor();
 		Cursor<ByteType> cCellOut = cellOut.cursor();
-		while(cout.hasNext()){
+		while (cout.hasNext()) {
 			byte expected = cout.next().get();
-			byte actual = cCellOut.next().get(); 
+			byte actual = cCellOut.next().get();
 			assertEquals(expected, actual);
 		}
 	}
 
 	@Test
-	public void testGaussianVsBilateral(){
-		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+	public void testGaussianVsBilateral() {
+		final byte[] data = { 7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2,
+				9, 8, 7, 3, 2, 1 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> gaussOut = generateByteArrayTestImg(false, 6, 6);
 		final Img<ByteType> bilateralOut = generateByteTestCellImg(false, 6, 6);
-		
+
 		ops.run(DefaultBilateral.class, bilateralOut, in, 15, 5, 2);
 		final double sigma = 5;
 		ops.run(GaussRAISingleSigma.class, gaussOut, in, sigma);
@@ -83,64 +87,67 @@ public class DefaultBilateralTest extends AbstractOpTest{
 
 	@Test
 	public void testZeroes() {
-		final byte[] data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+		final byte[] data = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
 
 		Cursor<ByteType> cout = out.cursor();
-		while(cout.hasNext()){
+		while (cout.hasNext()) {
 			byte expected = cout.next().get();
 			assertEquals(expected, 0);
 		}
 	}
-	
+
 	@Test
 	public void testNegatives() {
-		final byte[] data = {-7, -8, -9, -1, -2, -3, -7, -9, -8, -1, -3, -2, -8, -7, -9, -2, -1, -3, -8, -9, -7, -2, -3, -1, -9, -7, -8, -3, -1, -2, -9, -8, -7, -3, -2, -1};
+		final byte[] data = { -7, -8, -9, -1, -2, -3, -7, -9, -8, -1, -3, -2, -8, -7, -9, -2, -1, -3, -8, -9, -7, -2,
+				-3, -1, -9, -7, -8, -3, -1, -2, -9, -8, -7, -3, -2, -1 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
 
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
-		
-		final byte[] expected = {-8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2};
+
+		final byte[] expected = { -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6,
+				-4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2 };
 
 		Cursor<ByteType> cout = out.cursor();
-		for(int i = 0; i < expected.length; i++){
+		for (int i = 0; i < expected.length; i++) {
 			assertEquals(cout.next().get(), expected[i]);
 		}
 	}
-	
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testTooManyDimensions() {
-		final byte[] data = {2, 2, 2, 2, 2, 2, 2, 2};
+		final byte[] data = { 2, 2, 2, 2, 2, 2, 2, 2 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 2);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2, 2);
 
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
-		
-		final byte[] expected = {2, 2, 2, 2, 2, 2, 2, 2};
+
+		final byte[] expected = { 2, 2, 2, 2, 2, 2, 2, 2 };
 
 		Cursor<ByteType> cout = out.cursor();
-		for(int i = 0; i < expected.length; i++){
+		for (int i = 0; i < expected.length; i++) {
 			assertEquals(cout.next().get(), expected[i]);
 		}
 	}
-	
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testMismatchedDimensions() {
-		final byte[] data = {1, 1, 1, 1, 1, 1};
+		final byte[] data = { 1, 1, 1, 1, 1, 1 };
 		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 3);
 		final Img<ByteType> out = generateByteArrayTestImg(false, 3, 2);
 
 		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
-		
-		final byte[] expected = {1, 1, 1, 1, 1, 1};
+
+		final byte[] expected = { 1, 1, 1, 1, 1, 1 };
 		Cursor<ByteType> cout = out.cursor();
-		for(int i = 0; i < expected.length; i++){
+		for (int i = 0; i < expected.length; i++) {
 			assertEquals(cout.next().get(), expected[i]);
 		}
 	}
-	
+
 }

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -1,0 +1,136 @@
+package net.imagej.ops.filter;
+
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.integer.ByteType;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.filter.bilateral.DefaultBilateral;
+import net.imagej.ops.filter.gauss.GaussRAISingleSigma;
+
+import org.junit.Test;
+
+public class DefaultBilateralTest extends AbstractOpTest{
+	
+	@Test
+	public void testBigImage(){
+		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
+		Cursor<ByteType> cin = in.cursor();
+		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+		
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
+		
+		final byte[] expected = {8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 4, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2};
+		
+		Cursor<ByteType> cout = out.cursor();
+		for(int i = 0; i < expected.length; i++){
+			assertEquals(cout.next().get(), expected[i]);
+		}
+	}
+
+	@Test
+	public void testMath(){ 
+		final Img<ByteType> in = generateByteArrayTestImg(false, 2, 2);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2);
+		Cursor<ByteType> cin = in.cursor();
+		final byte[] data = {7, 4, 9, 1};
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 1);
+		
+		Cursor<ByteType> cout = out.cursor();
+		final byte[] expected = {5, 5, 5, 5};
+		int counter = 0;
+		while(cout.hasNext()){
+			byte actual = cout.next().get(); 
+			assertEquals(expected[counter++], actual);
+		}
+	}
+
+	@Test
+	public void testArrayToCellImg(){
+		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> cellOut = generateByteTestCellImg(false, 6, 6);
+		Cursor<ByteType> cin = in.localizingCursor();
+		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
+		ops.run(DefaultBilateral.class, cellOut, in, 15, 5, 2);
+
+		Cursor<ByteType> cout = out.cursor();
+		Cursor<ByteType> cCellOut = cellOut.cursor();
+		while(cout.hasNext()){
+			byte expected = cout.next().get();
+			byte actual = cCellOut.next().get(); 
+			assertEquals(expected, actual);
+		}
+	}
+
+	@Test
+	public void testGaussianVsBilateral(){
+		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> gaussOut = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> bilateralOut = generateByteTestCellImg(false, 6, 6);
+		Cursor<ByteType> cin = in.localizingCursor();
+		final byte[] data = {7, 8, 9, 1, 2, 3, 7, 9, 8, 1, 3, 2, 8, 7, 9, 2, 1, 3, 8, 9, 7, 2, 3, 1, 9, 7, 8, 3, 1, 2, 9, 8, 7, 3, 2, 1};
+
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, bilateralOut, in, 15, 5, 2);
+		final double sigma = 5;
+		ops.run(GaussRAISingleSigma.class, gaussOut, in, sigma);
+		assertEquals(areCongruent(gaussOut, bilateralOut), false);
+	}
+
+	@Test
+	public void testZeroes() {
+		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
+		Cursor<ByteType> cin = in.localizingCursor();
+		final byte[] data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
+
+		Cursor<ByteType> cout = out.cursor();
+		while(cout.hasNext()){
+			byte expected = cout.next().get();
+			assertEquals(expected, 0);
+		}
+	}
+	
+	@Test
+	public void testNegatives() {
+		final Img<ByteType> in = generateByteArrayTestImg(false, 6, 6);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 6, 6);
+		Cursor<ByteType> cin = in.localizingCursor();
+		final byte[] data = {-7, -8, -9, -1, -2, -3, -7, -9, -8, -1, -3, -2, -8, -7, -9, -2, -1, -3, -8, -9, -7, -2, -3, -1, -9, -7, -8, -3, -1, -2, -9, -8, -7, -3, -2, -1};
+
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
+		
+		final byte[] expected = {-8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -4, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2};
+
+		Cursor<ByteType> cout = out.cursor();
+		for(int i = 0; i < expected.length; i++){
+			assertEquals(cout.next().get(), expected[i]);
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -152,5 +152,24 @@ public class DefaultBilateralTest extends AbstractOpTest{
 			assertEquals(cout.next().get(), expected[i]);
 		}
 	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testMismatchedDimensions() {
+		final Img<ByteType> in = generateByteArrayTestImg(false, 2, 3);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 3, 2);
+		Cursor<ByteType> cin = in.localizingCursor();
+		final byte[] data = {1, 1, 1, 1, 1, 1};
 
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
+		
+		final byte[] expected = {1, 1, 1, 1, 1, 1};
+		Cursor<ByteType> cout = out.cursor();
+		for(int i = 0; i < expected.length; i++){
+			assertEquals(cout.next().get(), expected[i]);
+		}
+	}
+	
 }

--- a/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
+++ b/src/test/java/net/imagej/ops/filter/DefaultBilateralTest.java
@@ -132,5 +132,25 @@ public class DefaultBilateralTest extends AbstractOpTest{
 			assertEquals(cout.next().get(), expected[i]);
 		}
 	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testTooManyDimensions() {
+		final Img<ByteType> in = generateByteArrayTestImg(false, 2, 2, 2);
+		final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2, 2);
+		Cursor<ByteType> cin = in.localizingCursor();
+		final byte[] data = {2, 2, 2, 2, 2, 2, 2, 2};
+
+		for(byte b: data){
+			cin.next().set(b);
+		}
+		ops.run(DefaultBilateral.class, out, in, 15, 5, 2);
+		
+		final byte[] expected = {2, 2, 2, 2, 2, 2, 2, 2};
+
+		Cursor<ByteType> cout = out.cursor();
+		for(int i = 0; i < expected.length; i++){
+			assertEquals(cout.next().get(), expected[i]);
+		}
+	}
 
 }


### PR DESCRIPTION
This PR adds a `BilateralFilter` op. The op takes a source input image, a source output image, a spatial smoothing parameter `m_SigmaS`, a range (intensity) parameter `m_SigmaR`, and a radius parameter `m_radius` used by the op to determine the range of pixels used for each individual filter operation. These last three parameters could potentially be set in the code and not alterable by the user, however now they are passed through with the op call. This decision was made as depending on the size of the image and the reasons the user is using the filter different radii and sigmas might be useful. As of now the filter does have its own Gaussian operation, taken from KNIME's implementation of the filter. I did look into using ImageJ's Gauss op for the filter however with the variant version of the Gaussian operation used for the Bilateral filter I do not think ImageJ's Gauss op will work. I would be happy to implement it in the Bilateral Filter if it is determined that it will work.

Closes issue #488.