### PR TITLE
Ridge Detection

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -51,6 +51,7 @@ import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.composite.CompositeIntervalView;
 import net.imglib2.view.composite.RealComposite;
 import net.imglib2.type.numeric.real.DoubleType;
@@ -623,6 +624,22 @@ public class FilterNamespace extends AbstractNamespace {
 	public long[][] fftSize(final Dimensions in1, final boolean powerOfTwo) {
 		final long[][] result = (long[][]) ops().run(Ops.Filter.FFTSize.class, in1,
 			powerOfTwo);
+		return result;
+	}
+
+	// -- derivativeGauss --
+
+	@OpMethod(
+		op = net.imagej.ops.filter.derivativeGauss.DefaultDerivativeGauss.class)
+	public <T extends RealType<T>> RandomAccessibleInterval<DoubleType>
+		derivativeGauss(final RandomAccessibleInterval<T> out,
+			final RandomAccessibleInterval<DoubleType> in, final int[] derivatives,
+			final double sigma)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<DoubleType> result =
+			(RandomAccessibleInterval<DoubleType>) ops().run(
+				Ops.Filter.DerivativeGauss.class, out, in, derivatives, sigma);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
+++ b/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
@@ -198,8 +198,7 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 		double sum;
 		Cursor<T> cursor = Views.iterable(input).localizingCursor();
 		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
-			new OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>>(
-				Boundary.SINGLE);
+			new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
 		RandomAccess<T> inputRA = osmf.create(input);
 		RandomAccess<T> outputRA = output.randomAccess();
 
@@ -234,8 +233,7 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 		double sum;
 		Cursor<T> cursor = Views.iterable(input).localizingCursor();
 		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
-			new OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>>(
-				Boundary.SINGLE);
+			new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
 		RandomAccess<T> inputRA = osmf.create(input);
 		RandomAccess<DoubleType> outputRA = output.randomAccess();
 

--- a/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
+++ b/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
@@ -208,11 +208,11 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 			outputRA.setPosition(cursor);
 			sum = 0;
 			// loop from the bottom of the image to the top
-			for (int i = -(mask.length / 2); i <= mask.length / 2; i++) {
-				long[] pos = { cursor.getLongPosition(0) + i, cursor.getLongPosition(
-					1) };
-				inputRA.setPosition(pos);
-				sum += inputRA.get().getRealDouble() * mask[i + (mask.length / 2)];
+			final int halfWidth = mask.length / 2;
+			for (int i = -halfWidth; i <= halfWidth; i++) {
+				inputRA.setPosition(cursor.getLongPosition(0) + i, 0);
+				inputRA.setPosition(cursor.getLongPosition(1), 1);
+				sum += inputRA.get().getRealDouble() * mask[i + halfWidth];
 			}
 			outputRA.get().setReal(sum);
 		}
@@ -243,11 +243,11 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 			outputRA.setPosition(cursor);
 			sum = 0;
 			// loop from the bottom of the image to the top
-			for (int i = -(mask.length / 2); i <= mask.length / 2; i++) {
-				long[] pos = { cursor.getLongPosition(0), cursor.getLongPosition(1) +
-					i };
-				inputRA.setPosition(pos);
-				sum += inputRA.get().getRealDouble() * mask[i + (mask.length / 2)];
+			final int halfWidth = mask.length / 2;
+			for (int i = -halfWidth; i <= halfWidth; i++) {
+				inputRA.setPosition(cursor.getLongPosition(0), 0);
+				inputRA.setPosition(cursor.getLongPosition(1) + i, 1);
+				sum += inputRA.get().getRealDouble() * mask[i + halfWidth];
 			}
 			outputRA.get().setReal(sum);
 		}

--- a/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
+++ b/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
@@ -1,0 +1,276 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.derivativeGauss;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
+import net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Performs the 2-D partial derivative Gaussian kernel convolutions on an image,
+ * at a particular point.
+ * 
+ * @author Gabe Selzer
+ */
+@Plugin(type = Ops.Filter.DerivativeGauss.class)
+public class DefaultDerivativeGauss<T extends RealType<T>> extends
+	AbstractBinaryComputerOp<RandomAccessibleInterval<T>, int[], RandomAccessibleInterval<DoubleType>>
+	implements Ops.Filter.DerivativeGauss, Contingent
+{
+
+	@Parameter
+	private double sigma;
+
+	double SQRT2PI = Math.sqrt(2 * Math.PI);
+
+	/**
+	 * Calculates a value at a specified location in a normal mask.
+	 * 
+	 * @param x - the location in the mask.
+	 * @param sigma - the sigma for the convolution.
+	 * @return double - the value of the mask at location x.
+	 */
+	private double phi0(double x, double sigma) {
+		double t = x / sigma;
+		return (-sigma * Math.exp(-0.5 * t * t) / (SQRT2PI * x));
+	}
+
+	/**
+	 * Calculates a value at a specified location in a first partial derivative
+	 * mask.
+	 * 
+	 * @param x - the location in the mask.
+	 * @param sigma - the sigma for the convolution.
+	 * @return double - the value of the mask at location x.
+	 */
+	private double phi1(double x, double sigma) {
+		double t = x / sigma;
+		return (Math.exp(-0.5 * t * t) / (SQRT2PI * sigma));
+	}
+
+	/**
+	 * Calculates a value at a specified location in a second partial derivative
+	 * mask.
+	 * 
+	 * @param x - the location in the mask.
+	 * @param sigma - the sigma for the convolution.
+	 * @return double - the value of the mask at location x.
+	 */
+	private double phi2(double x, double sigma) {
+		double t = x / sigma;
+		return (-x * Math.exp(-0.5 * t * t) / (SQRT2PI * Math.pow(sigma, 3)));
+	}
+
+	/**
+	 * Creates the mask for normal convolutions
+	 * 
+	 * @param sigma - The sigma for the convolution.
+	 * @return double[] - The mask.
+	 */
+	private double[] get_mask_0(double sigma) {
+
+		int x = (int) Math.ceil(4 * sigma);
+		double[] h = new double[2 * x + 1];
+
+		for (int i = -x + 1; i < x; i++) {
+			h[i + x] = Math.abs(phi0(i + 0.5, sigma) - phi0(i - 0.5, sigma));
+		}
+		h[0] = phi0(-x + 0.5, sigma);
+		h[h.length - 1] = phi0(-x + 0.5, sigma);
+		return h;
+	}
+
+	/**
+	 * Creates the mask for first partial derivative convolutions
+	 * 
+	 * @param sigma - The sigma for the convolution.
+	 * @return double[] - The mask.
+	 */
+	private double[] get_mask_1(double sigma) {
+
+		int x = (int) Math.ceil(4 * sigma);
+		double[] h = new double[2 * x + 1];
+
+		for (int i = -x + 1; i < x; i++) {
+			h[i + x] = phi1(-i + 0.5, sigma) - phi1(-i - 0.5, sigma);
+		}
+		h[0] = -phi1(x - 0.5, sigma);
+		h[h.length - 1] = phi1(-x + 0.5, sigma);
+		return h;
+	}
+
+	/**
+	 * Creates the mask for second partial derivative convolutions
+	 * 
+	 * @param sigma - The sigma for the convolution.
+	 * @return double[] - The mask.
+	 */
+	private double[] get_mask_2(double sigma) {
+
+		int x = (int) Math.ceil(4 * sigma);
+		double[] h = new double[2 * x + 1];
+
+		for (int i = -x + 1; i < x; i++) {
+			h[i + x] = phi2(-i + 0.5, sigma) - phi2(-i - 0.5, sigma);
+		}
+		h[0] = -phi2(-x + 0.5, sigma);
+		h[h.length - 1] = phi2(x - 0.5, sigma);
+		return h;
+	}
+
+	/**
+	 * Returns the correct mask of nth partial derivative. Leaves the calculations
+	 * to the helper methods.
+	 * 
+	 * @param sigma - The sigma for the convolution.
+	 * @param n - A number specifying the nth partial derivative.
+	 * @return double[] - The mask.
+	 */
+	private double[] get_mask_general(int n, double sigma) {
+		double[] h;
+		switch (n) {
+			case 0:
+				h = get_mask_0(sigma);
+				break;
+			case 1:
+				h = get_mask_1(sigma);
+				break;
+			case 2:
+				h = get_mask_2(sigma);
+				break;
+			default:
+				h = get_mask_0(sigma);
+				break;
+		}
+		return h;
+	}
+
+	/**
+	 * Convolves the columns of the image
+	 * 
+	 * @param input - The input image.
+	 * @param output - The output image.
+	 * @param mask - The mask needed for the convolution, determined beforehand.
+	 */
+	private <T extends RealType<T>> void convolve_x(
+		RandomAccessibleInterval<T> input, RandomAccessibleInterval<T> output,
+		double[] mask)
+	{
+		double sum;
+		Cursor<T> cursor = Views.iterable(input).localizingCursor();
+		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
+			new OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>>(
+				Boundary.SINGLE);
+		RandomAccess<T> inputRA = osmf.create(input);
+		RandomAccess<T> outputRA = output.randomAccess();
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			inputRA.setPosition(cursor);
+			outputRA.setPosition(cursor);
+			sum = 0;
+			// loop from the bottom of the image to the top
+			for (int i = -(mask.length / 2); i <= mask.length / 2; i++) {
+				long[] pos = { cursor.getLongPosition(0) + i, cursor.getLongPosition(
+					1) };
+				inputRA.setPosition(pos);
+				sum += inputRA.get().getRealDouble() * mask[i + (mask.length / 2)];
+			}
+			outputRA.get().setReal(sum);
+		}
+
+	}
+
+	/**
+	 * Convolves the rows of the image
+	 * 
+	 * @param input - The input image.
+	 * @param output - The output image.
+	 * @param mask - The mask needed for the convolution, determined beforehand.
+	 */
+	private <T extends RealType<T>> void convolve_y(
+		RandomAccessibleInterval<T> input, RandomAccessibleInterval<DoubleType> output,
+		double[] mask)
+	{
+		double sum;
+		Cursor<T> cursor = Views.iterable(input).localizingCursor();
+		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
+			new OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>>(
+				Boundary.SINGLE);
+		RandomAccess<T> inputRA = osmf.create(input);
+		RandomAccess<DoubleType> outputRA = output.randomAccess();
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			inputRA.setPosition(cursor);
+			outputRA.setPosition(cursor);
+			sum = 0;
+			// loop from the bottom of the image to the top
+			for (int i = -(mask.length / 2); i <= mask.length / 2; i++) {
+				long[] pos = { cursor.getLongPosition(0), cursor.getLongPosition(1) +
+					i };
+				inputRA.setPosition(pos);
+				sum += inputRA.get().getRealDouble() * mask[i + (mask.length / 2)];
+			}
+			outputRA.get().setReal(sum);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void compute(RandomAccessibleInterval<T> input, int[] derivatives,
+		RandomAccessibleInterval<DoubleType> output)
+	{
+		RandomAccessibleInterval<T> intermediate =
+			(RandomAccessibleInterval<T>) ops().run(Ops.Copy.RAI.class, output);
+
+		// TODO n-Dimensional support.
+		convolve_x(input, intermediate, get_mask_general(derivatives[0], sigma));
+		convolve_y(intermediate, output, get_mask_general(derivatives[1], sigma));
+	}
+
+	@Override
+	public boolean conforms() {
+		return (in1().numDimensions() == in2().length && out()
+			.numDimensions() == in1().numDimensions());
+	}
+}

--- a/src/main/java/net/imagej/ops/segment/SegmentNamespace.java
+++ b/src/main/java/net/imagej/ops/segment/SegmentNamespace.java
@@ -30,8 +30,16 @@
 
 package net.imagej.ops.segment;
 
+import java.util.List;
+
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
+import net.imagej.ops.OpMethod;
+import net.imagej.ops.Ops;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPoint;
+import net.imglib2.roi.geom.real.DefaultWritablePolyline;
+import net.imglib2.type.numeric.RealType;
 
 import org.scijava.plugin.Plugin;
 
@@ -44,6 +52,22 @@ import org.scijava.plugin.Plugin;
 public class SegmentNamespace extends AbstractNamespace {
 
 	// -- SegmentNamespace methods --
+
+	// -- detectRidges --
+
+	@OpMethod(op = net.imagej.ops.segment.detectRidges.DefaultDetectRidges.class)
+	public <T extends RealType<T>> List<DefaultWritablePolyline> detectRidges(
+		final RandomAccessibleInterval<T> input, final double width,
+		final double lowerThreshold, final double higherThreshold,
+		final int ridgeLengthMin)
+	{
+		@SuppressWarnings("unchecked")
+		final List<DefaultWritablePolyline> result = (List<DefaultWritablePolyline>) ops().run(
+			Ops.Segment.DetectRidges.class, input, width, lowerThreshold,
+			higherThreshold, ridgeLengthMin);
+
+		return result;
+	}
 
 	// -- Namespace methods --
 

--- a/src/main/java/net/imagej/ops/segment/SegmentNamespace.java
+++ b/src/main/java/net/imagej/ops/segment/SegmentNamespace.java
@@ -69,6 +69,29 @@ public class SegmentNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	// -- detectJunctions --
+	
+	@OpMethod(op = net.imagej.ops.segment.detectJunctions.DefaultDetectJunctions.class)
+	public List<RealPoint> detectJunctions(final List<DefaultWritablePolyline> lines)
+	{
+		@SuppressWarnings("unchecked")
+		final List<RealPoint> result = (List<RealPoint>) ops().run(
+			Ops.Segment.DetectJunctions.class, lines);
+
+		return result;
+	}
+	
+	@OpMethod(op = net.imagej.ops.segment.detectJunctions.DefaultDetectJunctions.class)
+	public List<RealPoint> detectJunctions(final List<DefaultWritablePolyline> lines,
+		final double threshold)
+	{
+		@SuppressWarnings("unchecked")
+		final List<RealPoint> result = (List<RealPoint>) ops().run(
+			Ops.Segment.DetectJunctions.class, lines, threshold);
+
+		return result;
+	}
+
 	// -- Namespace methods --
 
 	@Override

--- a/src/main/java/net/imagej/ops/segment/detectJunctions/DefaultDetectJunctions.java
+++ b/src/main/java/net/imagej/ops/segment/detectJunctions/DefaultDetectJunctions.java
@@ -1,0 +1,330 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.segment.detectJunctions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.segment.detectRidges.DefaultDetectRidges;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imglib2.Interval;
+import net.imglib2.RealInterval;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealPositionable;
+import net.imglib2.roi.geom.real.DefaultWritablePolyline;
+import net.imglib2.roi.util.RealLocalizableRealPositionable;
+import net.imglib2.util.Intervals;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Finds the junctions between a {@link ArrayList} of {@link DefaultPolyline},
+ * intended to be used optionally after running {@link DefaultDetectRidges} but
+ * applicable to all groups of polylines. TODO refactor the op to determine
+ * junction points between n-d {@link DefaultPolyline}
+ * 
+ * @author Gabe Selzer
+ */
+@Plugin(type = Ops.Segment.DetectJunctions.class)
+public class DefaultDetectJunctions extends
+	AbstractUnaryFunctionOp<List<DefaultWritablePolyline>, List<RealPoint>>
+	implements Ops.Segment.DetectJunctions, Contingent
+{
+
+	@Parameter(required = false)
+	private double threshold = 2;
+
+	private boolean areClose(RealPoint p1, RealPoint p2) {
+		return getDistance(p1, p2) <= threshold;
+	}
+
+	private boolean areClose(RealPoint p1, List<RealPoint> points) {
+		for (RealPoint p : points) {
+			if (areClose(p1, p) == true) return true;
+		}
+		return false;
+	}
+
+	private static Interval slightlyEnlarge(RealInterval realInterval,
+		long border)
+	{
+		return Intervals.expand(Intervals.smallestContainingInterval(realInterval),
+			border);
+	}
+
+	private double getDistance(double[] point1, RealLocalizable point2) {
+		return Math.sqrt(Math.pow(point2.getDoublePosition(0) - point1[0], 2) + Math
+			.pow(point2.getDoublePosition(1) - point1[1], 2));
+	}
+
+	private double getDistance(RealLocalizable point1, RealLocalizable point2) {
+		return Math.sqrt(Math.pow(point2.getDoublePosition(0) - point1
+			.getDoublePosition(0), 2) + Math.pow(point2.getDoublePosition(1) - point1
+				.getDoublePosition(1), 2));
+	}
+
+	private RealPoint makeRealPoint(RealLocalizableRealPositionable input) {
+		return new RealPoint(input);
+	}
+
+	@Override
+	public List<RealPoint> calculate(List<DefaultWritablePolyline> input) {
+
+		// output that allows for both split polyline inputs and a
+		// realPointCollection for our junctions.
+		List<RealPoint> output = new ArrayList<>();
+
+		for (int first = 0; first < input.size() - 1; first++) {
+			DefaultWritablePolyline firstLine = input.get(first);
+			for (int second = first + 1; second < input.size(); second++) {
+				DefaultWritablePolyline secondLine = input.get(second);
+				// interval containing both plines
+				Interval intersect = Intervals.intersect(slightlyEnlarge(firstLine, 2),
+					slightlyEnlarge(secondLine, 2));
+				// if the two do not intersect, then don't bother checking them against
+				// each other.
+				if (Intervals.isEmpty(intersect)) continue;
+
+				// create an arraylist to contain all of the junctions for these two
+				// lines (so that we can filter the junctions before putting them in
+				// output).
+				ArrayList<RealPoint> currentPairJunctions = new ArrayList<>();
+
+				for (int p = 0; p < firstLine.numVertices() - 1; p++) {
+					for (int q = 0; q < secondLine.numVertices() - 1; q++) {
+						RealLocalizableRealPositionable p1 = firstLine.vertex(p);
+						RealLocalizableRealPositionable p2 = firstLine.vertex(p + 1);
+						RealLocalizableRealPositionable q1 = secondLine.vertex(q);
+						RealLocalizableRealPositionable q2 = secondLine.vertex(q + 1);
+
+						// special cases if both lines are vertical
+						boolean pVertical = Math.round(p1.getDoublePosition(0)) == Math
+							.round(p2.getDoublePosition(0));
+						boolean qVertical = Math.round(q1.getDoublePosition(0)) == Math
+							.round(q2.getDoublePosition(0));
+
+						// intersection point between the lines created by line segments p
+						// and q.
+						double[] intersectionPoint = new double[2];
+
+						// if both p and q are vertical, then p and q cannot intersect,
+						// since they are parallel and cannot be the same.
+						if (pVertical && qVertical) {
+							parallelRoutine(p1, p2, q1, q2, currentPairJunctions, true);
+							continue;
+						}
+						else if (pVertical) {
+							double mq = (q2.getDoublePosition(1) - q1.getDoublePosition(1)) /
+								(q2.getDoublePosition(0) - q1.getDoublePosition(0));
+							double bq = (q1.getDoublePosition(1) - mq * q1.getDoublePosition(
+								0));
+							double x = p1.getDoublePosition(0);
+							double y = mq * x + bq;
+							intersectionPoint[0] = x;
+							intersectionPoint[1] = y;
+						}
+						else if (qVertical) {
+							double mp = (p2.getDoublePosition(1) - p1.getDoublePosition(1)) /
+								(p2.getDoublePosition(0) - p1.getDoublePosition(0));
+							double bp = (p1.getDoublePosition(1) - mp * p1.getDoublePosition(
+								0));
+							double x = q1.getDoublePosition(0);
+							double y = mp * x + bp;
+							intersectionPoint[0] = x;
+							intersectionPoint[1] = y;
+						}
+						else {
+
+							double mp = (p2.getDoublePosition(1) - p1.getDoublePosition(1)) /
+								(p2.getDoublePosition(0) - p1.getDoublePosition(0));
+							double mq = (q2.getDoublePosition(1) - q1.getDoublePosition(1)) /
+								(q2.getDoublePosition(0) - q1.getDoublePosition(0));
+
+							if (mp == mq) {
+								parallelRoutine(p1, p2, q1, q2, currentPairJunctions, false);
+								continue;
+							}
+
+							double bp = (p2.getDoublePosition(1) - mp * p2.getDoublePosition(
+								0));
+							double bq = (q2.getDoublePosition(1) - mq * q2.getDoublePosition(
+								0));
+
+							// point of intersection of lines created by line segments p and
+							// q.
+							double x = (bq - bp) / (mp - mq);
+							double y = mp * x + bp;
+							intersectionPoint[0] = x;
+							intersectionPoint[1] = y;
+						}
+
+						// find the distance from the intersection point to both line
+						// segments, and the length of the line segments.
+						double distp1 = getDistance(intersectionPoint, p1);
+						double distp2 = getDistance(intersectionPoint, p2);
+						double distq1 = getDistance(intersectionPoint, q1);
+						double distq2 = getDistance(intersectionPoint, q2);
+
+						// max distance from line segment to intersection point
+						double maxDist = Math.max(Math.min(distp1, distp2), Math.min(distq1,
+							distq2));
+
+						// if the maximum distance is close enough to the two lines, then
+						// these lines are close enough to form a junction
+						if (maxDist <= threshold) currentPairJunctions.add(new RealPoint(
+							intersectionPoint));
+					}
+				}
+				// filter out the current pair's junctions by removing duplicates and
+				// then averaging all remaining nearby junctions
+				filterJunctions(currentPairJunctions);
+
+				// add the filtered junctions to the output list.
+				for (RealPoint point : currentPairJunctions)
+					output.add(point);
+			}
+		}
+
+		// filter the junctions -- for each set of junctions that seem vaguely
+		// similar, pick out the best one-
+		filterJunctions(output);
+
+		return output;
+	}
+
+	private void filterJunctions(List<RealPoint> list) {
+		// filter out all vaguely similar junction points.
+		for (int i = 0; i < list.size() - 1; i++) {
+			ArrayList<RealPoint> similars = new ArrayList<>();
+			similars.add(list.get(i));
+			list.remove(i);
+			for (int j = 0; j < list.size(); j++) {
+				if (areClose(list.get(j), similars)) {
+					similars.add(list.get(j));
+					list.remove(j);
+					j--;
+				}
+			}
+			if (list.size() > 0) list.add(i, averagePoints(similars));
+			else list.add(averagePoints(similars));
+		}
+	}
+
+	private RealPoint averagePoints(ArrayList<RealPoint> list) {
+		double[] pos = { 0, 0 };
+		for (RealPoint p : list) {
+			pos[0] += p.getDoublePosition(0);
+			pos[1] += p.getDoublePosition(1);
+		}
+		pos[0] /= list.size();
+		pos[1] /= list.size();
+		return new RealPoint(pos);
+	}
+
+	private <L extends RealLocalizable & RealPositionable> void parallelRoutine(
+		RealLocalizableRealPositionable p1, RealLocalizableRealPositionable p2,
+		RealLocalizableRealPositionable q1, RealLocalizableRealPositionable q2,
+		List<RealPoint> junctions, boolean areVertical)
+	{
+
+		// find out whether or not they are on the same line
+		boolean sameLine = false;
+		if (areVertical && Math.round(p1.getDoublePosition(0)) == Math.round(q1
+			.getDoublePosition(0))) sameLine = true;
+		else {
+			double m = (q2.getDoublePosition(1) - q1.getDoublePosition(1)) / (q2
+				.getDoublePosition(0) - q1.getDoublePosition(0));
+			double bp = (p2.getDoublePosition(1) - m * p2.getDoublePosition(0));
+			double bq = (q2.getDoublePosition(1) - m * q2.getDoublePosition(0));
+
+			if (bp == bq) sameLine = true;
+		}
+
+		// if the two line segments do not belong to the same line, then if the
+		// minimum distance between the two points is greater than the threshold,
+		// there is no junction
+		if (!sameLine && Math.min(Math.min(getDistance(p1, q1), getDistance(p2,
+			q1)), Math.min(getDistance(p1, q2), getDistance(p2, q2))) > threshold)
+			return;
+
+		int foundJunctions = 0;
+		double lengthp = getDistance(p1, p2);
+		double lengthq = getDistance(q1, q2);
+		// if p and q are segments on the same line, then p1, p2, q1, and q2 can all
+		// be junctions. There can be at most 2 junctions between these two line
+		// segments.
+		// check p1 to be a junction
+		if ((getDistance(p1, q1) < lengthq && getDistance(p1, q2) < lengthq &&
+			sameLine) || Math.min(getDistance(p1, q1), getDistance(p1,
+				q2)) < threshold)
+		{
+			junctions.add(makeRealPoint(p1));
+			foundJunctions++;
+		}
+		// check p2 to be a junction
+		if ((getDistance(p2, q1) < lengthq && getDistance(p2, q2) < lengthq &&
+			sameLine) || Math.min(getDistance(p2, q1), getDistance(p2,
+				q2)) < threshold)
+		{
+			junctions.add(makeRealPoint(p2));
+			foundJunctions++;
+		}
+
+		// check q1 to be a junction
+		if (((getDistance(q1, p1) < lengthp && getDistance(q1, p2) < lengthp &&
+			sameLine) || (Math.min(getDistance(q1, p1), getDistance(q1,
+				p2)) < threshold)) && foundJunctions < 2)
+		{
+			junctions.add(makeRealPoint(q1));
+			foundJunctions++;
+		}
+
+		// check q2 to be a junction
+		if (((getDistance(q2, p1) < lengthp && getDistance(q2, p2) < lengthp &&
+			sameLine) || (Math.min(getDistance(q2, p1), getDistance(q2,
+				p2)) < threshold)) && foundJunctions < 2)
+		{
+			junctions.add(makeRealPoint(q2));
+			foundJunctions++;
+		}
+	}
+
+	@Override
+	public boolean conforms() {
+		if (in().size() < 1) return false;
+		return in().get(0).vertex(0).numDimensions() == 2;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/segment/detectRidges/DefaultDetectRidges.java
+++ b/src/main/java/net/imagej/ops/segment/detectRidges/DefaultDetectRidges.java
@@ -1,0 +1,305 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.segment.detectRidges;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPoint;
+import net.imglib2.img.Img;
+import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
+import net.imglib2.roi.geom.real.DefaultWritablePolyline;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Performs the Ridge Detection algorithm on a 2-Dimensional, gray-scale image.
+ * 
+ * @author Gabe Selzer
+ */
+@Plugin(type = Ops.Segment.DetectRidges.class)
+public class DefaultDetectRidges<T extends RealType<T>> extends
+	AbstractUnaryFunctionOp<RandomAccessibleInterval<T>, List<DefaultWritablePolyline>>
+	implements Ops.Segment.DetectRidges, Contingent
+{
+
+	/**
+	 * The diameter of the lines to search for.
+	 */
+	@Parameter
+	double width;
+
+	/**
+	 * The threshold for which the gradient of a subsequent line point must be
+	 * above.
+	 */
+	@Parameter
+	double lowerThreshold;
+
+	/**
+	 * The threshold for which the gradient of a initial line point must be above.
+	 */
+	@Parameter
+	double higherThreshold;
+
+	@Parameter(min = "1")
+	int ridgeLengthMin;
+
+	/**
+	 * The threshold for angle differences between the eigenvectors of two
+	 * different ridge points. The eigenvector is fixed for angle differences
+	 * above this threshold.
+	 */
+	double angleThreshold = 100;
+
+	/**
+	 * Recursively determines the next line point and adds it to the running list
+	 * of line points.
+	 * 
+	 * @param gradientRA - the {@link RandomAccess} of the gradient image.
+	 * @param pRA - the {@link RandomAccess} of the eigenvector image.
+	 * @param nRA - the {@link RandomAccess} of the subpixel line location image.
+	 * @param points - the {@link ArrayList} containing the line points.
+	 * @param octant - integer denoting the octant of the last gradient vector,
+	 *          oriented with 1 being 0 degrees and increasing in the
+	 *          counterclockwise direction.
+	 * @param lastnx - the x component of the gradient vector of the last line
+	 *          point.
+	 * @param lastny - the y component of the gradient vector of the last line
+	 *          point.
+	 * @param lastpx - the x component of the subpixel line location of the last
+	 *          line point.
+	 * @param lastpy - the y component of the subpixel line location of the last
+	 *          line point.
+	 */
+	private void getNextPoint(RandomAccess<DoubleType> gradientRA,
+		RandomAccess<DoubleType> pRA, RandomAccess<DoubleType> nRA,
+		List<RealPoint> points, int octant, double lastnx, double lastny,
+		double lastpx, double lastpy)
+	{
+		Point currentPos = new Point(gradientRA);
+		// variables for the best line point of the three.
+		Point salientPoint = new Point(gradientRA);
+		double salientnx = 0;
+		double salientny = 0;
+		double salientpx = 0;
+		double salientpy = 0;
+		double bestSalience = Double.MAX_VALUE;
+		boolean lastPointInLine = true;
+		// check the three possible points that could continue the line, starting at
+		// the octant after the given octant and rotating clockwise around the
+		// current pixel.
+		double lastAngle = RidgeDetectionUtils.getAngle(lastnx, lastny);
+
+		for (int i = 1; i < 4; i++) {
+			int[] modifier = RidgeDetectionUtils.getOctantCoords(octant + i);
+			gradientRA.move(modifier[0], 0);
+			gradientRA.move(modifier[1], 1);
+			// make sure that we only do the calculations if there is a line point
+			// there.
+			if (gradientRA.get()
+				.get() > lowerThreshold /*&& isMaxRA.get().get() > 0*/)
+			{
+				long[] vectorArr = { gradientRA.getLongPosition(0), gradientRA
+					.getLongPosition(1), 0 };
+				nRA.setPosition(vectorArr);
+				double nx = nRA.get().get();
+				nRA.fwd(2);
+				double ny = nRA.get().get();
+				pRA.setPosition(vectorArr);
+				double px = pRA.get().get();
+				pRA.fwd(2);
+				double py = pRA.get().get();
+				double currentAngle = RidgeDetectionUtils.getAngle(nx, ny);
+				double subpixelDiff = Math.sqrt(Math.pow(px - lastpx, 2) + Math.pow(py -
+					lastpy, 2));
+				double angleDiff = Math.abs(currentAngle - lastAngle);
+				lastPointInLine = false;
+				// A salient line point will have the smallest combination of these
+				// numbers relative to other potential line points.
+				if (subpixelDiff + angleDiff < bestSalience) {
+					// record the values of the new most salient pixel
+					salientPoint = new Point(gradientRA);
+					salientnx = nx;
+					salientny = ny;
+					salientpx = px;
+					salientpy = py;
+					bestSalience = subpixelDiff + angleDiff;
+				}
+				//set the values to zero so that they are not added to another line.
+				gradientRA.get().set(0);
+
+			}
+
+			// reset our randomAccess for the next check
+			gradientRA.setPosition(currentPos);
+		}
+
+		// set the current pixel to 0 in the first slice of eigenRA!
+		gradientRA.get().setReal(0);
+
+		// find the next line point as long as there is one to find
+		if (!lastPointInLine) {
+			// take the most salient point
+			gradientRA.setPosition(salientPoint);
+			points.add(RidgeDetectionUtils.get2DRealPoint(gradientRA
+				.getDoublePosition(0) + salientpx, gradientRA.getDoublePosition(1) +
+					salientpy));
+
+			// the gradient vector itself refers to the greatest change in intensity,
+			// and for a pixel on a line this vector will be perpendicular to the
+			// direction of the line. But this vector can point to either the left or
+			// the right of the line from the perspective of the detector, and there
+			// is no guarantee that the vectors at line point will point off the same
+			// side of the line. So if they point off different sides, set the current
+			// vector by 180 degrees for the purposes of this detector. We set the
+			// threshold for angle fixing just above 90 degrees since any lower would
+			// prevent ridges curving.
+			double potentialGradient = RidgeDetectionUtils.getAngle(salientnx,
+				salientny);
+			// we increase any angles too close to zero since, for example, having one
+			// angle at 5 degrees and another at 355 would not satisfy the conditional
+			// even though they are close enough to satisfy.
+			if (lastAngle < angleThreshold) lastAngle += 360;
+			if (potentialGradient < angleThreshold) potentialGradient += 360;
+
+			if (Math.abs(potentialGradient - lastAngle) > angleThreshold) {
+				salientnx = -salientnx;
+				salientny = -salientny;
+			}
+
+			// perform the operation again on the new end of the line being formed.
+			getNextPoint(gradientRA, pRA, nRA, points, RidgeDetectionUtils.getOctant(
+				salientnx, salientny), salientnx, salientny, salientpx, salientpy);
+		}
+	}
+
+	@Override
+	public List<DefaultWritablePolyline> calculate(RandomAccessibleInterval<T> input) {
+
+		double sigma = (width / (2 * Math.sqrt(3)));
+
+		// generate the metadata images
+		RidgeDetectionMetadata ridgeDetectionMetadata = new RidgeDetectionMetadata(input, sigma,
+			lowerThreshold, higherThreshold);
+
+		// retrieve the metadata images
+		Img<DoubleType> p_values = ridgeDetectionMetadata.getPValues();
+		Img<DoubleType> n_values = ridgeDetectionMetadata.getNValues();
+		Img<DoubleType> gradients = ridgeDetectionMetadata.getGradients();
+
+		// create RandomAccesses for the metadata images
+		OutOfBoundsConstantValueFactory<DoubleType, RandomAccessibleInterval<DoubleType>> oscvf =
+			new OutOfBoundsConstantValueFactory<>(new DoubleType(0));
+		RandomAccess<DoubleType> pRA = oscvf.create(p_values);
+		RandomAccess<DoubleType> nRA = oscvf.create(n_values);
+		RandomAccess<DoubleType> gradientRA = oscvf.create(gradients);
+
+		// create the output polyline list.
+		List<DefaultWritablePolyline> lines = new ArrayList<>();
+
+		// start at the point of greatest maximum absolute value
+		gradientRA.setPosition(RidgeDetectionUtils.getMaxCoords(gradients, true));
+
+		// loop through the maximum values of the image
+		while (Math.abs(gradientRA.get().get()) > higherThreshold) {
+
+			// create the List of points that will be used to make the polyline
+			List<RealPoint> points = new ArrayList<>();
+
+			// get all of the necessary metadata from the image.
+			long[] eigenvectorPos = { gradientRA.getLongPosition(0), gradientRA
+				.getLongPosition(1), 0 };
+
+			// obtain the n-values
+			nRA.setPosition(eigenvectorPos);
+			double eigenx = nRA.get().getRealDouble();
+			nRA.fwd(2);
+			double eigeny = nRA.get().getRealDouble();
+
+			// obtain the p-values
+			pRA.setPosition(eigenvectorPos);
+			double px = pRA.get().getRealDouble();
+			pRA.fwd(2);
+			double py = pRA.get().getRealDouble();
+
+			// start the list by adding the current point, which is the most line-like
+			// point on the polyline
+			points.add(RidgeDetectionUtils.get2DRealPoint(gradientRA
+				.getDoublePosition(0) + px, gradientRA.getDoublePosition(1) + py));
+
+			// go in the direction to the left of the perpendicular value
+			getNextPoint(gradientRA, pRA, nRA, points, RidgeDetectionUtils.getOctant(
+				eigenx, eigeny), eigenx, eigeny, px, py);
+
+			// flip the array list around so that we get one cohesive line
+			gradientRA.setPosition(new long[] { eigenvectorPos[0],
+				eigenvectorPos[1] });
+			Collections.reverse(points);
+
+			// go in the opposite direction as before.
+			eigenx = -eigenx;
+			eigeny = -eigeny;
+			getNextPoint(gradientRA, pRA, nRA, points, RidgeDetectionUtils.getOctant(
+				eigenx, eigeny), eigenx, eigeny, px, py);
+
+			// set the value to 0 so that it is not reused.
+			gradientRA.get().setReal(0);
+
+			// turn the list of points into a polyline, add to output list. If the
+			// list has fewer vertices than the parameter, then we do not report it.
+			if (points.size() > ridgeLengthMin) {
+				DefaultWritablePolyline pline = new DefaultWritablePolyline(points);
+				lines.add(pline);
+			}
+			// find the next max absolute value
+			gradientRA.setPosition(RidgeDetectionUtils.getMaxCoords(gradients, true));
+		}
+
+		return lines;
+	}
+
+	@Override
+	public boolean conforms() {
+		return in().numDimensions() == 2;
+	}
+
+}

--- a/src/main/java/net/imagej/ops/segment/detectRidges/RidgeDetectionMetadata.java
+++ b/src/main/java/net/imagej/ops/segment/detectRidges/RidgeDetectionMetadata.java
@@ -1,0 +1,278 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.segment.detectRidges;
+
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.chain.RAIs;
+import net.imagej.ops.special.computer.BinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.function.BinaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+import org.scijava.Context;
+
+import Jama.EigenvalueDecomposition;
+import Jama.Matrix;
+
+/**
+ * Helper Method to generate the meta image used for {@link DefaultDetectRidges}
+ * 
+ * @author Gabe Selzer
+ */
+public class RidgeDetectionMetadata {
+
+	protected Img<DoubleType> pValues;
+	protected Img<DoubleType> nValues;
+	protected Img<DoubleType> gradients;
+
+	RandomAccessibleInterval<DoubleType> x;
+	RandomAccessibleInterval<DoubleType> y;
+	RandomAccessibleInterval<DoubleType> xx;
+	RandomAccessibleInterval<DoubleType> xy;
+	RandomAccessibleInterval<DoubleType> yy;
+
+	/**
+	 * Generates the metadata images from the input image
+	 * 
+	 * @param input - the image to be detected
+	 * @param sigma - the sigma for the gaussian derivative convolutions
+	 */
+	public <T extends RealType<T>> RidgeDetectionMetadata(
+		RandomAccessibleInterval<T> input, double sigma, double smallMax,
+		double bigMax)
+	{
+		// create op service for metadata generation
+		final Context context = new Context();
+		OpService opService = context.getService(OpService.class);
+
+		// convert input to doubleType
+		RandomAccessibleInterval<DoubleType> converted =
+			(RandomAccessibleInterval<DoubleType>) opService.run(
+				Ops.Convert.Float64.class, input);
+
+		RandomAccessibleInterval<DoubleType> temp = opService.create().img(
+			converted);
+
+		// create copyOp instance for faster calculations
+		UnaryFunctionOp<RandomAccessibleInterval<DoubleType>, RandomAccessibleInterval<DoubleType>> copyOp =
+			RAIs.function(opService, Ops.Copy.RAI.class, converted);
+
+		// create partial derivative gaussian op for faster calculations
+		BinaryComputerOp<RandomAccessibleInterval<DoubleType>, int[], RandomAccessibleInterval<DoubleType>> partialDerivativeOp =
+			Computers.binary(opService, Ops.Filter.DerivativeGauss.class, converted,
+				temp, new int[] { 0, 0 }, sigma);
+
+		// create dimensions array for p and n values images, later used for setting
+		// positions for their randomAccesses
+		long[] valuesArr = new long[input.numDimensions() + 1];
+		for (int d = 0; d < input.numDimensions(); d++)
+			valuesArr[d] = input.dimension(d);
+		valuesArr[valuesArr.length - 1] = 2;
+
+		// create metadata images and randomAccesses
+		pValues = opService.create().img(valuesArr);
+		RandomAccess<DoubleType> pRA = pValues.randomAccess();
+		nValues = opService.create().img(valuesArr);
+		RandomAccess<DoubleType> nRA = nValues.randomAccess();
+		gradients = opService.create().img(input, new DoubleType());
+		RandomAccess<DoubleType> gradientsRA = gradients.randomAccess();
+
+		// create a cursor of the input to direct all of the randomAccesses.
+		Cursor<T> cursor = Views.iterable(input).localizingCursor();
+
+		// create partial derivative images, randomAccesses
+		x = copyOp.calculate(converted);
+		RandomAccess<DoubleType> xRA = x.randomAccess();
+		y = copyOp.calculate(converted);
+		RandomAccess<DoubleType> yRA = y.randomAccess();
+		xx = copyOp.calculate(converted);
+		RandomAccess<DoubleType> xxRA = xx.randomAccess();
+		xy = copyOp.calculate(converted);
+		RandomAccess<DoubleType> xyRA = xy.randomAccess();
+		yy = copyOp.calculate(converted);
+		RandomAccess<DoubleType> yyRA = yy.randomAccess();
+
+		// fill partial derivative images with gaussian derivative convolutions
+		partialDerivativeOp.compute(converted, new int[] { 1, 0 }, x);
+		partialDerivativeOp.compute(converted, new int[] { 2, 0 }, xx);
+		partialDerivativeOp.compute(converted, new int[] { 1, 1 }, xy);
+		partialDerivativeOp.compute(converted, new int[] { 0, 1 }, y);
+		partialDerivativeOp.compute(converted, new int[] { 0, 2 }, yy);
+		
+		// loop through the points, fill in potentialPoints with second directional
+		// derivative across the line, eigenx with the x component of the normal
+		// vector to the line, and eigeny with the y component of that vector.
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			xRA.setPosition(cursor);
+			yRA.setPosition(cursor);
+			xxRA.setPosition(cursor);
+			xyRA.setPosition(cursor);
+			yyRA.setPosition(cursor);
+
+			// Get all of the values needed for the point.
+			double rx = xRA.get().getRealDouble();
+			double ry = yRA.get().getRealDouble();
+			double rxx = xxRA.get().getRealDouble();
+			double rxy = xyRA.get().getRealDouble();
+			double ryy = yyRA.get().getRealDouble();
+
+			// convolve image with 2D partial kernel,
+			// make a Hessian using the kernels
+			Matrix hessian = new Matrix(input.numDimensions(), input.numDimensions());
+			hessian.set(0, 0, xxRA.get().getRealDouble());
+			hessian.set(0, 1, xyRA.get().getRealDouble());
+			hessian.set(1, 0, xyRA.get().getRealDouble());
+			hessian.set(1, 1, yyRA.get().getRealDouble());
+
+			// Jacobian rotation to eliminate rxy
+			EigenvalueDecomposition e = hessian.eig();
+			Matrix eigenvalues = e.getD();
+			Matrix eigenvectors = e.getV();
+
+			// since the eigenvalues matrix is diagonal, find the index of the largest
+			// eigenvalue
+			int index = (Math.abs(eigenvalues.get(0, 0)) > Math.abs(eigenvalues.get(1,
+				1))) ? 0 : 1;
+
+			// get (nx, ny), i.e. the components of a vector perpendicular to our
+			// line, with length of one.
+			double nx = eigenvectors.get(0, index);
+			double ny = eigenvectors.get(1, index);
+
+			// obtain (px, py), the point in subpixel space where the first
+			// directional derivative vanishes.
+			double t = -1 * ((rx * nx) + (ry * ny)) / ((rxx * nx * nx) + (2 * rxy *
+				nx * ny) + (ryy * ny * ny));
+			double px = t * nx;
+			double py = t * ny;
+
+			// so long as the absolute values of px and py are below 0.5, this point
+			// is a line point.
+			if (Math.abs(px) <= 0.5 && Math.abs(py) <= 0.5) {
+
+				// create long array for setting position of pValues and nValues
+				valuesArr[0] = cursor.getLongPosition(0);
+				valuesArr[1] = cursor.getLongPosition(1);
+				valuesArr[2] = 0;
+
+				// set px to the first z slice of pValues
+				pRA.setPosition(valuesArr);
+				pRA.get().set(px);
+
+				// set py to the second z slice of pValues
+				pRA.fwd(2);
+				pRA.get().set(py);
+
+				// set nx t othe first z slice of nValues
+				nRA.setPosition(valuesArr);
+				nRA.get().set(nx);
+
+				// set ny to the second z slice of nValues
+				nRA.fwd(2);
+				nRA.get().set(ny);
+
+				// the eigenvalue is equal to the gradient at that pixel. If a large
+				// negative, we are on a line. Otherwise 0.
+				double gradient = eigenvalues.get(index, index) < -smallMax ? Math.abs(
+					eigenvalues.get(index, index)) : 0;
+
+				// set the gradient
+				gradientsRA.setPosition(cursor);
+				gradientsRA.get().set(gradient);
+			}
+
+		}
+	}
+
+	/**
+	 * returns the pValue image
+	 * 
+	 * @return the image containing the pValues
+	 */
+	protected Img<DoubleType> getPValues() {
+		return pValues;
+	}
+
+	/**
+	 * returns the pValue image's RandomAccess
+	 * 
+	 * @return the RandomAccess containing the pValues
+	 */
+	protected RandomAccess<DoubleType> getPValuesRandomAccess() {
+		return pValues.randomAccess();
+	}
+
+	/**
+	 * returns the nValue image
+	 * 
+	 * @return the image containing the nValues
+	 */
+	protected Img<DoubleType> getNValues() {
+		return nValues;
+	}
+
+	/**
+	 * returns the nValue image's RandomAccess
+	 * 
+	 * @return the RandomAccess containing the nValues
+	 */
+	protected RandomAccess<DoubleType> getNValuesRandomAccess() {
+		return nValues.randomAccess();
+	}
+
+	/**
+	 * returns the gradient image
+	 * 
+	 * @return the image containing the gradients
+	 */
+	protected Img<DoubleType> getGradients() {
+		return gradients;
+	}
+
+	/**
+	 * returns the gradient image's RandomAccess
+	 * 
+	 * @return the RandomAccess containing the gradients
+	 */
+	protected RandomAccess<DoubleType> getGradientsRandomAccess() {
+		return gradients.randomAccess();
+	}
+}

--- a/src/main/java/net/imagej/ops/segment/detectRidges/RidgeDetectionUtils.java
+++ b/src/main/java/net/imagej/ops/segment/detectRidges/RidgeDetectionUtils.java
@@ -1,0 +1,217 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.segment.detectRidges;
+
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealPoint;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+public class RidgeDetectionUtils {
+
+	/**
+	 * Returns the angle between the x-axis and a given vector (in components).
+	 * Always positive.
+	 * 
+	 * @param y - double denoting the y component of the vector.
+	 * @param x - double denoting the x component of the vector.
+	 * @return double denoting the angle between the vector and the x-axis.
+	 */
+	protected static double getAngle(double x, double y) {
+
+		double angle = 0;
+
+		if (y > 0 && x == 0) {
+			angle = 90;
+		}
+		else if (y < 0 && x == 0) {
+			angle = 270;
+		}
+		else {
+
+			// calculate the angle and convert it to degrees.
+			angle = Math.atan(y / x) * 180 / Math.PI;
+			// if x is negative then arctan will return the angle - 180 degrees, but
+			// we want the actual angle.
+			if (x < 0) angle += 180;
+			// we always want a positive angle
+			if (angle < 0) angle += 360;
+		}
+
+		return angle;
+	}
+
+	/**
+	 * This method determines the octant (neighboring pixel) a vector points
+	 * towards in pixel space. Explanation: Given a pixel denoted as '0', the
+	 * neighboring pixels are numbered counterclockwise around pixel 0, beginning
+	 * with pixel 1 to the right of pixel 0, and ending with pixel 8 one down and
+	 * one right from pixel 0. The method matches this number to a range of
+	 * degrees, e.g. a vector in octant 2 would have an angle between 22.5 degrees
+	 * and 67.5 degrees. This is helpful to determine which neighboring pixels to
+	 * look at in line detection.
+	 *
+	 * @param y - double denoting the y component of the vector.
+	 * @param x - double denoting the x component of the vector.
+	 * @return int denoting the octant in which a vector is in.
+	 */
+	protected static int getOctant(double x, double y) {
+		int octant = 1;
+		double angle = getAngle(x, y);
+
+		while (angle > 22.5) {
+			octant++;
+			angle -= 45;
+		}
+		while(octant > 8) octant -= 8;
+		while(octant < 1) octant += 8;
+
+		return octant;
+	}
+
+	/**
+	 * Creates the modifier array for the octants.
+	 * 
+	 * @param octant - describes the octant modifier needed.
+	 * @return double[] of length 2, with the first number denoting the modifier
+	 *         to the x-coordinate and the second denoting the modifier to the
+	 *         y-coordinate.
+	 */
+	protected static int[] getOctantCoords(int octant) {
+		int[] coords = new int[2];
+		switch (octant) {
+			case 9:
+			case 1:
+				coords[0] = 1;
+				break;
+			case 2:
+			case 10:
+				coords[0] = 1;
+				coords[1] = 1;
+				break;
+			case 3:
+			case 11:
+				coords[1] = 1;
+				break;
+			case 4:
+			case 12:
+				coords[0] = -1;
+				coords[1] = 1;
+				break;
+			case 5:
+				coords[0] = -1;
+				break;
+			case 6:
+				coords[0] = -1;
+				coords[1] = -1;
+				break;
+			case 7:
+			case -1:
+				coords[1] = -1;
+				break;
+			case 0:
+			case 8:
+				coords[0] = 1;
+				coords[1] = -1;
+				break;
+		}
+		return coords;
+	}
+
+	/**
+	 * Helper method to take a point in a n-d image and reduce it down to a 2
+	 * dimensional point (e.g. in 3D cartesian space removing the z-coordinate
+	 * from the point).
+	 * 
+	 * @param RA - the random access of the n>2 dimensional image.
+	 * @return Point in 2D space.
+	 */
+	protected static Point get2DPoint(RandomAccess<DoubleType> RA) {
+		long[] coords = new long[2];
+		coords[0] = RA.getLongPosition(0);
+		coords[1] = RA.getLongPosition(1);
+
+		return new Point(coords);
+	}
+
+	/**
+	 * Helper method to take a point in a n-d image and reduce it down to a 2
+	 * dimensional Realpoint (e.g. in 3D cartesian space removing the z-coordinate
+	 * from the point).
+	 * 
+	 * @param RA - the random access of the n>2 dimensional image.
+	 * @return Point in 2D space.
+	 */
+	protected static RealPoint get2DRealPoint(RandomAccess<DoubleType> RA) {
+		double[] coords = new double[2];
+		coords[0] = RA.getDoublePosition(0);
+		coords[1] = RA.getDoublePosition(1);
+
+		return new RealPoint(coords);
+	}
+
+	/**
+	 * Returns a {@link RealPoint} with the coordinates (x, y).
+	 * 
+	 * @param x - the x-coordinate
+	 * @param y - the y-coordinate
+	 * @return a {@link RealPoint} with coordinates (x,y)
+	 */
+	protected static RealPoint get2DRealPoint(double x, double y) {
+		return new RealPoint(new double[] { x, y });
+	}
+
+	protected static long[] getMaxCoords(
+		RandomAccessibleInterval<DoubleType> input, boolean useAbsoluteValue)
+	{
+		long[] dims = new long[input.numDimensions()];
+		double max = Double.MIN_VALUE;
+		Cursor<DoubleType> cursor = Views.iterable(input).localizingCursor();
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			double current = useAbsoluteValue ? Math.abs(cursor.get().get()) : cursor
+				.get().get();
+			if (current > max) {
+				max = current;
+				for (int d = 0; d < input.numDimensions(); d++) {
+					dims[d] = cursor.getLongPosition(d);
+				}
+			}
+		}
+		return dims;
+	}
+
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -339,6 +339,7 @@ namespaces = ```
 		[name: "topHat",                         iface: "TopHat"],
 	]],
 	[name: "segment", iface: "Segment", ops: [
+		[name: "detectRidges",                 iface: "DetectRidges"],
 	]],
 	[name: "stats", iface: "Stats", ops: [
 		[name: "geometricMean",                  iface: "GeometricMean"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -104,6 +104,7 @@ namespaces = ```
 		[name: "createFFTOutput",                iface: "CreateFFTOutput"],
 		[name: "partialDerivative",              iface: "PartialDerivative"],
 		[name: "allPartialDerivatives",          iface: "AllPartialDerivatives"],
+		[name: "derivativeGauss",                iface: "DerivativeGauss"],
 		[name: "dog",                            iface: "DoG",                 aliases: ["differenceOfGaussian"]],
 		[name: "fft",                            iface: "FFT"],
 		[name: "fftSize",                        iface: "FFTSize"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -340,6 +340,7 @@ namespaces = ```
 	]],
 	[name: "segment", iface: "Segment", ops: [
 		[name: "detectRidges",                 iface: "DetectRidges"],
+		[name: "detectJunctions",              iface: "DetectJunctions"],
 	]],
 	[name: "stats", iface: "Stats", ops: [
 		[name: "geometricMean",                  iface: "GeometricMean"],

--- a/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java
+++ b/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java
@@ -1,0 +1,74 @@
+
+package net.imagej.ops.filter.derivativeGauss;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+
+/**
+ * Contains tests for {@link DefaultDerivativeGauss}.
+ * 
+ * @author Gabe Selzer
+ */
+public class DefaultDerivativeGaussTest extends AbstractOpTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTooFewDimensions() {
+		Img<DoubleType> input = ops.convert().float64(generateFloatArrayTestImg(
+			false, 30));
+
+		Img<DoubleType> output = ops.create().img(input);
+
+		ops.filter().derivativeGauss(output, input, new int[] { 1, 0 }, 1d);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTooManyDimensions() {
+		Img<DoubleType> input = ops.convert().float64(generateFloatArrayTestImg(
+			false, 30, 30, 30));
+
+		Img<DoubleType> output = ops.create().img(input);
+
+		ops.filter().derivativeGauss(output, input, new int[] { 1, 0 }, 1d);
+	}
+	
+	@Test
+	public void regressionTest() {
+		int width = 10;
+		Img<DoubleType> input = ops.convert().float64(generateFloatArrayTestImg(
+			false, width, width));
+
+		Img<DoubleType> output = ops.create().img(input);
+
+		// Draw a line on the image
+		RandomAccess<DoubleType> inputRA = input.randomAccess();
+		inputRA.setPosition(5, 0);
+		for (int i = 0; i < 10; i++) {
+			inputRA.setPosition(i, 1);
+			inputRA.get().set(255);
+		}
+
+		// filter the image
+		ops.filter().derivativeGauss(output, input, new int[] { 1, 0 }, 0.5);
+
+		Cursor<DoubleType> cursor = output.localizingCursor();
+		int currentPixel = 0;
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			assertEquals(cursor.get().getRealDouble(), regressionRowValues[currentPixel % width], 0);
+			currentPixel++;
+		}
+	}
+
+	double[] regressionRowValues = { 0.0, 0.0, 0.0, 2.1876502452391353,
+		117.25400606437196, 0.0, -117.25400606437196, -2.1876502452391353, 0.0,
+		0.0 };
+
+}

--- a/src/test/java/net/imagej/ops/segment/detectJunctions/DefaultDetectJunctionsTest.java
+++ b/src/test/java/net/imagej/ops/segment/detectJunctions/DefaultDetectJunctionsTest.java
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.segment.detectJunctions;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.segment.detectJunctions.DefaultDetectJunctions;
+import net.imglib2.RealPoint;
+import net.imglib2.roi.geom.real.DefaultWritablePolyline;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link DefaultDetectJunctions}
+ * 
+ * @author Gabe Selzer
+ */
+public class DefaultDetectJunctionsTest extends AbstractOpTest {
+
+	@Test
+	public void TestRegression() {
+		List<DefaultWritablePolyline> lines = new ArrayList<>();
+
+		double threshold = Math.sqrt(2);
+
+		// create first polyline (horizontal)
+		List<RealPoint> list1 = new ArrayList<>();
+		RealPoint p = new RealPoint(-5, 0);
+		for (int i = 0; i < 10; i++) {
+			p.move(1, 0);
+			list1.add(new RealPoint(p));
+		}
+		lines.add(new DefaultWritablePolyline(list1));
+
+		// create second polyline (vertical)
+		List<RealPoint> list2 = new ArrayList<>();
+		p.setPosition(0, 0);
+		p.setPosition(-5, 1);
+		for (int i = 0; i < 10; i++) {
+			p.move(1, 1);
+			list2.add(new RealPoint(p));
+		}
+		lines.add(new DefaultWritablePolyline(list2));
+
+		// create third polyline (diagonal)
+		List<RealPoint> list3 = new ArrayList<>();
+		p.setPosition(-15, 0);
+		p.setPosition(-15, 1);
+		for (int i = 0; i < 20; i++) {
+			p.move(1, 0);
+			p.move(1, 1);
+			list3.add(new RealPoint(p));
+		}
+		lines.add(new DefaultWritablePolyline(list3));
+
+		// create fourth polyline (vertical, different intersection point)
+		List<RealPoint> list4 = new ArrayList<>();
+		p.setPosition(-11, 0);
+		p.setPosition(-18, 1);
+		for (int i = 0; i < 7; i++) {
+			p.move(1, 1);
+			list4.add(new RealPoint(p));
+		}
+		lines.add(new DefaultWritablePolyline(list4));
+
+		List<RealPoint> results;
+		results = (List<RealPoint>) ops.run(
+			net.imagej.ops.segment.detectJunctions.DefaultDetectJunctions.class, lines,
+			threshold);
+
+		List<RealPoint> expected = new ArrayList<>();
+		expected.add(new RealPoint(0, 0));
+		expected.add(new RealPoint(-11, -11));
+
+		for (int i = 0; i < results.size(); i++) {
+			assertEquals(results.get(i).getDoublePosition(0), expected.get(i)
+				.getDoublePosition(0), 0);
+			assertEquals(results.get(i).getDoublePosition(1), expected.get(i)
+				.getDoublePosition(1), 0);
+		}
+
+	}
+
+}

--- a/src/test/java/net/imagej/ops/segment/detectRidges/DefaultDetectRidgesTest.java
+++ b/src/test/java/net/imagej/ops/segment/detectRidges/DefaultDetectRidgesTest.java
@@ -1,0 +1,167 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, University of Konstanz and Brian Northan.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.segment.detectRidges;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.OpMatchingService;
+import net.imagej.ops.OpService;
+import net.imagej.ops.Ops;
+import net.imagej.ops.segment.detectRidges.DefaultDetectRidges;
+import net.imglib2.RandomAccess;
+import net.imglib2.RealPoint;
+import net.imglib2.img.Img;
+import net.imglib2.roi.geom.real.DefaultWritablePolyline;
+import net.imglib2.roi.util.RealLocalizableRealPositionable;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.app.StatusService;
+import org.scijava.cache.CacheService;
+import org.scijava.ui.UIService;
+
+/**
+ * Tests for {@link DefaultDetectRidges}
+ * 
+ * @author Gabe Selzer
+ *
+ */
+public class DefaultDetectRidgesTest extends AbstractOpTest {
+
+	@Override
+	protected Context createContext() {
+		return new Context(OpService.class, OpMatchingService.class,
+			CacheService.class, StatusService.class, UIService.class);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testTooFewDimensions() {
+		Img<FloatType> input = generateFloatArrayTestImg(false, 30);
+		
+		// run the image through ridge detection
+		int width = 1, ridgeLengthMin = 4;
+		double lowerThreshold = 2, higherThreshold = 4;
+
+		List<DefaultWritablePolyline> polylines = (List<DefaultWritablePolyline>) ops.run(
+			Ops.Segment.DetectRidges.class, input, width, lowerThreshold,
+			higherThreshold, ridgeLengthMin);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testTooManyDimensions() {
+		Img<FloatType> input = generateFloatArrayTestImg(false, 30, 30, 30, 30);
+		
+		// run the image through ridge detection
+		int width = 1, ridgeLengthMin = 4;
+		double lowerThreshold = 2, higherThreshold = 4;
+
+		List<DefaultWritablePolyline> polylines = (List<DefaultWritablePolyline>) ops.run(
+			Ops.Segment.DetectRidges.class, input, width, lowerThreshold,
+			higherThreshold, ridgeLengthMin);
+	}
+
+	@Test
+	public void RegressionTest() {
+		Img<FloatType> input = generateFloatArrayTestImg(false, 30, 30);
+		RandomAccess<FloatType> linePainter = input.randomAccess();
+
+		// paint lines on the input image
+		// vertical line, then horizontal line
+		for (int i = 0; i < 2; i++) {
+			linePainter.setPosition(15, i);
+			for (int j = 2; j < 12; j++) {
+				linePainter.setPosition(j, 1 - i);
+				linePainter.get().set(256);
+			}
+		}
+		// diagonal line
+		for (int j = 0; j < 10; j++) {
+			linePainter.setPosition(j, 0);
+			linePainter.setPosition(j, 1);
+			linePainter.get().set(256);
+		}
+		// circle
+		int radius = 4, h = 22, k = 22;
+		for (double a = 0; a < 2 * Math.PI; a += (Math.PI / (4 * radius))) {
+			linePainter.setPosition(h + (int) Math.round(radius * Math.cos(a)), 0);
+			linePainter.setPosition(k + (int) Math.round(radius * Math.sin(a)), 1);
+			linePainter.get().set(256);
+		}
+
+		// run the image through ridge detection
+		int width = 1, ridgeLengthMin = 4;
+		double lowerThreshold = 2, higherThreshold = 4;
+
+		List<DefaultWritablePolyline> polylines = (List<DefaultWritablePolyline>) ops.run(
+			Ops.Segment.DetectRidges.class, input, width, lowerThreshold,
+			higherThreshold, ridgeLengthMin);
+
+		int vertexCount = 0;
+		for (DefaultWritablePolyline pline : polylines) {
+			for (int i = 0; i < pline.numVertices(); i++) {
+				RealLocalizableRealPositionable p = pline.vertex(i);
+				assertEquals(p.getDoublePosition(0), plineVertices[vertexCount++],
+					1e-5);
+				assertEquals(p.getDoublePosition(1), plineVertices[vertexCount++],
+					1e-5);
+			}
+		}
+
+	}
+
+	double[] plineVertices = { 15.0, 12.0, 15.0, 11.0, 15.0, 10.0, 15.0, 9.0,
+		15.0, 8.0, 15.0, 7.0, 15.0, 6.0, 15.0, 5.0, 15.0, 4.0, 15.0, 3.0, 15.0, 2.0,
+		15.0, 1.0, 1.0, 15.0, 2.0, 15.0, 3.0, 15.0, 4.0, 15.0, 5.0, 15.0, 6.0, 15.0,
+		7.0, 15.0, 8.0, 15.0, 9.0, 15.0, 10.0, 15.0, 11.0, 15.0, 12.0, 15.0,
+		22.99751187109411, 18.020211123079733, 23.91666828802532,
+		18.083331199962224, 24.916668629361407, 19.083331370638593,
+		25.916668800037776, 20.08333171197468, 25.979788876920267,
+		21.00248812890589, 25.999999914664198, 22.0, 25.979788876920267,
+		22.99751187109411, 25.916668800037776, 23.91666828802532,
+		24.916668629361407, 24.916668629361407, 23.91666828802532,
+		25.916668800037776, 22.99751187109411, 25.979788876920267, 22.0,
+		25.999999914664198, 21.00248812890589, 25.979788876920267,
+		20.08333171197468, 25.916668800037776, 19.083331370638593,
+		24.916668629361407, 18.083331199962224, 23.91666828802532,
+		18.020211123079733, 22.99751187109411, 18.000000085335802, 22.0,
+		18.020211123079733, 21.00248812890589, 18.083331199962224,
+		20.08333171197468, 19.083331370638593, 19.083331370638593,
+		20.08333171197468, 18.083331199962224, 21.00248812890589,
+		18.020211123079733, 22.0, 18.000000085335802, 9.999999999999869,
+		9.000000085339167, 9.0, 9.0, 8.0, 8.0, 7.0, 7.0, 6.0, 6.0, 5.0, 5.0, 4.0,
+		4.0, 3.0, 3.0, 2.0, 2.0, 1.0, 1.0, 0.0, 0.8333387946876465 };
+
+}


### PR DESCRIPTION
This PR adds support for a Ridge Detection algorithm, inspired by Thorsten Wagner's [original implementation](https://imagej.net/Ridge_Detection) and adapted from Carsten Steger's [paper](https://pdfs.semanticscholar.org/86de/a10b5c7b831a24132db3e4b50a01f9f001b0.pdf). The PR adds multiple ops intended to be used in a single workflow however separated to accommodate user preferences. The package includes a Ridge Detection algorithm, used to find bright "Curvilinear Structures" against a dark background, and a Junction Detection algorithm used to find junctions or near junctions (as determined by the threshold parameter) between a list of polylines. As of now the algorithm package is not yet complete, however this PR is being made for the forum discussion about the scientific need for the current and potentially future ops. Any input on the ops would be greatly appreciated there. Before this PR is merged the snapshot dependency on the Imglib2 ROIs will need to be sorted out as well. 