### PR TITLE
Improve invert Namespace to prevent mismatching between invert ops

### DIFF
--- a/src/main/java/net/imagej/ops/OpMethod.java
+++ b/src/main/java/net/imagej/ops/OpMethod.java
@@ -47,4 +47,13 @@ public @interface OpMethod {
 
 	Class<? extends Op>[] ops() default {};
 
+	/**
+	 * A HACK to allow whitelisting known-good namespace method signatures.
+	 * <p>
+	 * Methods with this attribute set to true will still count toward namespace
+	 * completeness, but their the strict type argument check will be skipped.
+	 * <em>DO NOT USE THIS UNLESS YOU ARE CONFIDENT IT IS CORRECT AND NEEDED.</em>
+	 * </p>
+	 */
+	boolean skipTypeCheck() default false;
 }

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -254,9 +254,8 @@ public class ImageNamespace extends AbstractNamespace {
 	// -- invert --
 
 	/** Executes the "invert" operation on the given arguments. */
-	@OpMethod(ops = {net.imagej.ops.image.invert.InvertII.class,
-		net.imagej.ops.image.invert.InvertIIInteger.class
-	})
+	@OpMethod(ops = { net.imagej.ops.image.invert.InvertII.class,
+		net.imagej.ops.image.invert.InvertIIInteger.class }, skipTypeCheck = true)
 	public <T extends RealType<T>> IterableInterval<T>
 		invert(final IterableInterval<T> out, final IterableInterval<T> in)
 	{
@@ -271,7 +270,7 @@ public class ImageNamespace extends AbstractNamespace {
 	 * {@link RealType} minimum.
 	 */
 	@OpMethod(ops = { net.imagej.ops.image.invert.InvertII.class,
-		net.imagej.ops.image.invert.InvertIIInteger.class })
+		net.imagej.ops.image.invert.InvertIIInteger.class }, skipTypeCheck = true)
 	public <T extends RealType<T>> IterableInterval<T> invert(
 		final IterableInterval<T> out, final IterableInterval<T> in,
 		final T min)
@@ -287,7 +286,7 @@ public class ImageNamespace extends AbstractNamespace {
 	 * {@link RealType} minimum.
 	 */
 	@OpMethod(ops = { net.imagej.ops.image.invert.InvertII.class,
-		net.imagej.ops.image.invert.InvertIIInteger.class })
+		net.imagej.ops.image.invert.InvertIIInteger.class }, skipTypeCheck = true)
 	public <T extends RealType<T>> IterableInterval<T>
 		invert(final IterableInterval<T> out, final IterableInterval<T> in,
 			final T min, final T max)

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -40,7 +40,6 @@ import net.imglib2.histogram.Histogram1d;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.Type;
-import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.IntType;
 
@@ -258,7 +257,7 @@ public class ImageNamespace extends AbstractNamespace {
 	@OpMethod(ops = {net.imagej.ops.image.invert.InvertII.class,
 		net.imagej.ops.image.invert.InvertIIInteger.class
 	})
-	public <T extends RealType> IterableInterval<T>
+	public <T extends RealType<T>> IterableInterval<T>
 		invert(final IterableInterval<T> out, final IterableInterval<T> in)
 	{
 		@SuppressWarnings("unchecked")
@@ -275,7 +274,7 @@ public class ImageNamespace extends AbstractNamespace {
 		net.imagej.ops.image.invert.InvertIIInteger.class })
 	public <T extends RealType<T>> IterableInterval<T> invert(
 		final IterableInterval<T> out, final IterableInterval<T> in,
-		final RealType<T> min)
+		final T min)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
@@ -291,7 +290,7 @@ public class ImageNamespace extends AbstractNamespace {
 		net.imagej.ops.image.invert.InvertIIInteger.class })
 	public <T extends RealType<T>> IterableInterval<T>
 		invert(final IterableInterval<T> out, final IterableInterval<T> in,
-			final RealType<T> min, final RealType<T> max)
+			final T min, final T max)
 	{
 		@SuppressWarnings("unchecked")
 		final IterableInterval<T> result = (IterableInterval<T>) ops().run(

--- a/src/main/java/net/imagej/ops/image/ImageNamespace.java
+++ b/src/main/java/net/imagej/ops/image/ImageNamespace.java
@@ -256,57 +256,46 @@ public class ImageNamespace extends AbstractNamespace {
 
 	/** Executes the "invert" operation on the given arguments. */
 	@OpMethod(ops = {net.imagej.ops.image.invert.InvertII.class,
-									net.imagej.ops.image.invert.InvertIIInteger.class})
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
-			final IterableInterval<O> out, final IterableInterval<I> in) {
+		net.imagej.ops.image.invert.InvertIIInteger.class
+	})
+	public <T extends RealType> IterableInterval<T>
+		invert(final IterableInterval<T> out, final IterableInterval<T> in)
+	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.Ops.Image.Invert.class, out,
-				in);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Invert.class, out, in);
 		return result;
 	}
 
-	/** Executes the "invert" operation on the given arguments, given a {@link RealType} minimum. */
-	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
-			final IterableInterval<O> out, final IterableInterval<I> in, final RealType<I> min) {
+	/**
+	 * Executes the "invert" operation on the given arguments, given a
+	 * {@link RealType} minimum.
+	 */
+	@OpMethod(ops = { net.imagej.ops.image.invert.InvertII.class,
+		net.imagej.ops.image.invert.InvertIIInteger.class })
+	public <T extends RealType<T>> IterableInterval<T> invert(
+		final IterableInterval<T> out, final IterableInterval<T> in,
+		final RealType<T> min)
+	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.Ops.Image.Invert.class, out,
-				in);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Invert.class, out, in, min);
 		return result;
 	}
 
-	/** Executes the "invert" operation on the given arguments, given a {@link IntegerType} minimum. */
-	@OpMethod(op = net.imagej.ops.image.invert.InvertIIInteger.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
-			final IterableInterval<O> out, final IterableInterval<I> in, final IntegerType min) {
+	/**
+	 * Executes the "invert" operation on the given arguments, given a
+	 * {@link RealType} minimum.
+	 */
+	@OpMethod(ops = { net.imagej.ops.image.invert.InvertII.class,
+		net.imagej.ops.image.invert.InvertIIInteger.class })
+	public <T extends RealType<T>> IterableInterval<T>
+		invert(final IterableInterval<T> out, final IterableInterval<T> in,
+			final RealType<T> min, final RealType<T> max)
+	{
 		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.Ops.Image.Invert.class, out,
-				in);
-		return result;
-	}
-
-	/** Executes the "invert" operation on the given arguments, given a {@link RealType} minimum. */
-	@OpMethod(op = net.imagej.ops.image.invert.InvertII.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
-			final IterableInterval<O> out, final IterableInterval<I> in, final RealType<I> min, final RealType<I> max) {
-		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.Ops.Image.Invert.class, out,
-				in);
-		return result;
-	}
-
-	/** Executes the "invert" operation on the given arguments, given a {@link IntegerType} minimum. */
-	@OpMethod(op =	net.imagej.ops.image.invert.InvertIIInteger.class)
-	public <I extends RealType<I>, O extends RealType<O>> IterableInterval<O> invert(
-			final IterableInterval<O> out, final IterableInterval<I> in, final IntegerType min, final IntegerType max) {
-		@SuppressWarnings("unchecked")
-		final IterableInterval<O> result = (IterableInterval<O>) ops().run(
-				net.imagej.ops.Ops.Image.Invert.class, out,
-				in);
+		final IterableInterval<T> result = (IterableInterval<T>) ops().run(
+			net.imagej.ops.Ops.Image.Invert.class, out, in, min, max);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/image/invert/InvertII.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertII.java
@@ -80,12 +80,12 @@ public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
 
 					@Override
 					public void compute(I in, O out) {
-						if ((minMax - in
-							.getRealDouble()) <= out.getMinValue()) out.setReal(out
-								.getMinValue());
-						else if ((minMax - in
-							.getRealDouble()) >= out.getMaxValue()) out.setReal(out
-								.getMaxValue());
+						if ((minMax - in.getRealDouble()) <= out.getMinValue()) {
+							out.setReal(out.getMinValue());
+						}
+						else if ((minMax - in.getRealDouble()) >= out.getMaxValue()) {
+							out.setReal(out.getMaxValue());
+						}
 						else out.setReal(minMax - in.getRealDouble());
 					}
 				});

--- a/src/main/java/net/imagej/ops/image/invert/InvertII.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertII.java
@@ -44,23 +44,23 @@ import org.scijava.plugin.Plugin;
  * @author Martin Horn (University of Konstanz)
  * @author Gabe Selzer
  */
-@Plugin(type = Ops.Image.Invert.class, priority = Priority.NORMAL)
-public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
-	AbstractUnaryComputerOp<IterableInterval<I>, IterableInterval<O>> implements
+@Plugin(type = Ops.Image.Invert.class)
+public class InvertII<T extends RealType<T>> extends
+	AbstractUnaryComputerOp<IterableInterval<T>, IterableInterval<T>> implements
 	Ops.Image.Invert
 {
 
 	@Parameter(required = false)
-	private I min;
+	private T min;
 
 	@Parameter(required = false)
-	private I max;
+	private T max;
 
-	private UnaryComputerOp<IterableInterval<I>, IterableInterval<O>> mapper;
+	private UnaryComputerOp<IterableInterval<T>, IterableInterval<T>> mapper;
 
 	@Override
-	public void compute(final IterableInterval<I> input,
-		final IterableInterval<O> output)
+	public void compute(final IterableInterval<T> input,
+		final IterableInterval<T> output)
 	{
 		if (mapper == null) {
 			final double minValue = min == null ? input.firstElement().getMinValue() : //
@@ -69,11 +69,11 @@ public class InvertII<I extends RealType<I>, O extends RealType<O>> extends
 				max.getRealDouble();
 			final double minMax = maxValue + minValue;
 			mapper = Computers.unary(ops(), Ops.Map.class, output, input,
-				new AbstractUnaryComputerOp<I, O>()
+				new AbstractUnaryComputerOp<T, T>()
 			{
 
 					@Override
-					public void compute(I in, O out) {
+					public void compute(T in, T out) {
 						if ((minMax - in.getRealDouble()) <= out.getMinValue()) {
 							out.setReal(out.getMinValue());
 						}

--- a/src/main/java/net/imagej/ops/image/invert/InvertII.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertII.java
@@ -29,20 +29,14 @@
 
 package net.imagej.ops.image.invert;
 
-import java.math.BigDecimal;
-
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imagej.ops.special.function.Functions;
-import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
-import net.imglib2.util.Pair;
 
-import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 

--- a/src/main/java/net/imagej/ops/image/invert/InvertIIInteger.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertIIInteger.java
@@ -30,25 +30,20 @@
 
 package net.imagej.ops.image.invert;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
-import net.imagej.ops.special.function.Functions;
-import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imagej.types.UnboundedIntegerType;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.integer.AbstractIntegerType;
 import net.imglib2.type.numeric.integer.LongType;
 import net.imglib2.type.numeric.integer.Unsigned128BitType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
-import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
-import net.imglib2.util.Pair;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;

--- a/src/main/java/net/imagej/ops/image/invert/InvertIIInteger.java
+++ b/src/main/java/net/imagej/ops/image/invert/InvertIIInteger.java
@@ -127,10 +127,13 @@ public class InvertIIInteger<T extends RealType<T>> extends
 	@Override
 	public boolean conforms() {
 		final T inType = in().firstElement();
-		return inType instanceof Unsigned128BitType ||
-			inType instanceof UnsignedLongType ||
-			inType instanceof UnboundedIntegerType ||
-			inType instanceof LongType;
+		
+		if (inType instanceof IntegerType) {
+			final IntegerType<?> copy = (IntegerType<?>) inType.createVariable();
+			copy.setInteger(Long.MAX_VALUE);
+			return copy.getIntegerLong() == Long.MAX_VALUE;
+		}
+		return false;
 	}
 
 }

--- a/src/test/java/net/imagej/ops/AbstractNamespaceTest.java
+++ b/src/test/java/net/imagej/ops/AbstractNamespaceTest.java
@@ -182,8 +182,14 @@ public abstract class AbstractNamespaceTest extends AbstractOpTest {
 
 			if (!checkVarArgs(method)) success = false;
 
+			// HACK: Allow @OpMethod to specify that type checking should be skipped.
+			final OpMethod opMethod = method.getAnnotation(OpMethod.class);
+			final boolean checkTypes = opMethod == null || !opMethod.skipTypeCheck();
+
 			for (final Class<? extends Op> opType : opTypes(method)) {
-				if (!checkOpImpl(method, qName, opType, coverSet)) success = false;
+				if (!checkOpImpl(method, qName, opType, coverSet, checkTypes)) {
+					success = false;
+				}
 			}
 		}
 
@@ -257,31 +263,37 @@ public abstract class AbstractNamespaceTest extends AbstractOpTest {
 	 * @param qName The fully qualified (with namespace) name of the op.
 	 * @param opType The {@link Op} to which the method should be compared.
 	 * @param coverSet The set of ops which have already matched a method.
+	 * @param checkTypes Whether to validate that the method's type arguments and
+	 *          return type match the given op implementation's types.
 	 * @return true iff the method and {@link Op} match up.
 	 */
 	private boolean checkOpImpl(final Method method, final String qName,
-		final Class<? extends Op> opType, final OpCoverSet coverSet)
+		final Class<? extends Op> opType, final OpCoverSet coverSet,
+		final boolean checkTypes)
 	{
 		// TODO: Type matching needs to be type<->type instead of class<->type.
 		// That is, the "special class placeholder" also needs to work with Type.
 		// Then we can pass Types here instead of Class instances.
 		// final Object[] argTypes = method.getGenericParameterTypes();
 		final Object[] argTypes = method.getParameterTypes();
-		final OpRef ref = OpRef.create(qName, argTypes);
 		final OpInfo info = ops.info(opType);
-		final OpCandidate candidate = new OpCandidate(ops, ref, info);
 
-		// check input types
-		if (!inputTypesMatch(candidate)) {
-			error("Mismatched inputs", opType, method);
-			return false;
-		}
+		if (checkTypes) {
+			final OpRef ref = OpRef.create(qName, argTypes);
+			final OpCandidate candidate = new OpCandidate(ops, ref, info);
 
-		// check output types
-		final Type returnType = method.getGenericReturnType();
-		if (!outputTypesMatch(returnType, candidate)) {
-			error("Mismatched outputs", opType, method);
-			return false;
+			// check input types
+			if (!inputTypesMatch(candidate)) {
+				error("Mismatched inputs", opType, method);
+				return false;
+			}
+
+			// check output types
+			final Type returnType = method.getGenericReturnType();
+			if (!outputTypesMatch(returnType, candidate)) {
+				error("Mismatched outputs", opType, method);
+				return false;
+			}
 		}
 
 		// mark this op as covered (w.r.t. the given number of args)

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -30,11 +30,13 @@
 package net.imagej.ops.image.invert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 import java.math.BigInteger;
 
 import net.imagej.ops.AbstractOpTest;
+import net.imagej.ops.Op;
 import net.imagej.ops.Ops;
 import net.imagej.types.UnboundedIntegerType;
 import net.imglib2.Cursor;
@@ -316,7 +318,9 @@ public class InvertTest extends AbstractOpTest {
 		min.setReal(type.getMinValue());
 		final T max = type.copy();
 		max.setReal(type.getMaxValue());
-		ops.run(InvertII.class, out, in);
+		final Op op = ops.op(Ops.Image.Invert.class, out, in);
+		assertSame(InvertII.class, op.getClass());
+		op.run();
 
 		defaultCompare(in, out, min, max);
 	}
@@ -326,7 +330,9 @@ public class InvertTest extends AbstractOpTest {
 			final T min, final T max)
 	{
 
-		ops.run(InvertII.class, out, in, (min), (max));
+		final Op op = ops.op(Ops.Image.Invert.class, out, in, (min), (max));
+		assertSame(InvertII.class, op.getClass());
+		op.run();
 
 		defaultCompare(in, out, min, max);
 	}
@@ -359,7 +365,9 @@ public class InvertTest extends AbstractOpTest {
 	{
 
 		// unsigned type test
-		ops.run(Ops.Image.Invert.class, out, in, min, max);
+		final Op op = ops.op(Ops.Image.Invert.class, out, in, min, max);
+		assertSame(InvertIIInteger.class, op.getClass());
+		op.run();
 
 		integerCompare(in, out, min, max);
 
@@ -369,7 +377,9 @@ public class InvertTest extends AbstractOpTest {
 		assertIntegerInvert(final Img<T> in, final Img<T> out)
 	{
 
-		ops.run(Ops.Image.Invert.class, out, in);
+		final Op op = ops.op(Ops.Image.Invert.class, out, in);
+		assertSame(InvertIIInteger.class, op.getClass());
+		op.run();
 		
 		Cursor<T> inCursor = in.localizingCursor();
 		Cursor<T> outCursor = out.localizingCursor();

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -30,6 +30,7 @@
 package net.imagej.ops.image.invert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.math.BigInteger;
 
@@ -397,6 +398,9 @@ public class InvertTest extends AbstractOpTest {
 		if (min == null && max == null) {
 			minMax = InvertIIInteger.minValue(in.firstElement()).getBigInteger().add(
 				InvertIIInteger.maxValue(in.firstElement()).getBigInteger());
+		}
+		else if (min == null || max == null) {
+			fail("Internal coding error");
 		}
 		else {
 			minMax = min.getBigInteger().add(max.getBigInteger());

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -126,20 +126,6 @@ public class InvertTest extends AbstractOpTest {
 	}
 
 	@Test
-	public void
-		testUnsigned12BitTypeInvertToUnsignedVariableBitLengthTypeInvert()
-	{
-		final Img<Unsigned12BitType> inUnsigned12BitType =
-			generateUnsigned12BitArrayTestImg(true, 5, 5);
-		final Img<UnsignedVariableBitLengthType> outUnsignedVariableBitLengthType =
-			generateUnsignedVariableBitLengthTypeArrayTestImg(false, 64, 5, 5);
-		assertIntegerInvert(inUnsigned12BitType, outUnsignedVariableBitLengthType);
-		assertIntegerInvertMinMaxProvided(inUnsigned12BitType,
-			outUnsignedVariableBitLengthType, new Unsigned12BitType(1),
-			new Unsigned12BitType(17));
-	}
-
-	@Test
 	public void testUnsignedByteTypeInvert() {
 		final Img<UnsignedByteType> inUnsignedByteType =
 			generateUnsignedByteArrayTestImg(true, 5, 5);
@@ -187,13 +173,6 @@ public class InvertTest extends AbstractOpTest {
 	}
 
 	@Test
-	public void testDoubleTypeToIntTypeInvert() {
-		final Img<DoubleType> inDoubleType = generateDoubleArrayTestImg(true, 5, 5);
-		final Img<IntType> outIntType = generateIntArrayTestImg(false, 5, 5);
-		assertDefaultInvert(inDoubleType, outIntType);
-	}
-
-	@Test
 	public void testFloatTypeInvert() {
 		final Img<FloatType> inFloatType = generateFloatArrayTestImg(true, 5, 5);
 		final Img<FloatType> outFloatType = inFloatType.factory().create(
@@ -213,26 +192,6 @@ public class InvertTest extends AbstractOpTest {
 			new IntType(40));
 		assertDefaultInvertMinMaxProvided(inIntType, outIntType, new IntType(
 			Integer.MIN_VALUE), new IntType(-10));
-	}
-
-	@Test
-	public void testIntTypeToDoubleTypeInvert() {
-		final Img<IntType> inIntType = generateIntArrayTestImg(true, 5, 5);
-		final Img<DoubleType> outDoubleType = generateDoubleArrayTestImg(false, 5,
-			5);
-		assertDefaultInvert(inIntType, outDoubleType);
-		assertDefaultInvertMinMaxProvided(inIntType, outDoubleType, new IntType(
-			Integer.MAX_VALUE), new IntType(Integer.MAX_VALUE));
-	}
-
-	@Test
-	public void testIntTypeToUnboundedIntegerTypeInvert() {
-		final Img<IntType> inIntType = generateIntArrayTestImg(false, 5, 5);
-		final Img<UnboundedIntegerType> outUnboundedIntegerType =
-			generateUnboundedIntegerTypeListTestImg(true, 5, 5);
-		assertIntegerInvert(inIntType, outUnboundedIntegerType);
-		assertIntegerInvertMinMaxProvided(inIntType, outUnboundedIntegerType,
-			new IntType(Integer.MAX_VALUE - 1), new IntType(Integer.MAX_VALUE));
 	}
 
 	@Test
@@ -296,18 +255,6 @@ public class InvertTest extends AbstractOpTest {
 	}
 
 	@Test
-	public void testShortTypeToUnsignedShortTypeInvert() {
-		final Img<ShortType> inShortType = generateShortArrayTestImg(true, 5, 5);
-		final Img<UnsignedShortType> outUnsignedShortType =
-			generateUnsignedShortArrayTestImg(false, 5, 5);
-		assertDefaultInvert(inShortType, outUnsignedShortType);
-		assertDefaultInvertMinMaxProvided(inShortType, outUnsignedShortType,
-			new ShortType((Short.MAX_VALUE)), new ShortType((Short.MAX_VALUE)));
-		assertDefaultInvertMinMaxProvided(inShortType, outUnsignedShortType,
-			new ShortType((short) (-5)), new ShortType((short) -3));
-	}
-
-	@Test
 	public void testUnsignedShortTypeInvert() {
 		final Img<UnsignedShortType> inUnsignedShortType =
 			generateUnsignedShortArrayTestImg(true, 5, 5);
@@ -316,17 +263,6 @@ public class InvertTest extends AbstractOpTest {
 		assertDefaultInvert(inUnsignedShortType, outUnsignedShortType);
 		assertDefaultInvertMinMaxProvided(inUnsignedShortType, outUnsignedShortType,
 			new UnsignedShortType((short) 437), new UnsignedShortType((short) 8008));
-	}
-
-	@Test
-	public void testUnsignedShortTypeToShortTypeInvert() {
-		final Img<UnsignedShortType> inUnsignedShortType =
-			generateUnsignedShortArrayTestImg(true, 5, 5);
-		final Img<ShortType> outShortType = generateShortArrayTestImg(false, 5, 5);
-		assertDefaultInvert(inUnsignedShortType, outShortType);
-		assertDefaultInvertMinMaxProvided(inUnsignedShortType, outShortType,
-			new UnsignedShortType((short) 65540), new UnsignedShortType(
-				(short) 70000));
 	}
 
 	@Test
@@ -343,17 +279,6 @@ public class InvertTest extends AbstractOpTest {
 		assertIntegerInvertMinMaxProvided(inUnboundedIntegerType,
 			outUnboundedIntegerType, new UnboundedIntegerType(0),
 			new UnboundedIntegerType(1));
-	}
-
-	@Test
-	public void testUnboundedIntegerTypeToIntTypeInvert() {
-		final Img<UnboundedIntegerType> inUnboundedIntegerType =
-			generateUnboundedIntegerTypeListTestImg(true, 5, 5);
-		final Img<IntType> outIntType = generateIntArrayTestImg(false, 5, 5);
-		assertIntegerInvert(inUnboundedIntegerType, outIntType);
-		assertIntegerInvertMinMaxProvided(inUnboundedIntegerType, outIntType,
-			new UnboundedIntegerType(Integer.MAX_VALUE), new UnboundedIntegerType(
-				Integer.MAX_VALUE + 1));
 	}
 
 	@Test
@@ -381,55 +306,43 @@ public class InvertTest extends AbstractOpTest {
 			new UnsignedVariableBitLengthType(1, 6));
 	}
 
-	@Test
-	public void testUnsignedVariableBitLengthTypeToUnsigned12BitTypeInvert() {
-		final Img<UnsignedVariableBitLengthType> inUnsignedVariableBitLengthType =
-			generateUnsignedVariableBitLengthTypeArrayTestImg(true, 64, 5, 5);
-		final Img<Unsigned12BitType> outUnsigned12BitType =
-			generateUnsigned12BitArrayTestImg(true, 5, 5);
-		assertIntegerInvert(inUnsignedVariableBitLengthType, outUnsigned12BitType);
-		assertIntegerInvertMinMaxProvided(inUnsignedVariableBitLengthType,
-			outUnsigned12BitType, new UnsignedVariableBitLengthType(4100, 13),
-			new UnsignedVariableBitLengthType(4500, 13));
-	}
-
-	private <I extends RealType<I>, O extends RealType<O>> void
-		assertDefaultInvert(final Img<I> in, final Img<O> out)
+	private <T extends RealType<T>> void
+		assertDefaultInvert(final Img<T> in, final Img<T> out)
 	{
 
-		final I type = in.firstElement();
-		final I min = type.copy();
+		final T type = in.firstElement();
+		final T min = type.copy();
 		min.setReal(type.getMinValue());
-		final I max = type.copy();
+		final T max = type.copy();
 		max.setReal(type.getMaxValue());
 		ops.run(InvertII.class, out, in);
 
 		defaultCompare(in, out, min, max);
 	}
 
-	private <I extends RealType<I>, O extends RealType<O>> void
-		assertDefaultInvertMinMaxProvided(final Img<I> in, final Img<O> out,
-			final RealType<I> min, final RealType<I> max)
+	private <T extends RealType<T>> void
+		assertDefaultInvertMinMaxProvided(final Img<T> in, final Img<T> out,
+			final T min, final T max)
 	{
 
 		ops.run(InvertII.class, out, in, (min), (max));
 
-		defaultCompare(in, out, (I) min, (I) max);
+		defaultCompare(in, out, min, max);
 	}
 
-	private <I extends RealType<I>, O extends RealType<O>> void defaultCompare(
-		final Img<I> in, final Img<O> out, final I min, final I max)
+	private <T extends RealType<T>> void defaultCompare(
+		final Img<T> in, final Img<T> out, final T min, final T max)
 	{
-		final Cursor<I> inAccess = in.localizingCursor();
-		final RandomAccess<O> outAccess = out.randomAccess();
+		final Cursor<T> inAccess = in.localizingCursor();
+		final RandomAccess<T> outAccess = out.randomAccess();
 		while (inAccess.hasNext()) {
-			final I inVal = inAccess.next();
+			final T inVal = inAccess.next();
 			outAccess.setPosition(inAccess);
-			final O outVal = outAccess.get();
+			final T outVal = outAccess.get();
 			final double bigIn = inVal.getRealDouble();
 			final double minMax = min.getRealDouble() + max.getRealDouble() - bigIn;
 			final double bigOut = outVal.getRealDouble();
-			final O minMaxType = outVal.createVariable();
+			final T minMaxType = outVal.createVariable();
 			minMaxType.setReal(minMax);
 			if (minMax <= outVal.getMinValue()) assertEquals(outVal.getMinValue(),
 				bigOut, 0.00005);
@@ -439,9 +352,9 @@ public class InvertTest extends AbstractOpTest {
 		}
 	}
 
-	private <I extends IntegerType<I>, O extends IntegerType<O>> void
-		assertIntegerInvertMinMaxProvided(final Img<I> in, final Img<O> out,
-			final I min, final I max)
+	private <T extends IntegerType<T>> void
+		assertIntegerInvertMinMaxProvided(final Img<T> in, final Img<T> out,
+			final T min, final T max)
 	{
 
 		// unsigned type test
@@ -451,18 +364,26 @@ public class InvertTest extends AbstractOpTest {
 
 	}
 
-	private <I extends IntegerType<I>, O extends IntegerType<O>> void
-		assertIntegerInvert(final Img<I> in, final Img<O> out)
+	private <T extends IntegerType<T>> void
+		assertIntegerInvert(final Img<T> in, final Img<T> out)
 	{
 
 		ops.run(Ops.Image.Invert.class, out, in);
-
+		
+		Cursor<T> inCursor = in.localizingCursor();
+		Cursor<T> outCursor = out.localizingCursor();
+		
+		while(inCursor.hasNext()) {
+			inCursor.fwd();
+			outCursor.fwd();
+		}
+		
 		integerCompare(in, out, null, null);
 	}
 
-	private <I extends IntegerType<I>, O extends IntegerType<O>> void
-		integerCompare(final Img<I> in, final Img<O> out, final IntegerType<I> min,
-			final IntegerType<I> max)
+	private <T extends IntegerType<T>> void
+		integerCompare(final Img<T> in, final Img<T> out, final IntegerType<T> min,
+			final IntegerType<T> max)
 	{
 
 		// Get min/max for the output type.
@@ -481,19 +402,22 @@ public class InvertTest extends AbstractOpTest {
 			minMax = min.getBigInteger().add(max.getBigInteger());
 		}
 
-		final Cursor<I> inAccess = in.localizingCursor();
-		final RandomAccess<O> outAccess = out.randomAccess();
+		final Cursor<T> inAccess = in.localizingCursor();
+		final RandomAccess<T> outAccess = out.randomAccess();
 		while (inAccess.hasNext()) {
-			final I inVal = inAccess.next();
+			final T inVal = inAccess.next();
 			outAccess.setPosition(inAccess);
-			final O outVal = outAccess.get();
+			final T outVal = outAccess.get();
 			final BigInteger bigIn = inVal.getBigInteger();
 			final BigInteger bigOut = outVal.getBigInteger();
 			final BigInteger calcOut = minMax.subtract(bigIn);
-			if (calcOut.compareTo(minOut) <= 0) assertEquals(minOut, bigOut);
-			else if (calcOut.compareTo(maxOut) >= 0) assertEquals(maxOut, bigOut);
+			if (calcOut.compareTo(minOut) <= 0) {
+				assertEquals(minOut, bigOut);
+			}
+			else if (calcOut.compareTo(maxOut) >= 0) {
+				assertEquals(maxOut, bigOut);
+			}
 			else {
-
 				assertEquals(calcOut, bigOut);
 
 			}

--- a/src/test/java/net/imagej/ops/image/invert/InvertTest.java
+++ b/src/test/java/net/imagej/ops/image/invert/InvertTest.java
@@ -64,6 +64,8 @@ import net.imglib2.type.numeric.real.FloatType;
 import org.junit.Test;
 
 /**
+ * Tests {@link InvertII} and {@link InvertIIInteger}.
+ * 
  * @author Martin Horn (University of Konstanz)
  * @author Gabe Selzer
  */


### PR DESCRIPTION
This PR contains a refactoring of the namespaces of the invert ops and all of the relevant changes associated. Initally both `InvertII` and `InvertIIInteger` were contained within a single ops interface, `Invert`; `InvertII` does its math using `double` and is relatively fast while `InvertIIInteger` uses `BigInteger` to accommodate types that cannot fit in `double` and is slower. `InvertII` relies on `RealType` inputs while `InvertIIInteger` relies on `IntegerType`, but otherwise the method signatures are the same for both methods. The similarity between the method signatures for the two ops confused the op matcher when looking to choose between the two, and as a result tests failed. To solve this problem another interface  `InvertBigTypes` was created to be used by `InvertIIInteger` to prevent any confusion on the op matcher's part.

There are a few naming and logistical concerns I have before merging this:

* `InvertBigTypes` and `InvertIIInteger` do not have consistent names: `InvertBigTypes` was chosen as the interface because the only reason `InvertIIInteger` should be called is when people need to use it for bigger type datasets, however I have left `InvertIIInteger` with the name it has always had because it does work for all `IntegerType`s. Despite this I wonder if the naming between the two should be more consistent.

* As of right now `Invert` and `InvertIIInteger` are tested in the same test class and are in the same source package, as they were before. I do not know if this should be changed.

@ctrueden As of now all commits build and all tests pass on each commit.