### PR TITLE
Set design lens RI equal to experiment lens RI

### DIFF
--- a/src/main/java/net/imagej/ops/create/kernelDiffraction/DefaultCreateKernelGibsonLanni.java
+++ b/src/main/java/net/imagej/ops/create/kernelDiffraction/DefaultCreateKernelGibsonLanni.java
@@ -111,6 +111,8 @@ public class DefaultCreateKernelGibsonLanni<T extends ComplexType<T> & NativeTyp
 	public void initialize() {
 		createOp = (BinaryFunctionOp) Functions.binary(ops(), Ops.Create.Img.class,
 			Img.class, Dimensions.class, NativeType.class);
+
+		ni0 = ni;
 	}
 
 	@Override
@@ -231,7 +233,7 @@ public class DefaultCreateKernelGibsonLanni<T extends ComplexType<T> & NativeTyp
 			beta = k0 * this.NA * r[n] * this.resLateral;
 
 			for (int m = 0; m < this.numBasis; m++) {
-				//am = (3 * m + 1) * factor;
+				// am = (3 * m + 1) * factor;
 				am = (3 * m + 1);
 				rm = am * bj1.value(am * b) * bj0.value(beta * b) * b;
 				rm = rm - beta * b * bj0.value(am * b) * bj1.value(beta * b);


### PR DESCRIPTION
This is a one line change to DefaultCreateKernelGibsonLanni.java that sets the default design lens refractive index (ni0) to be equal to the actual lens refractive index (ni).  Previously the design lens refractive index was hardcoded to 1.5, which resulted in aberrations in the generated PSF if the actual lens ri was not 1.5.  

This issue became apparent, when deconvolving an image that was shared on Twitter by Eugene Katrhuka.  The generated PSF wasn't right at first, but works now https://twitter.com/truenorth_ia/status/975685798229172224.  Twitter is actually a pretty useful way to waste time.  

Assuming all checks pass and no one has any other objections I'll merge this tomorrow.    