### PR TITLE
Rename to "DefaultPearsons" and "DefaultPValue"

### DIFF
--- a/src/main/java/net/imagej/ops/coloc/ColocNamespace.java
+++ b/src/main/java/net/imagej/ops/coloc/ColocNamespace.java
@@ -83,29 +83,29 @@ public class ColocNamespace extends AbstractNamespace {
 
 	// -- pearsons --
 
-	@OpMethod(op = net.imagej.ops.coloc.pearsons.Pearsons.class)
+	@OpMethod(op = net.imagej.ops.coloc.pearsons.DefaultPearsons.class)
 	public <T extends RealType<T>, U extends RealType<U>> Double pearsons(
 		final Iterable<T> image1, final Iterable<U> image2)
 	{
 		final Double result = (Double) ops().run(
-			net.imagej.ops.coloc.pearsons.Pearsons.class, image1, image2);
+			net.imagej.ops.coloc.pearsons.DefaultPearsons.class, image1, image2);
 		return result;
 	}
 
 	// -- pValue --
 
-	@OpMethod(op = net.imagej.ops.coloc.pValue.PValue.class)
+	@OpMethod(op = net.imagej.ops.coloc.pValue.DefaultPValue.class)
 	public <T extends RealType<T>, U extends RealType<U>> PValueResult pValue(
 		final PValueResult out, final RandomAccessibleInterval<T> in1,
 		final RandomAccessibleInterval<U> in2,
 		final BinaryFunctionOp<Iterable<T>, Iterable<U>, Double> op)
 	{
 		final PValueResult result = (PValueResult) ops().run(
-			net.imagej.ops.coloc.pValue.PValue.class, out, in1, in2, op);
+			net.imagej.ops.coloc.pValue.DefaultPValue.class, out, in1, in2, op);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.coloc.pValue.PValue.class)
+	@OpMethod(op = net.imagej.ops.coloc.pValue.DefaultPValue.class)
 	public <T extends RealType<T>, U extends RealType<U>> PValueResult pValue(
 		final PValueResult out, final RandomAccessibleInterval<T> in1,
 		final RandomAccessibleInterval<U> in2,
@@ -113,12 +113,12 @@ public class ColocNamespace extends AbstractNamespace {
 		final int nrRandomizations)
 	{
 		final PValueResult result = (PValueResult) ops().run(
-			net.imagej.ops.coloc.pValue.PValue.class, out, in1, in2, op,
+			net.imagej.ops.coloc.pValue.DefaultPValue.class, out, in1, in2, op,
 			nrRandomizations);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.coloc.pValue.PValue.class)
+	@OpMethod(op = net.imagej.ops.coloc.pValue.DefaultPValue.class)
 	public <T extends RealType<T>, U extends RealType<U>> PValueResult pValue(
 		final PValueResult out, final RandomAccessibleInterval<T> in1,
 		final RandomAccessibleInterval<U> in2,
@@ -126,12 +126,12 @@ public class ColocNamespace extends AbstractNamespace {
 		final int nrRandomizations, final Dimensions psfSize)
 	{
 		final PValueResult result = (PValueResult) ops().run(
-			net.imagej.ops.coloc.pValue.PValue.class, out, in1, in2, op,
+			net.imagej.ops.coloc.pValue.DefaultPValue.class, out, in1, in2, op,
 			nrRandomizations, psfSize);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.coloc.pValue.PValue.class)
+	@OpMethod(op = net.imagej.ops.coloc.pValue.DefaultPValue.class)
 	public <T extends RealType<T>, U extends RealType<U>> PValueResult pValue(
 		final PValueResult out, final RandomAccessibleInterval<T> in1,
 		final RandomAccessibleInterval<U> in2,
@@ -139,7 +139,7 @@ public class ColocNamespace extends AbstractNamespace {
 		final int nrRandomizations, final Dimensions psfSize, final long seed)
 	{
 		final PValueResult result = (PValueResult) ops().run(
-			net.imagej.ops.coloc.pValue.PValue.class, out, in1, in2, op,
+			net.imagej.ops.coloc.pValue.DefaultPValue.class, out, in1, in2, op,
 			nrRandomizations, psfSize, seed);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/coloc/pValue/DefaultPValue.java
+++ b/src/main/java/net/imagej/ops/coloc/pValue/DefaultPValue.java
@@ -51,7 +51,7 @@ import org.scijava.plugin.Plugin;
  * Statistical Approach".
  */
 @Plugin(type = Ops.Coloc.PValue.class)
-public class PValue<T extends RealType<T>, U extends RealType<U>> extends
+public class DefaultPValue<T extends RealType<T>, U extends RealType<U>> extends
 	AbstractBinaryComputerOp<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, PValueResult>
 	implements Ops.Coloc.PValue
 {

--- a/src/main/java/net/imagej/ops/coloc/pearsons/DefaultPearsons.java
+++ b/src/main/java/net/imagej/ops/coloc/pearsons/DefaultPearsons.java
@@ -44,7 +44,7 @@ import org.scijava.plugin.Plugin;
  * @author Ellen T Arena
  */
 @Plugin(type = Ops.Coloc.Pearsons.class)
-public class Pearsons<T extends RealType<T>, U extends RealType<U>> extends
+public class DefaultPearsons<T extends RealType<T>, U extends RealType<U>> extends
 	AbstractBinaryFunctionOp<Iterable<T>, Iterable<U>, Double> implements
 	Ops.Coloc.Pearsons
 {

--- a/src/test/java/net/imagej/ops/coloc/icq/LiICQTest.java
+++ b/src/test/java/net/imagej/ops/coloc/icq/LiICQTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import net.imagej.ops.coloc.ColocalisationTest;
-import net.imagej.ops.coloc.pValue.PValue;
+import net.imagej.ops.coloc.pValue.DefaultPValue;
 import net.imagej.ops.coloc.pValue.PValueResult;
 import net.imagej.ops.special.function.BinaryFunctionOp;
 import net.imagej.ops.special.function.Functions;
@@ -103,7 +103,7 @@ public class LiICQTest extends ColocalisationTest {
 			mean, spread, sigma, 0x98765432);
 		BinaryFunctionOp<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op =
 			Functions.binary(ops, LiICQ.class, Double.class, ch1, ch2);
-		PValueResult value = (PValueResult) ops.run(PValue.class, new PValueResult(), ch1, ch2, op);
+		PValueResult value = (PValueResult) ops.run(DefaultPValue.class, new PValueResult(), ch1, ch2, op);
 		assertEquals(0.786, value.getPValue(), 0.0);
 	}
 

--- a/src/test/java/net/imagej/ops/coloc/kendallTau/KendallTauBRankTest.java
+++ b/src/test/java/net/imagej/ops/coloc/kendallTau/KendallTauBRankTest.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.coloc.ColocalisationTest;
-import net.imagej.ops.coloc.pValue.PValue;
+import net.imagej.ops.coloc.pValue.DefaultPValue;
 import net.imagej.ops.coloc.pValue.PValueResult;
 import net.imagej.ops.special.function.BinaryFunctionOp;
 import net.imagej.ops.special.function.Functions;
@@ -123,7 +123,7 @@ public class KendallTauBRankTest extends AbstractOpTest {
 			mean, spread, sigma, 0x98765432);
 		BinaryFunctionOp<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op =
 			Functions.binary(ops, KendallTauBRank.class, Double.class, ch1, ch2);
-		PValueResult value = (PValueResult) ops.run(PValue.class, new PValueResult(), ch1, ch2, op);
+		PValueResult value = (PValueResult) ops.run(DefaultPValue.class, new PValueResult(), ch1, ch2, op);
 		assertEquals(0.813, value.getPValue(), 0.0);
 	}
 

--- a/src/test/java/net/imagej/ops/coloc/pValue/DefaultPValueTest.java
+++ b/src/test/java/net/imagej/ops/coloc/pValue/DefaultPValueTest.java
@@ -43,11 +43,11 @@ import net.imglib2.type.numeric.real.FloatType;
 import org.junit.Test;
 
 /**
- * Tests {@link PValue}.
+ * Tests {@link DefaultPValue}.
  *
  * @author Ellen T Arena
  */
-public class PValueTest extends ColocalisationTest {
+public class DefaultPValueTest extends ColocalisationTest {
 
 	/*
 	 * Tests 

--- a/src/test/java/net/imagej/ops/coloc/pearsons/DefaultPearsonsTest.java
+++ b/src/test/java/net/imagej/ops/coloc/pearsons/DefaultPearsonsTest.java
@@ -42,11 +42,11 @@ import net.imglib2.type.numeric.real.FloatType;
 import org.junit.Test;
 
 /**
- * Tests {@link Pearsons}.
+ * Tests {@link DefaultPearsons}.
  *
  * @author Ellen T Arena
  */
-public class PearsonsTest extends ColocalisationTest {
+public class DefaultPearsonsTest extends ColocalisationTest {
 	
 	/**
 	 * Tests if the fast implementation of Pearson's correlation with two
@@ -54,7 +54,7 @@ public class PearsonsTest extends ColocalisationTest {
 	 */
 	@Test
 	public void fastPearsonsZeroCorrTest(){
-		double result = (Double) ops.run(Pearsons.class, zeroCorrelationImageCh1, zeroCorrelationImageCh2);
+		double result = (Double) ops.run(DefaultPearsons.class, zeroCorrelationImageCh1, zeroCorrelationImageCh2);
 		assertEquals(0.0, result, 0.05);
 	}
 	
@@ -64,7 +64,7 @@ public class PearsonsTest extends ColocalisationTest {
 	 */
 	@Test
 	public void fastPearsonsPositiveCorrTest() {
-		double result = (Double) ops.run(Pearsons.class, positiveCorrelationImageCh1, positiveCorrelationImageCh2);
+		double result = (Double) ops.run(DefaultPearsons.class, positiveCorrelationImageCh1, positiveCorrelationImageCh2);
 		assertEquals(0.75, result, 0.01);
 	}
 	
@@ -83,7 +83,7 @@ public class PearsonsTest extends ColocalisationTest {
 					512, 512, mean, spread, sigma, 0x01234567);
 			RandomAccessibleInterval<FloatType> ch2 = produceMeanBasedNoiseImage(new FloatType(),
 					512, 512, mean, spread, sigma, 0x98765432);
-			double resultFast = (Double) ops.run(Pearsons.class, ch1, ch2);
+			double resultFast = (Double) ops.run(DefaultPearsons.class, ch1, ch2);
 			assertEquals(0.0, resultFast, 0.1);
 
 			/* If the means are the same, it causes a numerical problem in the classic implementation of Pearson's


### PR DESCRIPTION
To prevent naming conflicts, added "Default" to Op names for Pearsons
and PValue implementations.