### PR TITLE
Add uniform noise op

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -67,36 +67,36 @@ public class FilterNamespace extends AbstractNamespace {
 
 	// -- addNoise --
 
-	@OpMethod(ops = { net.imagej.ops.filter.addNoise.AddNoiseRealType.class,
-		net.imagej.ops.filter.addNoise.AddNoiseRealTypeCFI.class })
-	public <I extends RealType<I>, O extends RealType<O>> O addNoise(final O out,
+	@OpMethod(ops = { net.imagej.ops.filter.addGaussianNoise.AddGaussianNoiseRealType.class,
+		net.imagej.ops.filter.addGaussianNoise.AddGaussianNoiseRealTypeCFI.class })
+	public <I extends RealType<I>, O extends RealType<O>> O addGaussianNoise(final O out,
 		final I in, final double rangeMin, final double rangeMax,
 		final double rangeStdDev)
 	{
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(Ops.Filter.AddNoise.class, out, in, rangeMin,
+		final O result = (O) ops().run(Ops.Filter.AddGaussianNoise.class, out, in, rangeMin,
 			rangeMax, rangeStdDev);
 		return result;
 	}
 
-	@OpMethod(ops = { net.imagej.ops.filter.addNoise.AddNoiseRealType.class,
-		net.imagej.ops.filter.addNoise.AddNoiseRealTypeCFI.class })
-	public <I extends RealType<I>, O extends RealType<O>> O addNoise(final O out,
+	@OpMethod(ops = { net.imagej.ops.filter.addGaussianNoise.AddGaussianNoiseRealType.class,
+		net.imagej.ops.filter.addGaussianNoise.AddGaussianNoiseRealTypeCFI.class })
+	public <I extends RealType<I>, O extends RealType<O>> O addGaussianNoise(final O out,
 		final I in, final double rangeMin, final double rangeMax,
 		final double rangeStdDev, final long seed)
 	{
 		@SuppressWarnings("unchecked")
-		final O result = (O) ops().run(Ops.Filter.AddNoise.class, out, in, rangeMin,
+		final O result = (O) ops().run(Ops.Filter.AddGaussianNoise.class, out, in, rangeMin,
 			rangeMax, rangeStdDev, seed);
 		return result;
 	}
 
-	@OpMethod(op = net.imagej.ops.filter.addNoise.AddNoiseRealTypeCFI.class)
-	public <T extends RealType<T>> T addNoise(final T in, final double rangeMin,
+	@OpMethod(op = net.imagej.ops.filter.addGaussianNoise.AddGaussianNoiseRealTypeCFI.class)
+	public <T extends RealType<T>> T addGaussianNoise(final T in, final double rangeMin,
 		final double rangeMax, final double rangeStdDev)
 	{
 		@SuppressWarnings("unchecked")
-		final T result = (T) ops().run(Ops.Filter.AddNoise.class, in, rangeMin,
+		final T result = (T) ops().run(Ops.Filter.AddGaussianNoise.class, in, rangeMin,
 			rangeMax, rangeStdDev);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -133,6 +133,26 @@ public class FilterNamespace extends AbstractNamespace {
 			Ops.Filter.AddPoissonNoise.class, out, in);
 		return result;
 	}
+	
+	@OpMethod(op = net.imagej.ops.filter.addUniformNoise.AddUniformNoiseRealType.class)
+	public <I extends RealType<I>, O extends RealType<O>> O addUniformNoise(final O out,
+		final I in, final double rangeMin, final double rangeMax)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(Ops.Filter.AddUniformNoise.class, out, in, rangeMin,
+			rangeMax);
+		return result;
+	}
+	
+	@OpMethod(op = net.imagej.ops.filter.addUniformNoise.AddUniformNoiseRealType.class)
+	public <I extends RealType<I>, O extends RealType<O>> O addUniformNoise(final O out,
+		final I in, final double rangeMin, final double rangeMax, final long seed)
+	{
+		@SuppressWarnings("unchecked")
+		final O result = (O) ops().run(Ops.Filter.AddUniformNoise.class, out, in, rangeMin,
+			rangeMax, seed);
+		return result;
+	}
 
 	/**
 	 * Executes a bilateral filter on the given arguments.

--- a/src/main/java/net/imagej/ops/filter/addGaussianNoise/AddGaussianNoiseRealType.java
+++ b/src/main/java/net/imagej/ops/filter/addGaussianNoise/AddGaussianNoiseRealType.java
@@ -27,7 +27,7 @@
  * #L%
  */
 
-package net.imagej.ops.filter.addNoise;
+package net.imagej.ops.filter.addGaussianNoise;
 
 import java.util.Random;
 
@@ -42,9 +42,9 @@ import org.scijava.plugin.Plugin;
  * Sets the real component of an output real number to the addition of the real
  * component of an input real number with an amount of Gaussian noise.
  */
-@Plugin(type = Ops.Filter.AddNoise.class)
-public class AddNoiseRealType<I extends RealType<I>, O extends RealType<O>>
-	extends AbstractUnaryComputerOp<I, O> implements Ops.Filter.AddNoise
+@Plugin(type = Ops.Filter.AddGaussianNoise.class)
+public class AddGaussianNoiseRealType<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractUnaryComputerOp<I, O> implements Ops.Filter.AddGaussianNoise
 {
 
 	@Parameter

--- a/src/main/java/net/imagej/ops/filter/addGaussianNoise/AddGaussianNoiseRealTypeCFI.java
+++ b/src/main/java/net/imagej/ops/filter/addGaussianNoise/AddGaussianNoiseRealTypeCFI.java
@@ -27,7 +27,7 @@
  * #L%
  */
 
-package net.imagej.ops.filter.addNoise;
+package net.imagej.ops.filter.addGaussianNoise;
 
 import java.util.Random;
 
@@ -44,12 +44,12 @@ import org.scijava.plugin.Plugin;
  * <p>
  * This op is a hybrid computer/function/inplace, since input and output types
  * are the same. For input and output of different types, see
- * {@link AddNoiseRealType}.
+ * {@link AddGaussianNoiseRealType}.
  * </p>
  */
-@Plugin(type = Ops.Filter.AddNoise.class, priority = Priority.HIGH)
-public class AddNoiseRealTypeCFI<T extends RealType<T>> extends
-	AbstractUnaryHybridCFI<T, T> implements Ops.Filter.AddNoise
+@Plugin(type = Ops.Filter.AddGaussianNoise.class, priority = Priority.HIGH)
+public class AddGaussianNoiseRealTypeCFI<T extends RealType<T>> extends
+	AbstractUnaryHybridCFI<T, T> implements Ops.Filter.AddGaussianNoise
 {
 
 	@Parameter
@@ -71,7 +71,7 @@ public class AddNoiseRealTypeCFI<T extends RealType<T>> extends
 	@Override
 	public void compute(final T input, final T output) {
 		if (rng == null) rng = new Random(seed);
-		AddNoiseRealType.addNoise(input, output, rangeMin, rangeMax, rangeStdDev,
+		AddGaussianNoiseRealType.addNoise(input, output, rangeMin, rangeMax, rangeStdDev,
 			rng);
 	}
 
@@ -80,7 +80,7 @@ public class AddNoiseRealTypeCFI<T extends RealType<T>> extends
 	@Override
 	public void mutate(final T arg) {
 		if (rng == null) rng = new Random(seed);
-		AddNoiseRealType.addNoise(arg, arg, rangeMin, rangeMax, rangeStdDev, rng);
+		AddGaussianNoiseRealType.addNoise(arg, arg, rangeMin, rangeMax, rangeStdDev, rng);
 	}
 
 	// -- UnaryOutputFactory methods --

--- a/src/main/java/net/imagej/ops/filter/addUniformNoise/AddUniformNoiseRealType.java
+++ b/src/main/java/net/imagej/ops/filter/addUniformNoise/AddUniformNoiseRealType.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2018 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.filter.addUniformNoise;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imglib2.type.numeric.RealType;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.util.MersenneTwisterFast;
+
+/**
+ * Sets the real output value of a {@link Realtype} T to a randomly generated
+ * value x, bounded by (and including) the {@code rangeMin} and {@code rangeMax}
+ * parameters, i.e. {@code rangeMin <= x <= rangeMax}.
+ * 
+ * @author Gabe Selzer
+ */
+@Plugin(type = Ops.Filter.AddUniformNoise.class)
+public class AddUniformNoiseRealType<I extends RealType<I>, O extends RealType<O>>
+	extends AbstractUnaryComputerOp<I, O> implements Ops.Filter.AddUniformNoise
+{
+
+	@Parameter
+	private double rangeMin;
+
+	@Parameter
+	private double rangeMax;
+
+	@Parameter(required = false)
+	private long seed = 0xabcdef1234567890L;
+
+	private MersenneTwisterFast rng;
+
+	@Override
+	public void initialize() {
+		if (rng == null) rng = new MersenneTwisterFast(seed);
+		if (rangeMax < rangeMin) {
+			double temp = rangeMax;
+			rangeMax = rangeMin;
+			rangeMin = temp;
+		}
+
+		// if an unacceptable value is passed for either range param (i.e. a NaN
+		// value or a Double so large that the maths will become infected by
+		// INFINITY, do not proceed.
+		if (!Double.isFinite(rangeMax - rangeMin))
+			throw new IllegalArgumentException("range not allowed by op.");
+	}
+
+	@Override
+	public void compute(I input, O output) {
+		int i = 0;
+		do {
+			final double newVal = (rangeMax - rangeMin) * rng.nextDouble(true, true) +
+				rangeMin;
+			if ((rangeMin <= newVal) && (newVal <= rangeMax)) {
+				output.setReal(newVal);
+				return;
+			}
+			if (i++ > 100) {
+				throw new IllegalArgumentException(
+					"noise function failing to terminate. probably misconfigured.");
+			}
+		}
+		while (true);
+	}
+
+}

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -98,6 +98,7 @@ namespaces = ```
 	[name: "filter", iface: "Filter", ops: [
 		[name: "addGaussianNoise",               iface: "AddGaussianNoise"],
 		[name: "addPoissonNoise",                iface: "AddPoissonNoise"],
+		[name: "addUniformNoise",                iface: "AddUniformNoise"],
 		[name: "bilateral",                      iface: "Bilateral"],
 		[name: "convolve",                       iface: "Convolve"],
 		[name: "correlate",                      iface: "Correlate"],

--- a/src/main/templates/net/imagej/ops/Ops.list
+++ b/src/main/templates/net/imagej/ops/Ops.list
@@ -96,7 +96,7 @@ namespaces = ```
 		
 	]],
 	[name: "filter", iface: "Filter", ops: [
-		[name: "addNoise",                       iface: "AddNoise"],
+		[name: "addGaussianNoise",               iface: "AddGaussianNoise"],
 		[name: "addPoissonNoise",                iface: "AddPoissonNoise"],
 		[name: "bilateral",                      iface: "Bilateral"],
 		[name: "convolve",                       iface: "Convolve"],

--- a/src/test/java/net/imagej/ops/convert/ConvertIIsTest.java
+++ b/src/test/java/net/imagej/ops/convert/ConvertIIsTest.java
@@ -143,7 +143,7 @@ public class ConvertIIsTest extends AbstractOpTest {
 	private void addNoise(final Iterable<ShortType> image) {
 		// NB: Need "? super ShortType" instead of "?" to make javac happy.
 		final UnaryInplaceOp<? super ShortType, ShortType> noiseOp = Inplaces.unary(
-			ops, Ops.Filter.AddNoise.class, ShortType.class, -32768, 32767, 10000);
+			ops, Ops.Filter.AddGaussianNoise.class, ShortType.class, -32768, 32767, 10000);
 		ops.map(image, noiseOp);
 	}
 


### PR DESCRIPTION
This PR adds an op to add uniformly distributed noise throughout an image, as an alternative to the non-uniform `AddGaussianNoise` op, renamed in this PR from `AddNoise`.

Questions:
* As of now this Op does not take into account the value of the input, instead filling the output with random noise completely independent of whatever is in the input. Is this something that is desired or should this Op continue to disregard the input?