### PR TITLE
Decon iteration

### DIFF
--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -200,6 +200,37 @@ public class DeconvolveNamespace extends AbstractNamespace {
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2, final int maxIterations)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(
+				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
+				maxIterations);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<O> out,
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput, final int maxIterations)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(
+				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
+				fftInput, maxIterations);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<O> out,
+			final RandomAccessibleInterval<I> in1,
 			final RandomAccessibleInterval<K> in2,
 			final RandomAccessibleInterval<C> fftInput,
 			final RandomAccessibleInterval<C> fftKernel, final int maxIterations)

--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -141,8 +141,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyF.class)
-	public <
-		I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
@@ -159,8 +158,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyF.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
@@ -178,8 +176,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyF.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
@@ -199,48 +196,42 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
 			final RandomAccessibleInterval<K> in2,
 			final RandomAccessibleInterval<C> fftInput,
-			final RandomAccessibleInterval<C> fftKernel, final int maxIterations,
-			final Interval imgConvolutionInterval)
+			final RandomAccessibleInterval<C> fftKernel, final int maxIterations)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
-				fftInput, fftKernel, maxIterations, imgConvolutionInterval);
+				fftInput, fftKernel, maxIterations);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
 			final RandomAccessibleInterval<K> in2,
 			final RandomAccessibleInterval<C> fftInput,
 			final RandomAccessibleInterval<C> fftKernel,
-			final boolean performInputFFT, final int maxIterations,
-			final Interval imgConvolutionInterval)
+			final boolean performInputFFT, final int maxIterations)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
-				fftInput, fftKernel, performInputFFT, maxIterations,
-				imgConvolutionInterval);
+				fftInput, fftKernel, performInputFFT, maxIterations);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
@@ -248,20 +239,38 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<C> fftInput,
 			final RandomAccessibleInterval<C> fftKernel,
 			final boolean performInputFFT, final boolean performKernelFFT,
-			final int maxIterations, final Interval imgConvolutionInterval)
+			final int maxIterations)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(
+				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
+				fftInput, fftKernel, performInputFFT, performKernelFFT, maxIterations);
+		return result;
+	}
+
+	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<O> out,
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final boolean performKernelFFT,
+			final int maxIterations, final UnaryInplaceOp<O, O> accelerator)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
 				fftInput, fftKernel, performInputFFT, performKernelFFT, maxIterations,
-				imgConvolutionInterval);
+				accelerator);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
@@ -269,30 +278,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<C> fftInput,
 			final RandomAccessibleInterval<C> fftKernel,
 			final boolean performInputFFT, final boolean performKernelFFT,
-			final int maxIterations, final Interval imgConvolutionInterval,
-			final UnaryInplaceOp<O, O> accelerator)
-	{
-		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<O> result =
-			(RandomAccessibleInterval<O>) ops().run(
-				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
-				fftInput, fftKernel, performInputFFT, performKernelFFT, maxIterations,
-				imgConvolutionInterval, accelerator);
-		return result;
-	}
-
-	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-		RandomAccessibleInterval<O> richardsonLucy(
-			final RandomAccessibleInterval<O> out,
-			final RandomAccessibleInterval<I> in1,
-			final RandomAccessibleInterval<K> in2,
-			final RandomAccessibleInterval<C> fftInput,
-			final RandomAccessibleInterval<C> fftKernel,
-			final boolean performInputFFT, final boolean performKernelFFT,
-			final int maxIterations, final Interval imgConvolutionInterval,
-			final UnaryInplaceOp<O, O> accelerator,
+			final int maxIterations, final UnaryInplaceOp<O, O> accelerator,
 			final UnaryComputerOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> update)
 	{
 		@SuppressWarnings("unchecked")
@@ -300,13 +286,12 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
 				fftInput, fftKernel, performInputFFT, performKernelFFT, maxIterations,
-				imgConvolutionInterval, accelerator, update);
+				accelerator, update);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
@@ -314,8 +299,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<C> fftInput,
 			final RandomAccessibleInterval<C> fftKernel,
 			final boolean performInputFFT, final boolean performKernelFFT,
-			final int maxIterations, final Interval imgConvolutionInterval,
-			final UnaryInplaceOp<O, O> accelerator,
+			final int maxIterations, final UnaryInplaceOp<O, O> accelerator,
 			final UnaryComputerOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> update,
 			RandomAccessibleInterval<O> raiExtendedEstimate)
 	{
@@ -324,13 +308,12 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
 				fftInput, fftKernel, performInputFFT, performKernelFFT, maxIterations,
-				imgConvolutionInterval, accelerator, update, raiExtendedEstimate);
+				accelerator, update, raiExtendedEstimate);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyC.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucy(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
@@ -338,8 +321,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<C> fftInput,
 			final RandomAccessibleInterval<C> fftKernel,
 			final boolean performInputFFT, final boolean performKernelFFT,
-			final int maxIterations, final Interval imgConvolutionInterval,
-			final UnaryInplaceOp<O, O> accelerator,
+			final int maxIterations, final UnaryInplaceOp<O, O> accelerator,
 			final UnaryComputerOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> update,
 			RandomAccessibleInterval<O> raiExtendedEstimate,
 			final ArrayList<UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>>> iterativePostProcessing)
@@ -349,8 +331,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.RichardsonLucyC.class, out, in1, in2,
 				fftInput, fftKernel, performInputFFT, performKernelFFT, maxIterations,
-				imgConvolutionInterval, accelerator, update, raiExtendedEstimate,
-				iterativePostProcessing);
+				accelerator, update, raiExtendedEstimate, iterativePostProcessing);
 		return result;
 	}
 
@@ -439,8 +420,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyTVF.class)
-	public <
-		I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucyTV(
 			final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
@@ -459,8 +439,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyTVF.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucyTV(
 			final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
@@ -479,8 +458,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	}
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyTVF.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucyTV(
 			final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
@@ -502,8 +480,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	// -- richardson lucy correction ops
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyCorrection.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucyCorrection(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<I> in1,
@@ -522,8 +499,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	// -- richardson lucy update ops
 
 	@OpMethod(op = net.imagej.ops.deconvolve.RichardsonLucyTVUpdate.class)
-	public <
-		I extends RealType<I>, O extends RealType<O>, C extends ComplexType<C>>
+	public <I extends RealType<I>, O extends RealType<O>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> richardsonLucyUpdate(
 			final RandomAccessibleInterval<O> out,
 			final RandomAccessibleInterval<O> in, final float regularizationFactor)

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyC.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyC.java
@@ -154,6 +154,16 @@ public class RichardsonLucyC<I extends RealType<I>, O extends RealType<O>, K ext
 	public void compute(RandomAccessibleInterval<I> in,
 		RandomAccessibleInterval<K> kernel, RandomAccessibleInterval<O> out)
 	{
+		// create FFT input memory if needed
+		if (getFFTInput() == null) {
+			setFFTInput(getCreateOp().calculate(in));
+		}
+
+		// create FFT kernel memory if needed
+		if (getFFTKernel() == null) {
+			setFFTKernel(getCreateOp().calculate(in));
+		}
+
 		// if a starting point for the estimate was not passed in then create
 		// estimate Img and use the input as the starting point
 		if (raiExtendedEstimate == null) {

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyC.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyC.java
@@ -60,8 +60,8 @@ import org.scijava.plugin.Plugin;
 
 /**
  * Richardson Lucy algorithm for (@link RandomAccessibleInterval) (Lucy, L. B.
- * (1974).
- * "An iterative technique for the rectification of observed distributions".)
+ * (1974). "An iterative technique for the rectification of observed
+ * distributions".)
  * 
  * @author Brian Northan
  * @param <I>
@@ -70,8 +70,7 @@ import org.scijava.plugin.Plugin;
  * @param <C>
  */
 
-@Plugin(type = Ops.Deconvolve.RichardsonLucy.class,
-	priority = Priority.HIGH)
+@Plugin(type = Ops.Deconvolve.RichardsonLucy.class, priority = Priority.HIGH)
 public class RichardsonLucyC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends AbstractIterativeFFTFilterC<I, O, K, C> implements
 	Ops.Deconvolve.RichardsonLucy
@@ -159,13 +158,13 @@ public class RichardsonLucyC<I extends RealType<I>, O extends RealType<O>, K ext
 		// estimate Img and use the input as the starting point
 		if (raiExtendedEstimate == null) {
 
-			raiExtendedEstimate = createOp.calculate(getImgConvolutionInterval());
+			raiExtendedEstimate = createOp.calculate(in);
 
 			copyOp.compute(in, raiExtendedEstimate);
 		}
 
 		// create image for the reblurred
-		raiExtendedReblurred = createOp.calculate(getImgConvolutionInterval());
+		raiExtendedReblurred = createOp.calculate(in);
 
 		// perform fft of psf
 		fftKernelOp.compute(kernel, getFFTKernel());

--- a/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyF.java
+++ b/src/main/java/net/imagej/ops/deconvolve/RichardsonLucyF.java
@@ -42,7 +42,6 @@ import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imagej.ops.special.inplace.Inplaces;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
@@ -58,8 +57,8 @@ import org.scijava.plugin.Plugin;
 
 /**
  * Richardson Lucy function op that operates on (@link RandomAccessibleInterval)
- * (Lucy, L. B. (1974).
- * "An iterative technique for the rectification of observed distributions".)
+ * (Lucy, L. B. (1974). "An iterative technique for the rectification of
+ * observed distributions".)
  * 
  * @author Brian Northan
  * @param <I>
@@ -67,8 +66,7 @@ import org.scijava.plugin.Plugin;
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Ops.Deconvolve.RichardsonLucy.class,
-	priority = Priority.HIGH)
+@Plugin(type = Ops.Deconvolve.RichardsonLucy.class, priority = Priority.HIGH)
 public class RichardsonLucyF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 	extends AbstractFFTFilterF<I, O, K, C> implements
 	Ops.Deconvolve.RichardsonLucy
@@ -131,7 +129,7 @@ public class RichardsonLucyF<I extends RealType<I> & NativeType<I>, O extends Re
 		createFilterComputer(RandomAccessibleInterval<I> raiExtendedInput,
 			RandomAccessibleInterval<K> raiExtendedKernel,
 			RandomAccessibleInterval<C> fftImg, RandomAccessibleInterval<C> fftKernel,
-			RandomAccessibleInterval<O> output, Interval imgConvolutionInterval)
+			RandomAccessibleInterval<O> output)
 	{
 		UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> accelerator =
 			null;
@@ -148,7 +146,7 @@ public class RichardsonLucyF<I extends RealType<I> & NativeType<I>, O extends Re
 			normalizer =
 				(UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>>) Inplaces
 					.unary(ops(), NonCirculantNormalizationFactor.class, output, in(),
-						in2(), fftImg, fftKernel, imgConvolutionInterval);
+						in2(), fftImg, fftKernel);
 
 			ArrayList<UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>>> list =
 				new ArrayList<>();
@@ -159,19 +157,19 @@ public class RichardsonLucyF<I extends RealType<I> & NativeType<I>, O extends Re
 			// normalized by image area)
 			UnaryFunctionOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> fg =
 				(UnaryFunctionOp) Functions.unary(ops(), NonCirculantFirstGuess.class,
-					RandomAccessibleInterval.class, RandomAccessibleInterval.class,
-					imgConvolutionInterval, Util.getTypeFromInterval(output), in());
+					RandomAccessibleInterval.class, RandomAccessibleInterval.class, Util
+						.getTypeFromInterval(output), in());
 
 			return Computers.binary(ops(), RichardsonLucyC.class, output,
 				raiExtendedInput, raiExtendedKernel, fftImg, fftKernel, true, true,
-				maxIterations, imgConvolutionInterval, accelerator, computeEstimateOp,
-				fg.calculate(raiExtendedInput), list);
+				maxIterations, accelerator, computeEstimateOp, fg.calculate(
+					raiExtendedInput), list);
 		}
 
 		// return a richardson lucy computer
 		return Computers.binary(ops(), RichardsonLucyC.class, output,
 			raiExtendedInput, raiExtendedKernel, fftImg, fftKernel, true, true,
-			maxIterations, imgConvolutionInterval, accelerator, computeEstimateOp);
+			maxIterations, accelerator, computeEstimateOp);
 	}
 
 	/**

--- a/src/main/java/net/imagej/ops/filter/AbstractFFTFilterC.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractFFTFilterC.java
@@ -29,7 +29,15 @@
 
 package net.imagej.ops.filter;
 
+import net.imagej.ops.filter.fft.CreateOutputFFTMethods;
 import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imglib2.Dimensions;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
 
 import org.scijava.plugin.Parameter;
 
@@ -42,23 +50,24 @@ import org.scijava.plugin.Parameter;
  * @param <K>
  * @param <C>
  */
-public abstract class AbstractFFTFilterC<I, O, K, C> extends
-	AbstractBinaryComputerOp<I, K, O>
+public abstract class AbstractFFTFilterC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+	extends
+	AbstractBinaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>>
 {
 
 	/**
 	 * Buffer to be used to store FFTs for input. Size of fftInput must correspond
 	 * to the fft size of raiExtendedInput
 	 */
-	@Parameter
-	private C fftInput;
+	@Parameter(required = false)
+	private RandomAccessibleInterval<C> fftInput;
 
 	/**
 	 * Buffer to be used to store FFTs for kernel. Size of fftKernel must
 	 * correspond to the fft size of raiExtendedKernel
 	 */
-	@Parameter
-	private C fftKernel;
+	@Parameter(required = false)
+	private RandomAccessibleInterval<C> fftKernel;
 
 	/**
 	 * boolean indicating that the input FFT has already been calculated
@@ -72,12 +81,48 @@ public abstract class AbstractFFTFilterC<I, O, K, C> extends
 	@Parameter(required = false)
 	private boolean performKernelFFT = true;
 
-	protected C getFFTInput() {
+	/**
+	 * FFT type
+	 */
+	private ComplexType<C> fftType;
+
+	/**
+	 * Op used to create the complex FFTs
+	 */
+	private UnaryFunctionOp<Dimensions, RandomAccessibleInterval<C>> createOp;
+
+	@Override
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void initialize() {
+		super.initialize();
+
+		if (fftType == null) {
+			fftType = (ComplexType<C>) ops().create().nativeType(
+				ComplexFloatType.class);
+		}
+
+		/**
+		 * Op used to create the complex FFTs
+		 */
+		createOp = (UnaryFunctionOp) Functions.unary(ops(),
+			CreateOutputFFTMethods.class, RandomAccessibleInterval.class,
+			Dimensions.class, fftType, true);
+	}
+
+	protected RandomAccessibleInterval<C> getFFTInput() {
 		return fftInput;
 	}
 
-	protected C getFFTKernel() {
+	public void setFFTInput(RandomAccessibleInterval<C> fftInput) {
+		this.fftInput = fftInput;
+	}
+
+	protected RandomAccessibleInterval<C> getFFTKernel() {
 		return fftKernel;
+	}
+
+	public void setFFTKernel(RandomAccessibleInterval<C> fftKernel) {
+		this.fftKernel = fftKernel;
 	}
 
 	protected boolean getPerformInputFFT() {
@@ -86,6 +131,12 @@ public abstract class AbstractFFTFilterC<I, O, K, C> extends
 
 	protected boolean getPerformKernelFFT() {
 		return performKernelFFT;
+	}
+
+	public UnaryFunctionOp<Dimensions, RandomAccessibleInterval<C>>
+		getCreateOp()
+	{
+		return createOp;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/filter/AbstractFFTFilterF.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractFFTFilterF.java
@@ -38,7 +38,6 @@ import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imglib2.Dimensions;
 import net.imglib2.FinalDimensions;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ComplexType;
@@ -58,7 +57,8 @@ import org.scijava.plugin.Parameter;
  * @param <C>
  */
 public abstract class AbstractFFTFilterF<I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C> & NativeType<C>>
-		extends AbstractFilterF<I, O, K, C> {
+	extends AbstractFilterF<I, O, K, C>
+{
 
 	/**
 	 * FFT type
@@ -80,50 +80,57 @@ public abstract class AbstractFFTFilterF<I extends RealType<I>, O extends RealTy
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void initialize() {
 		super.initialize();
-		
+
 		/**
 		 * Op used to pad the input
 		 */
-		setPadOp( (BinaryFunctionOp) Functions.binary(ops(), PadInputFFTMethods.class, RandomAccessibleInterval.class,
-				RandomAccessibleInterval.class, Dimensions.class, true, getOBFInput()));
+		setPadOp((BinaryFunctionOp) Functions.binary(ops(),
+			PadInputFFTMethods.class, RandomAccessibleInterval.class,
+			RandomAccessibleInterval.class, Dimensions.class, true, getOBFInput()));
 
 		/**
 		 * Op used to pad the kernel
 		 */
-		setPadKernelOp ((BinaryFunctionOp) Functions.binary(ops(), PadShiftKernelFFTMethods.class,
-				RandomAccessibleInterval.class, RandomAccessibleInterval.class, Dimensions.class, true));
+		setPadKernelOp((BinaryFunctionOp) Functions.binary(ops(),
+			PadShiftKernelFFTMethods.class, RandomAccessibleInterval.class,
+			RandomAccessibleInterval.class, Dimensions.class, true));
 
 		if (fftType == null) {
-			fftType = (ComplexType<C>) ops().create().nativeType(ComplexFloatType.class);
+			fftType = (ComplexType<C>) ops().create().nativeType(
+				ComplexFloatType.class);
 		}
 
 		/**
 		 * Op used to create the complex FFTs
 		 */
-		createOp = (UnaryFunctionOp) Functions.unary(ops(), CreateOutputFFTMethods.class,
-				RandomAccessibleInterval.class, Dimensions.class, fftType, true);
+		createOp = (UnaryFunctionOp) Functions.unary(ops(),
+			CreateOutputFFTMethods.class, RandomAccessibleInterval.class,
+			Dimensions.class, fftType, true);
 	}
 
 	/**
 	 * create FFT memory, create FFT filter and run it
 	 */
 	@Override
-	public void computeFilter(final RandomAccessibleInterval<I> input, final RandomAccessibleInterval<K> kernel,
-			RandomAccessibleInterval<O> output, long[] paddedSize) {
+	public void computeFilter(final RandomAccessibleInterval<I> input,
+		final RandomAccessibleInterval<K> kernel,
+		RandomAccessibleInterval<O> output, long[] paddedSize)
+	{
 
-		RandomAccessibleInterval<C> fftInput = createOp.calculate(new FinalDimensions(paddedSize));
+		RandomAccessibleInterval<C> fftInput = createOp.calculate(
+			new FinalDimensions(paddedSize));
 
-		RandomAccessibleInterval<C> fftKernel = createOp.calculate(new FinalDimensions(paddedSize));
+		RandomAccessibleInterval<C> fftKernel = createOp.calculate(
+			new FinalDimensions(paddedSize));
 
 		// TODO: in this case it is difficult to match the filter op in the
 		// 'initialize' as we don't know the size yet, thus we can't create
 		// memory
 		// for the FFTs
-		filter = createFilterComputer(input, kernel, fftInput, fftKernel, output, input);
+		filter = createFilterComputer(input, kernel, fftInput, fftKernel, output);
 
 		filter.compute(input, kernel, output);
 	}
-	
 
 	/**
 	 * This function is called after the RAIs and FFTs are set up and create the
@@ -134,11 +141,12 @@ public abstract class AbstractFFTFilterF<I extends RealType<I>, O extends RealTy
 	 * @param fftImg
 	 * @param fftKernel
 	 * @param output
-	 * @param imgConvolutionInterval
 	 */
-	abstract public BinaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>> createFilterComputer(
-			RandomAccessibleInterval<I> raiExtendedInput, RandomAccessibleInterval<K> raiExtendedKernel,
+	abstract public
+		BinaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>>
+		createFilterComputer(RandomAccessibleInterval<I> raiExtendedInput,
+			RandomAccessibleInterval<K> raiExtendedKernel,
 			RandomAccessibleInterval<C> fftImg, RandomAccessibleInterval<C> fftKernel,
-			RandomAccessibleInterval<O> output, Interval imgConvolutionInterval);
+			RandomAccessibleInterval<O> output);
 
 }

--- a/src/main/java/net/imagej/ops/filter/AbstractIterativeFFTFilterC.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractIterativeFFTFilterC.java
@@ -47,8 +47,7 @@ import org.scijava.plugin.Parameter;
  * @param <C>
  */
 public abstract class AbstractIterativeFFTFilterC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-	extends
-	AbstractFFTFilterC<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>>
+	extends AbstractFFTFilterC<I, O, K, C>
 {
 
 	@Parameter(required = false)

--- a/src/main/java/net/imagej/ops/filter/AbstractIterativeFFTFilterC.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractIterativeFFTFilterC.java
@@ -30,7 +30,6 @@
 package net.imagej.ops.filter;
 
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
@@ -62,21 +61,11 @@ public abstract class AbstractIterativeFFTFilterC<I extends RealType<I>, O exten
 	private int maxIterations;
 
 	/**
-	 * The interval to process TODO: this is probably redundant - remove
-	 */
-	@Parameter
-	private Interval imgConvolutionInterval;
-
-	/**
 	 * An op which implements an acceleration strategy (takes a larger step at
 	 * each iteration).
 	 */
 	@Parameter(required = false)
 	private UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> accelerator;
-
-	public Interval getImgConvolutionInterval() {
-		return imgConvolutionInterval;
-	}
 
 	public
 		UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>>

--- a/src/main/java/net/imagej/ops/filter/FFTMethodsLinearFFTFilterC.java
+++ b/src/main/java/net/imagej/ops/filter/FFTMethodsLinearFFTFilterC.java
@@ -35,6 +35,7 @@ import net.imagej.ops.filter.ifft.IFFTMethodsOpC;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
 import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
@@ -54,9 +55,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Filter.LinearFilter.class, priority = Priority.LOW)
 public class FFTMethodsLinearFFTFilterC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-	extends
-	AbstractFFTFilterC<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>>
-	implements Ops.Filter.LinearFilter
+	extends AbstractFFTFilterC<I, O, K, C> implements Ops.Filter.LinearFilter
 {
 
 	// TODO: should this be a parameter? figure out best way to override
@@ -93,6 +92,16 @@ public class FFTMethodsLinearFFTFilterC<I extends RealType<I>, O extends RealTyp
 	public void compute(RandomAccessibleInterval<I> in,
 		RandomAccessibleInterval<K> kernel, RandomAccessibleInterval<O> out)
 	{
+		// create FFT input memory if needed
+		if (getFFTInput() == null) {
+			setFFTInput(getCreateOp().calculate(in));
+		}
+
+		// create FFT kernel memory if needed
+		if (getFFTKernel() == null) {
+			setFFTKernel(getCreateOp().calculate(in));
+		}
+		
 		// perform input FFT if needed
 		if (getPerformInputFFT()) {
 			fftIn.compute(in, getFFTInput());

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -287,9 +287,39 @@ public class FilterNamespace extends AbstractNamespace {
 				in, kernel);
 		return result;
 	}
+	
+	/** Executes the "convolve" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveFFTC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> convolve(
+			final RandomAccessibleInterval<O> output,
+			final RandomAccessibleInterval<I> raiExtendedInput,
+			final RandomAccessibleInterval<K> raiExtendedKernel)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Convolve.class, output,
+				raiExtendedInput, raiExtendedKernel);
+		return result;
+	}
 
 	/** Executes the "convolve" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveFFTC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> convolve(
+			final RandomAccessibleInterval<O> output,
+			final RandomAccessibleInterval<I> raiExtendedInput,
+			final RandomAccessibleInterval<K> raiExtendedKernel,
+			final RandomAccessibleInterval<C> fftInput)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Convolve.class, output,
+				raiExtendedInput, raiExtendedKernel, fftInput);
+		return result;
+	}
 
+	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveFFTC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> convolve(
@@ -438,6 +468,37 @@ public class FilterNamespace extends AbstractNamespace {
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Correlate.class, in,
 				kernel, borderSize, obfInput, obfKernel, outType, fftType);
+		return result;
+	}
+	
+	/** Executes the "correlate" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.filter.correlate.CorrelateFFTC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> correlate(
+			final RandomAccessibleInterval<O> output,
+			final RandomAccessibleInterval<I> raiExtendedInput,
+			final RandomAccessibleInterval<K> raiExtendedKernel)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Correlate.class,
+				output, raiExtendedInput, raiExtendedKernel);
+		return result;
+	}
+	
+	/** Executes the "correlate" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.filter.correlate.CorrelateFFTC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> correlate(
+			final RandomAccessibleInterval<O> output,
+			final RandomAccessibleInterval<I> raiExtendedInput,
+			final RandomAccessibleInterval<K> raiExtendedKernel,
+			final RandomAccessibleInterval<C> fftInput)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Correlate.class,
+				output, raiExtendedInput, raiExtendedKernel, fftInput);
 		return result;
 	}
 
@@ -911,6 +972,39 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	// -- linear filter --
+	
+	/** Executes the "linearFilter" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.filter.FFTMethodsLinearFFTFilterC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> linearFilter(
+			final RandomAccessibleInterval<O> out,
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final BinaryComputerOp<RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>> frequencyOp)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.LinearFilter.class,
+				out, in1, in2, frequencyOp);
+		return result;
+	}
+	
+	/** Executes the "linearFilter" operation on the given arguments. */
+	@OpMethod(op = net.imagej.ops.filter.FFTMethodsLinearFFTFilterC.class)
+	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> linearFilter(
+			final RandomAccessibleInterval<O> out,
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final BinaryComputerOp<RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>> frequencyOp)
+	{
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<O> result =
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.LinearFilter.class,
+				out, in1, in2, fftInput, frequencyOp);
+		return result;
+	}
 
 	/** Executes the "linearFilter" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.FFTMethodsLinearFFTFilterC.class)

--- a/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTC.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTC.java
@@ -56,7 +56,7 @@ import org.scijava.plugin.Plugin;
 @Plugin(type = Ops.Filter.Convolve.class, priority = Priority.LOW)
 public class ConvolveFFTC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends
-	AbstractFFTFilterC<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>>
+	AbstractFFTFilterC<I, O, K, C>
 	implements Ops.Filter.Convolve
 {
 

--- a/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTF.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTF.java
@@ -33,7 +33,6 @@ import net.imagej.ops.Ops;
 import net.imagej.ops.filter.AbstractFFTFilterF;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
 import net.imglib2.type.NativeType;
@@ -81,7 +80,7 @@ public class ConvolveFFTF<I extends RealType<I> & NativeType<I>, O extends RealT
 		createFilterComputer(RandomAccessibleInterval<I> raiExtendedInput,
 			RandomAccessibleInterval<K> raiExtendedKernel,
 			RandomAccessibleInterval<C> fftImg, RandomAccessibleInterval<C> fftKernel,
-			RandomAccessibleInterval<O> output, Interval imgConvolutionInterval)
+			RandomAccessibleInterval<O> output)
 	{
 		return Computers.binary(ops(), ConvolveFFTC.class, output, raiExtendedInput,
 			raiExtendedKernel, fftImg, fftKernel);

--- a/src/main/java/net/imagej/ops/filter/correlate/CorrelateFFTC.java
+++ b/src/main/java/net/imagej/ops/filter/correlate/CorrelateFFTC.java
@@ -52,9 +52,7 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Ops.Filter.Correlate.class)
 public class CorrelateFFTC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
-	extends
-	AbstractFFTFilterC<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>>
-	implements Ops.Filter.Correlate
+	extends AbstractFFTFilterC<I, O, K, C> implements Ops.Filter.Correlate
 {
 
 	private BinaryComputerOp<RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>> complexConjugateMul;
@@ -70,7 +68,8 @@ public class CorrelateFFTC<I extends RealType<I>, O extends RealType<O>, K exten
 			ComplexConjugateMultiplyMap.class, getFFTInput(), getFFTKernel(),
 			getFFTInput());
 
-		// create a correlater by creating a linear filter and passing the complex conjugate multiplier
+		// create a correlater by creating a linear filter and passing the complex
+		// conjugate multiplier
 		// as the frequency operation
 		linearFilter = (BinaryComputerOp) Computers.binary(ops(),
 			FFTMethodsLinearFFTFilterC.class, RandomAccessibleInterval.class,

--- a/src/main/java/net/imagej/ops/filter/correlate/CorrelateFFTF.java
+++ b/src/main/java/net/imagej/ops/filter/correlate/CorrelateFFTF.java
@@ -34,7 +34,6 @@ import net.imagej.ops.Ops;
 import net.imagej.ops.filter.AbstractFFTFilterF;
 import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory.Boundary;
@@ -55,8 +54,7 @@ import org.scijava.plugin.Plugin;
  * @param <K>
  * @param <C>
  */
-@Plugin(type = Ops.Filter.Correlate.class,
-	priority = Priority.VERY_HIGH)
+@Plugin(type = Ops.Filter.Correlate.class, priority = Priority.VERY_HIGH)
 public class CorrelateFFTF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 	extends AbstractFFTFilterF<I, O, K, C> implements Contingent,
 	Ops.Filter.Correlate
@@ -84,7 +82,7 @@ public class CorrelateFFTF<I extends RealType<I> & NativeType<I>, O extends Real
 		createFilterComputer(RandomAccessibleInterval<I> raiExtendedInput,
 			RandomAccessibleInterval<K> raiExtendedKernel,
 			RandomAccessibleInterval<C> fftImg, RandomAccessibleInterval<C> fftKernel,
-			RandomAccessibleInterval<O> output, Interval imgConvolutionInterval)
+			RandomAccessibleInterval<O> output)
 	{
 		return Computers.binary(ops(), CorrelateFFTC.class, output,
 			raiExtendedInput, raiExtendedKernel, fftImg, fftKernel);


### PR DESCRIPTION
This is a small iteration of the filter code, so that there are FFT filter computers that do not need the caller to create the FFT memory before hand.  This issue became apparent when I was trying to match the experimental GPU version, in which case there is no need to create RAIs for the FFTs beforehand, because the algorithm is done on the GPU, and the GPU code allocates the FFT memory. 

This is a fairly small incremental change, so I'll probably merge it tomorrow, as long as all the tests pass.  

Previously the simplest RichardsonLucyC interface was 

```
public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
		RandomAccessibleInterval<O> richardsonLucy(
			final RandomAccessibleInterval<O> out,
			final RandomAccessibleInterval<I> in1,
			final RandomAccessibleInterval<K> in2,
			final RandomAccessibleInterval<C> fftInput,
			final RandomAccessibleInterval<C> fftKernel, final int maxIterations)
```

Now we have

```
public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
		RandomAccessibleInterval<O> richardsonLucy(
			final RandomAccessibleInterval<O> out,
			final RandomAccessibleInterval<I> in1,
			final RandomAccessibleInterval<K> in2, final int maxIterations)
```
