### PR TITLE
Add n-d support for derivativeGauss

### DIFF
--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -136,7 +136,7 @@ public class FilterNamespace extends AbstractNamespace {
 
 	/**
 	 * Executes a bilateral filter on the given arguments.
-	 * 
+	 *
 	 * @param in
 	 * @param out
 	 * @param sigmaR
@@ -287,7 +287,7 @@ public class FilterNamespace extends AbstractNamespace {
 				in, kernel);
 		return result;
 	}
-	
+
 	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveFFTC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -470,7 +470,7 @@ public class FilterNamespace extends AbstractNamespace {
 				kernel, borderSize, obfInput, obfKernel, outType, fftType);
 		return result;
 	}
-	
+
 	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.correlate.CorrelateFFTC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -485,7 +485,7 @@ public class FilterNamespace extends AbstractNamespace {
 				output, raiExtendedInput, raiExtendedKernel);
 		return result;
 	}
-	
+
 	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.correlate.CorrelateFFTC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -694,7 +694,7 @@ public class FilterNamespace extends AbstractNamespace {
 	public <T extends RealType<T>> RandomAccessibleInterval<DoubleType>
 		derivativeGauss(final RandomAccessibleInterval<T> out,
 			final RandomAccessibleInterval<DoubleType> in, final int[] derivatives,
-			final double sigma)
+			final double... sigma)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<DoubleType> result =
@@ -818,7 +818,7 @@ public class FilterNamespace extends AbstractNamespace {
 
 	/**
 	 * Executes the "Frangi Vesselness" filter operation on the given arguments.
-	 * 
+	 *
 	 * @param in - input image
 	 * @param out - output image
 	 * @param spacing - n-dimensional array indicating the physical distance
@@ -972,7 +972,7 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	// -- linear filter --
-	
+
 	/** Executes the "linearFilter" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.FFTMethodsLinearFFTFilterC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -988,7 +988,7 @@ public class FilterNamespace extends AbstractNamespace {
 				out, in1, in2, frequencyOp);
 		return result;
 	}
-	
+
 	/** Executes the "linearFilter" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.FFTMethodsLinearFFTFilterC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>

--- a/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
+++ b/src/main/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGauss.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -32,6 +32,8 @@ package net.imagej.ops.filter.derivativeGauss;
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.computer.AbstractBinaryComputerOp;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
@@ -47,7 +49,7 @@ import org.scijava.plugin.Plugin;
 /**
  * Performs the 2-D partial derivative Gaussian kernel convolutions on an image,
  * at a particular point.
- * 
+ *
  * @author Gabe Selzer
  */
 @Plugin(type = Ops.Filter.DerivativeGauss.class)
@@ -57,58 +59,58 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 {
 
 	@Parameter
-	private double sigma;
+	private double[] sigma;
 
 	double SQRT2PI = Math.sqrt(2 * Math.PI);
 
 	/**
 	 * Calculates a value at a specified location in a normal mask.
-	 * 
+	 *
 	 * @param x - the location in the mask.
 	 * @param sigma - the sigma for the convolution.
 	 * @return double - the value of the mask at location x.
 	 */
-	private double phi0(double x, double sigma) {
-		double t = x / sigma;
-		return (-sigma * Math.exp(-0.5 * t * t) / (SQRT2PI * x));
+	private double phi0(final double x, final double sigma) {
+		final double t = x / sigma;
+		return -sigma * Math.exp(-0.5 * t * t) / (SQRT2PI * x);
 	}
 
 	/**
 	 * Calculates a value at a specified location in a first partial derivative
 	 * mask.
-	 * 
+	 *
 	 * @param x - the location in the mask.
 	 * @param sigma - the sigma for the convolution.
 	 * @return double - the value of the mask at location x.
 	 */
-	private double phi1(double x, double sigma) {
-		double t = x / sigma;
-		return (Math.exp(-0.5 * t * t) / (SQRT2PI * sigma));
+	private double phi1(final double x, final double sigma) {
+		final double t = x / sigma;
+		return Math.exp(-0.5 * t * t) / (SQRT2PI * sigma);
 	}
 
 	/**
 	 * Calculates a value at a specified location in a second partial derivative
 	 * mask.
-	 * 
+	 *
 	 * @param x - the location in the mask.
 	 * @param sigma - the sigma for the convolution.
 	 * @return double - the value of the mask at location x.
 	 */
-	private double phi2(double x, double sigma) {
-		double t = x / sigma;
-		return (-x * Math.exp(-0.5 * t * t) / (SQRT2PI * Math.pow(sigma, 3)));
+	private double phi2(final double x, final double sigma) {
+		final double t = x / sigma;
+		return -x * Math.exp(-0.5 * t * t) / (SQRT2PI * Math.pow(sigma, 3));
 	}
 
 	/**
 	 * Creates the mask for normal convolutions
-	 * 
+	 *
 	 * @param sigma - The sigma for the convolution.
 	 * @return double[] - The mask.
 	 */
-	private double[] get_mask_0(double sigma) {
+	private double[] get_mask_0(final double sigma) {
 
-		int x = (int) Math.ceil(4 * sigma);
-		double[] h = new double[2 * x + 1];
+		final int x = (int) Math.ceil(4 * sigma);
+		final double[] h = new double[2 * x + 1];
 
 		for (int i = -x + 1; i < x; i++) {
 			h[i + x] = Math.abs(phi0(i + 0.5, sigma) - phi0(i - 0.5, sigma));
@@ -120,14 +122,14 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 
 	/**
 	 * Creates the mask for first partial derivative convolutions
-	 * 
+	 *
 	 * @param sigma - The sigma for the convolution.
 	 * @return double[] - The mask.
 	 */
-	private double[] get_mask_1(double sigma) {
+	private double[] get_mask_1(final double sigma) {
 
-		int x = (int) Math.ceil(4 * sigma);
-		double[] h = new double[2 * x + 1];
+		final int x = (int) Math.ceil(4 * sigma);
+		final double[] h = new double[2 * x + 1];
 
 		for (int i = -x + 1; i < x; i++) {
 			h[i + x] = phi1(-i + 0.5, sigma) - phi1(-i - 0.5, sigma);
@@ -139,14 +141,14 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 
 	/**
 	 * Creates the mask for second partial derivative convolutions
-	 * 
+	 *
 	 * @param sigma - The sigma for the convolution.
 	 * @return double[] - The mask.
 	 */
-	private double[] get_mask_2(double sigma) {
+	private double[] get_mask_2(final double sigma) {
 
-		int x = (int) Math.ceil(4 * sigma);
-		double[] h = new double[2 * x + 1];
+		final int x = (int) Math.ceil(4 * sigma);
+		final double[] h = new double[2 * x + 1];
 
 		for (int i = -x + 1; i < x; i++) {
 			h[i + x] = phi2(-i + 0.5, sigma) - phi2(-i - 0.5, sigma);
@@ -159,12 +161,12 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 	/**
 	 * Returns the correct mask of nth partial derivative. Leaves the calculations
 	 * to the helper methods.
-	 * 
+	 *
 	 * @param sigma - The sigma for the convolution.
 	 * @param n - A number specifying the nth partial derivative.
 	 * @return double[] - The mask.
 	 */
-	private double[] get_mask_general(int n, double sigma) {
+	private double[] get_mask_general(final int n, final double sigma) {
 		double[] h;
 		switch (n) {
 			case 0:
@@ -185,21 +187,21 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 
 	/**
 	 * Convolves the columns of the image
-	 * 
+	 *
 	 * @param input - The input image.
 	 * @param output - The output image.
 	 * @param mask - The mask needed for the convolution, determined beforehand.
 	 */
 	private <T extends RealType<T>> void convolve_x(
-		RandomAccessibleInterval<T> input, RandomAccessibleInterval<T> output,
-		double[] mask)
+		final RandomAccessibleInterval<T> input,
+		final RandomAccessibleInterval<DoubleType> output, final double[] mask)
 	{
 		double sum;
-		Cursor<T> cursor = Views.iterable(input).localizingCursor();
-		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
+		final Cursor<T> cursor = Views.iterable(input).localizingCursor();
+		final OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
 			new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
-		RandomAccess<T> inputRA = osmf.create(input);
-		RandomAccess<T> outputRA = output.randomAccess();
+		final RandomAccess<T> inputRA = osmf.create(input);
+		final RandomAccess<DoubleType> outputRA = output.randomAccess();
 
 		while (cursor.hasNext()) {
 			cursor.fwd();
@@ -220,21 +222,22 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 
 	/**
 	 * Convolves the rows of the image
-	 * 
+	 *
 	 * @param input - The input image.
 	 * @param output - The output image.
 	 * @param mask - The mask needed for the convolution, determined beforehand.
 	 */
-	private <T extends RealType<T>> void convolve_y(
-		RandomAccessibleInterval<T> input, RandomAccessibleInterval<DoubleType> output,
-		double[] mask)
+	private <T extends RealType<T>> void convolve_n(
+		final RandomAccessibleInterval<T> input,
+		final RandomAccessibleInterval<DoubleType> output, final double[] mask,
+		final int n)
 	{
 		double sum;
-		Cursor<T> cursor = Views.iterable(input).localizingCursor();
-		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
+		final Cursor<T> cursor = Views.iterable(input).localizingCursor();
+		final OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> osmf =
 			new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
-		RandomAccess<T> inputRA = osmf.create(input);
-		RandomAccess<DoubleType> outputRA = output.randomAccess();
+		final RandomAccess<T> inputRA = osmf.create(input);
+		final RandomAccess<DoubleType> outputRA = output.randomAccess();
 
 		while (cursor.hasNext()) {
 			cursor.fwd();
@@ -244,8 +247,11 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 			// loop from the bottom of the image to the top
 			final int halfWidth = mask.length / 2;
 			for (int i = -halfWidth; i <= halfWidth; i++) {
-				inputRA.setPosition(cursor.getLongPosition(0), 0);
-				inputRA.setPosition(cursor.getLongPosition(1) + i, 1);
+				for (int dim = 0; dim < input.numDimensions(); dim++) {
+					long position = cursor.getLongPosition(dim);
+					if (dim == n) position += i;
+					inputRA.setPosition(position, dim);
+				}
 				sum += inputRA.get().getRealDouble() * mask[i + halfWidth];
 			}
 			outputRA.get().setReal(sum);
@@ -254,20 +260,52 @@ public class DefaultDerivativeGauss<T extends RealType<T>> extends
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void compute(RandomAccessibleInterval<T> input, int[] derivatives,
-		RandomAccessibleInterval<DoubleType> output)
+	public void compute(final RandomAccessibleInterval<T> input,
+		final int[] derivatives, final RandomAccessibleInterval<DoubleType> output)
 	{
-		RandomAccessibleInterval<T> intermediate =
-			(RandomAccessibleInterval<T>) ops().run(Ops.Copy.RAI.class, output);
 
-		// TODO n-Dimensional support.
-		convolve_x(input, intermediate, get_mask_general(derivatives[0], sigma));
-		convolve_y(intermediate, output, get_mask_general(derivatives[1], sigma));
+		// throw exception if not enough derivative values were given
+		if (input.numDimensions() != derivatives.length)
+			throw new IllegalArgumentException(
+				"derivatives array must include values for each dimension!");
+
+		// throw exception if derivatives contains a derivative this Op cannot
+		// perform
+		for (final int derivative : derivatives)
+			if (derivative < 0 || derivative > 2) throw new IllegalArgumentException(
+				"derivatives greater than second-order or less than zeroth order cannot be performed!");
+
+		// create the intermediate image used as the input for all convolutions
+		// after the first
+		final RandomAccessibleInterval<DoubleType> intermediate = ops().create()
+			.img(output, new DoubleType());
+
+		// create a copyOp to copy the data from output to the intermediary
+		final UnaryComputerOp<RandomAccessibleInterval<DoubleType>, RandomAccessibleInterval<DoubleType>> copyOp =
+			Computers.unary(ops(), Ops.Copy.RAI.class, output, output);
+
+		// convolve the first dimension, transferring data to the intermediary
+		convolve_n(input, intermediate, get_mask_general(derivatives[0], sigma[0]),
+			0);
+
+		// convolve the remaining dimensions
+		for (int n = 1; n < input.numDimensions(); n++) {
+			// convolve from the intermediary, outputting to output
+			convolve_n(intermediate, output, get_mask_general(derivatives[n],
+				sigma[n]), n);
+			// if there is still another dimension to convolve, transfer the data from
+			// the last convolution back into output so that we can convolve again.
+			if (n + 1 != input.numDimensions()) copyOp.compute(output, intermediate);
+		}
 	}
 
 	@Override
 	public boolean conforms() {
-		return (in1().numDimensions() == in2().length && out()
-			.numDimensions() == in1().numDimensions());
+
+		// the image needs to have one at least 1 dimension
+		if (in1().numDimensions() < 1) return false;
+
+		// make sure the output is of the same size as the input
+		return out().numDimensions() == in1().numDimensions();
 	}
 }

--- a/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java
+++ b/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java
@@ -47,19 +47,7 @@ import org.junit.Test;
 public class DefaultDerivativeGaussTest extends AbstractOpTest {
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testTooFewDimensions() {
-		final Img<DoubleType> input = ops.convert().float64(
-			generateFloatArrayTestImg(false, 30));
-
-		final Img<DoubleType> output = ops.create().img(input);
-
-		final int[] derivatives = new int[] { 1, 0 };
-		final double[] sigmas = new double[] { 1, 1 };
-		ops.filter().derivativeGauss(output, input, derivatives, sigmas);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testTooManyDimensions() {
+	public void testImgParamDimensionsMismatch() {
 		final Img<DoubleType> input = ops.convert().float64(
 			generateFloatArrayTestImg(false, 30, 30, 30));
 

--- a/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java
+++ b/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,41 +41,45 @@ import org.junit.Test;
 
 /**
  * Contains tests for {@link DefaultDerivativeGauss}.
- * 
+ *
  * @author Gabe Selzer
  */
 public class DefaultDerivativeGaussTest extends AbstractOpTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTooFewDimensions() {
-		Img<DoubleType> input = ops.convert().float64(generateFloatArrayTestImg(
-			false, 30));
+		final Img<DoubleType> input = ops.convert().float64(
+			generateFloatArrayTestImg(false, 30));
 
-		Img<DoubleType> output = ops.create().img(input);
+		final Img<DoubleType> output = ops.create().img(input);
 
-		ops.filter().derivativeGauss(output, input, new int[] { 1, 0 }, 1d);
+		final int[] derivatives = new int[] { 1, 0 };
+		final double[] sigmas = new double[] { 1, 1 };
+		ops.filter().derivativeGauss(output, input, derivatives, sigmas);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTooManyDimensions() {
-		Img<DoubleType> input = ops.convert().float64(generateFloatArrayTestImg(
-			false, 30, 30, 30));
+		final Img<DoubleType> input = ops.convert().float64(
+			generateFloatArrayTestImg(false, 30, 30, 30));
 
-		Img<DoubleType> output = ops.create().img(input);
+		final Img<DoubleType> output = ops.create().img(input);
 
-		ops.filter().derivativeGauss(output, input, new int[] { 1, 0 }, 1d);
+		final int[] derivatives = new int[] { 1, 0 };
+		final double[] sigmas = new double[] { 1, 1 };
+		ops.filter().derivativeGauss(output, input, derivatives, sigmas);
 	}
-	
+
 	@Test
 	public void regressionTest() {
-		int width = 10;
-		Img<DoubleType> input = ops.convert().float64(generateFloatArrayTestImg(
-			false, width, width));
+		final int width = 10;
+		final Img<DoubleType> input = ops.convert().float64(
+			generateFloatArrayTestImg(false, width, width));
 
-		Img<DoubleType> output = ops.create().img(input);
+		final Img<DoubleType> output = ops.create().img(input);
 
 		// Draw a line on the image
-		RandomAccess<DoubleType> inputRA = input.randomAccess();
+		final RandomAccess<DoubleType> inputRA = input.randomAccess();
 		inputRA.setPosition(5, 0);
 		for (int i = 0; i < 10; i++) {
 			inputRA.setPosition(i, 1);
@@ -83,13 +87,16 @@ public class DefaultDerivativeGaussTest extends AbstractOpTest {
 		}
 
 		// filter the image
-		ops.filter().derivativeGauss(output, input, new int[] { 1, 0 }, 0.5);
+		final int[] derivatives = new int[] { 1, 0 };
+		final double[] sigmas = new double[] { 0.5, 0.5 };
+		ops.filter().derivativeGauss(output, input, derivatives, sigmas);
 
-		Cursor<DoubleType> cursor = output.localizingCursor();
+		final Cursor<DoubleType> cursor = output.localizingCursor();
 		int currentPixel = 0;
 		while (cursor.hasNext()) {
 			cursor.fwd();
-			assertEquals(cursor.get().getRealDouble(), regressionRowValues[currentPixel % width], 0);
+			assertEquals(cursor.get().getRealDouble(),
+				regressionRowValues[currentPixel % width], 0);
 			currentPixel++;
 		}
 	}


### PR DESCRIPTION
This PR adds support for N-Dimensional Partial Derivative/Gaussian convolutions, adding acceptable input types 

Existing `Op` functionality does not change with the update (i.e. the [existing regression test](https://github.com/imagej/imagej-ops/blob/c6953badc5ce87d6692c19c954eaa19ce4c1bf44/src/test/java/net/imagej/ops/filter/derivativeGauss/DefaultDerivativeGaussTest.java#L62) still passes without any data modification)

TODO: Are any more tests required?