### PR TITLE
Fix permuteCoordinatesInverseView namespace methods

### DIFF
--- a/src/main/java/net/imagej/ops/transform/TransformNamespace.java
+++ b/src/main/java/net/imagej/ops/transform/TransformNamespace.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -610,7 +610,7 @@ public class TransformNamespace extends AbstractNamespace {
 		final int d)
 	{
 		return (IntervalView<T>) ops().run(
-			Ops.Transform.PermuteCoordinatesView.class, input, permutation, d);
+			Ops.Transform.PermuteCoordinatesInverseView.class, input, permutation, d);
 	}
 
 	/**
@@ -630,7 +630,7 @@ public class TransformNamespace extends AbstractNamespace {
 		final RandomAccessibleInterval<T> input, final int... permutation)
 	{
 		return (IntervalView<T>) ops().run(
-			Ops.Transform.PermuteCoordinatesView.class, input, permutation);
+			Ops.Transform.PermuteCoordinatesInverseView.class, input, permutation);
 	}
 
 	/**


### PR DESCRIPTION
Before the permuteCoordinatesInverse methods in the transform namespace were calling ops.run() with `Ops.Transform.PermuteCoordinatesView.class`, which was wrong. Now they call with `Ops.Transform.PermuteCoordinatesInverseView.class`.