### PR TITLE
Fix min/max String Exception bug

### DIFF
--- a/src/main/java/net/imagej/ops/image/ascii/DefaultASCII.java
+++ b/src/main/java/net/imagej/ops/image/ascii/DefaultASCII.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -46,7 +46,7 @@ import org.scijava.plugin.Plugin;
  * <p>
  * Only the first two dimensions of the image are considered.
  * </p>
- * 
+ *
  * @author Curtis Rueden
  */
 @Plugin(type = Ops.Image.ASCII.class)
@@ -107,6 +107,8 @@ public class DefaultASCII<T extends RealType<T>> extends
 		final Cursor<T> cursor = image.localizingCursor();
 		final int[] pos = new int[image.numDimensions()];
 		final T tmp = image.firstElement().copy();
+		final T zero = tmp.copy();
+		zero.setZero();
 		while (cursor.hasNext()) {
 			cursor.fwd();
 			cursor.localize(pos);
@@ -115,6 +117,8 @@ public class DefaultASCII<T extends RealType<T>> extends
 			// normalized = (value - min) / (max - min)
 			tmp.set(cursor.get());
 			tmp.sub(min);
+			// NB: if a value is below min we set tmp to zero.
+			if (tmp.compareTo(zero) < 0) tmp.setZero();
 			final double normalized = tmp.getRealDouble() / span.getRealDouble();
 
 			final int charLen = CHARS.length();

--- a/src/test/java/net/imagej/ops/image/ascii/ASCIITest.java
+++ b/src/test/java/net/imagej/ops/image/ascii/ASCIITest.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,14 +40,15 @@ import org.junit.Test;
 
 /**
  * Tests {@link net.imagej.ops.Ops.Image.ASCII}.
- * 
+ *
  * @author Leon Yang
+ * @author Gabe Selzer
  */
 public class ASCIITest extends AbstractOpTest {
 
 	@Test
 	public void testDefaultASCII() {
-		// character set used in DefaultASCII, could be updated if necessary
+// character set used in DefaultASCII, could be updated if necessary
 		final String CHARS = "#O*o+-,. ";
 		final int len = CHARS.length();
 		final int width = 10;
@@ -67,5 +68,37 @@ public class ASCIITest extends AbstractOpTest {
 			}
 			assertTrue(ascii.charAt(i * (width + 1) + width) == '\n');
 		}
+	}
+
+	@Test
+	public void testASCIIMinMax() {
+		// character set used in DefaultASCII, could be updated if necessary
+		final String CHARS = "#O*o+-,. ";
+		final int len = CHARS.length();
+		final int width = 10;
+		final byte[] array = new byte[width * len];
+		for (int i = 0; i < len; i++) {
+			for (int j = 0; j < width; j++) {
+				array[i * width + j] = (byte) (i * width + j);
+			}
+		}
+		final UnsignedByteType min = new UnsignedByteType(0);
+		final UnsignedByteType max = new UnsignedByteType(90);
+		final Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(array, width,
+			len);
+		final String ascii = (String) ops.run(DefaultASCII.class, img, min, max);
+		for (int i = 0; i < len; i++) {
+			for (int j = 0; j < width; j++) {
+				assertTrue(ascii.charAt(i * (width + 1) + j) == CHARS.charAt(i));
+			}
+			assertTrue(ascii.charAt(i * (width + 1) + width) == '\n');
+		}
+
+		// make sure that the clamped ASCII string is not equivalent to the
+		// unclamped String
+		final String asciiUnclamped = (String) ops.run(DefaultASCII.class, img);
+
+		assertTrue(asciiUnclamped != ascii);
+
 	}
 }


### PR DESCRIPTION
When you provide an image of a type that can be negative, the Op can attempt to access the string of valid ascii image characters at a negative index, throwing an error. This PR fixes the bug and adds a test containing the code that threw an error before, as well as making sure that the clamped ascii image is not the same as the unclamped image.