### PR TITLE
FrangiVesselnessCommand: set headless = true

### DIFF
--- a/src/main/java/net/imagej/ops/commands/filter/FrangiVesselness.java
+++ b/src/main/java/net/imagej/ops/commands/filter/FrangiVesselness.java
@@ -54,7 +54,7 @@ import org.scijava.plugin.Plugin;
  * 
  * @author Gabe Selzer
  */
-@Plugin(type = Command.class, menuPath = "Process>Filters>Frangi Vesselness")
+@Plugin(type = Command.class, headless = true, menuPath = "Process>Filters>Frangi Vesselness")
 public class FrangiVesselness<T extends RealType<T>> implements Command {
 
 	@Parameter


### PR DESCRIPTION
I just noticed this was not set to headless = true. Therefore it could not be used in KNIME via our ImageJ2 integration.  