### PR TITLE
Fix bug in noncirculant deconvolution

### DIFF
--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -37,7 +37,6 @@ import net.imagej.ops.OpMethod;
 import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.inplace.UnaryInplaceOp;
 import net.imglib2.Dimensions;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
@@ -590,14 +589,14 @@ public class DeconvolveNamespace extends AbstractNamespace {
 		normalizationFactor(final RandomAccessibleInterval<O> arg,
 			final Dimensions k, final Dimensions l,
 			final RandomAccessibleInterval<O> fftInput,
-			final RandomAccessibleInterval<O> fftKernel,
-			final Interval imgConvolutionInterval)
+			final RandomAccessibleInterval<O> fftKernel)
+
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) ops().run(
 				net.imagej.ops.deconvolve.NonCirculantNormalizationFactor.class, arg, k,
-				l, fftInput, fftKernel, imgConvolutionInterval);
+				l, fftInput, fftKernel);
 		return result;
 	}
 
@@ -605,14 +604,12 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.deconvolve.NonCirculantFirstGuess.class)
 	public <I extends RealType<I>, O extends RealType<O>>
 		RandomAccessibleInterval<O> firstGuess(final RandomAccessibleInterval<I> in,
-			final Interval imgConvolutionInterval, final Type<O> outType,
-			final Dimensions k)
+			final Type<O> outType, final Dimensions k)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
 			(RandomAccessibleInterval<O>) ops().run(
-				net.imagej.ops.deconvolve.NonCirculantFirstGuess.class, in,
-				imgConvolutionInterval, outType, k);
+				net.imagej.ops.deconvolve.NonCirculantFirstGuess.class, in, outType, k);
 		return result;
 	}
 

--- a/src/main/java/net/imagej/ops/deconvolve/NonCirculantFirstGuess.java
+++ b/src/main/java/net/imagej/ops/deconvolve/NonCirculantFirstGuess.java
@@ -36,7 +36,6 @@ import net.imagej.ops.special.function.UnaryFunctionOp;
 import net.imagej.ops.special.hybrid.Hybrids;
 import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.Dimensions;
-import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.Type;
@@ -59,16 +58,12 @@ import org.scijava.plugin.Plugin;
  * @param <C>
  */
 
-@Plugin(type = Ops.Deconvolve.FirstGuess.class,
-	priority = Priority.LOW)
+@Plugin(type = Ops.Deconvolve.FirstGuess.class, priority = Priority.LOW)
 public class NonCirculantFirstGuess<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	extends
 	AbstractUnaryFunctionOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>
 	implements Ops.Deconvolve.FirstGuess
 {
-
-	@Parameter
-	private Interval imgConvolutionInterval;
 
 	@Parameter
 	Type<O> outType;
@@ -99,7 +94,7 @@ public class NonCirculantFirstGuess<I extends RealType<I>, O extends RealType<O>
 	@Override
 	public RandomAccessibleInterval<O> calculate(RandomAccessibleInterval<I> in) {
 
-		final Img<O> firstGuess = create.calculate(imgConvolutionInterval);
+		final Img<O> firstGuess = create.calculate(in);
 
 		// set first guess to be a constant = to the average value
 

--- a/src/main/java/net/imagej/ops/deconvolve/NonCirculantNormalizationFactor.java
+++ b/src/main/java/net/imagej/ops/deconvolve/NonCirculantNormalizationFactor.java
@@ -99,12 +99,6 @@ public class NonCirculantNormalizationFactor<I extends RealType<I>, O extends Re
 	@Parameter
 	RandomAccessibleInterval<C> fftKernel;
 
-	/**
-	 * The interval to process TODO: this is probably redundant - remove
-	 */
-	@Parameter
-	private Interval imgConvolutionInterval;
-
 	// Normalization factor for edge handling (see
 	// http://bigwww.epfl.ch/deconvolution/challenge2013/index.html?p=doc_math_rl)
 	private Img<O> normalization = null;
@@ -138,15 +132,14 @@ public class NonCirculantNormalizationFactor<I extends RealType<I>, O extends Re
 	public void mutate(RandomAccessibleInterval<O> arg) {
 		// if the normalization image hasn't been computed yet, then compute it
 		if (normalization == null) {
-			normalization = create.calculate(imgConvolutionInterval);
-			this.createNormalizationImageSemiNonCirculant();
+			this.createNormalizationImageSemiNonCirculant(arg);
 		}
 
 		// normalize for non-circulant deconvolution
 		divide.mutate1(normalization, Views.iterable(arg));
 	}
 
-	protected void createNormalizationImageSemiNonCirculant() {
+	protected void createNormalizationImageSemiNonCirculant(Interval fastFFTInterval) {
 
 		// k is the window size (valid image region)
 		final int length = k.numDimensions();
@@ -160,8 +153,10 @@ public class NonCirculantNormalizationFactor<I extends RealType<I>, O extends Re
 			n[d] = k.dimension(d) + l.dimension(d) - 1;
 		}
 
+		// nFFT is the size of n after (potentially) extending further
+		// to a fast FFT size
 		for (int d = 0; d < length; d++) {
-			nFFT[d] = imgConvolutionInterval.dimension(d);
+			nFFT[d] = fastFFTInterval.dimension(d);
 		}
 
 		FinalDimensions fd = new FinalDimensions(nFFT);

--- a/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
+++ b/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
@@ -42,6 +42,7 @@ import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 import org.junit.Test;
@@ -54,40 +55,66 @@ public class DeconvolveTest extends AbstractOpTest {
 	@Test
 	public void testDeconvolve() {
 		int[] size = new int[] { 225, 167 };
-		int[] kernelSize = new int[] { 27, 39 };
 
 		// create an input with a small sphere at the center
 		Img<FloatType> in = new ArrayImgFactory<FloatType>().create(size,
 			new FloatType());
 		placeSphereInCenter(in);
 
-		// create a kernel with a small sphere in the center
-		Img<FloatType> kernel = new ArrayImgFactory<FloatType>().create(kernelSize,
-			new FloatType());
-		placeSphereInCenter(kernel);
+		// crop the image so the sphere is truncated at the corner
+		// (this is useful for testing non-circulant mode)
+		IntervalView<FloatType> incropped = Views.interval(in, new long[] {
+			size[0] / 2, size[1] / 2 }, new long[] { size[0] - 1, size[1] - 1 });
 
-		// convolve and calculate the sum of output
+		incropped = Views.zeroMin(incropped);
+
+		RandomAccessibleInterval<FloatType> kernel = ops.create().kernelGauss(
+			new double[] { 4.0, 4.0 }, new FloatType());
+
+		// convolve 
 		@SuppressWarnings("unchecked")
 		final Img<FloatType> convolved = (Img<FloatType>) ops.run(
-			ConvolveFFTF.class, in, kernel);
+			ConvolveFFTF.class, incropped, kernel);
 
+		// deconvolve with standard Richardson Lucy
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<FloatType> deconvolved2 =
+		final RandomAccessibleInterval<FloatType> deconvolved =
 			(RandomAccessibleInterval<FloatType>) ops.run(RichardsonLucyF.class,
 				convolved, kernel, null, new OutOfBoundsConstantValueFactory<>(Util
 					.getTypeFromInterval(in).createVariable()), 10);
 
-		assertEquals(size[0], deconvolved2.dimension(0));
-		assertEquals(size[1], deconvolved2.dimension(1));
-		final Cursor<FloatType> deconvolved2Cursor = Views.iterable(deconvolved2)
+		// deconvolve with accelerated non-circulant Richardson Lucy
+		@SuppressWarnings("unchecked")
+		final RandomAccessibleInterval<FloatType> deconvolved2 =
+			(RandomAccessibleInterval<FloatType>) ops.run(RichardsonLucyF.class,
+				convolved, kernel, null, new OutOfBoundsConstantValueFactory<>(Util
+					.getTypeFromInterval(in).createVariable()), null, null, null, 10,
+				true, true);
+
+		assertEquals(incropped.dimension(0), deconvolved.dimension(0));
+		assertEquals(incropped.dimension(1), deconvolved.dimension(1));
+
+		assertEquals(incropped.dimension(0), deconvolved2.dimension(0));
+		assertEquals(incropped.dimension(1), deconvolved2.dimension(1));
+
+		final Cursor<FloatType> deconvolvedCursor = Views.iterable(deconvolved)
 			.cursor();
-		float[] deconvolved2Values = { 1.0936068E-14f, 2.9685445E-14f,
-			4.280788E-15f, 3.032084E-18f, 1.1261E-39f, 0.0f, -8.7E-44f, -8.11881E-31f,
-			-2.821192E-18f, 1.8687104E-20f, -2.927517E-23f, 1.2815774E-29f,
-			-1.0611375E-19f, -5.2774515E-21f, -6.154334E-20f };
-		for (int i = 0; i < deconvolved2Values.length; i++) {
-			assertEquals(deconvolved2Values[i], deconvolved2Cursor.next().get(),
-				0.0f);
+
+		final Cursor<FloatType> deconvolvedCursor2 = Views.iterable(deconvolved2)
+			.cursor();
+
+		float[] deconvolvedValues = { 3.6045982E-4f, 0.0016963598f, 0.0053468645f,
+			0.011868152f, 0.019616995f, 0.025637051f, 0.028158935f, 0.027555753f,
+			0.025289025f, 0.02266813f, 0.020409783f, 0.018752098f, 0.017683199f,
+			0.016951872f, 0.016685976f };
+
+		float[] deconvolvedValues2 = { 0.2630328f, 0.3163978f, 0.37502986f,
+			0.436034f, 0.4950426f, 0.5468085f, 0.58636993f, 0.6105018f, 0.6186566f,
+			0.61295974f, 0.59725416f, 0.575831f, 0.5524411f, 0.5307535f,  0.5109127f };
+
+		for (int i = 0; i < deconvolvedValues.length; i++) {
+			assertEquals(deconvolvedValues[i], deconvolvedCursor.next().get(), 0.0f);
+			assertEquals(deconvolvedValues2[i], deconvolvedCursor2.next().get(), 0.0f);
 		}
 	}
 
@@ -99,7 +126,7 @@ public class DeconvolveTest extends AbstractOpTest {
 		for (int d = 0; d < img.numDimensions(); d++)
 			center.setPosition(img.dimension(d) / 2, d);
 
-		HyperSphere<FloatType> hyperSphere = new HyperSphere<>(img, center, 2);
+		HyperSphere<FloatType> hyperSphere = new HyperSphere<>(img, center, 30);
 
 		for (final FloatType value : hyperSphere) {
 			value.setReal(1);


### PR DESCRIPTION
This pull request contains a fairly small bug fix.  I'll leave it open for a couple of days in case anyone has any feedback, then close it if no one reports any issues. 

- Remove redundant Parameters
- Add non-circulant mode to DeconvolveTest

This pull request addresses #586.  The error was caused because I removed a parameter from several ops, but did forgot to remove it when matching one of the ops. 

In ```DeconvolutionTest.java``` added a call to '''RichardsonLucyF''' with '''nonCirculant'''=true, and '''accelerate'''=true, to make sure these cases are covered.  

Also see the following [gist](https://gist.github.com/bnorthan/7756400d7c0e046e2524f3676ac61db4), it contains DeconvolutionTest, with some extra cases and displays the inputs and outputs in the GUI.  It's useful for understanduing how the algorithms are working, especially when deconvolving truncated objects. 
