### PR TITLE
Fix floating point numbers comparison in CreateKernelDiffractionTest

### DIFF
--- a/src/test/java/net/imagej/ops/create/kernelDiffraction/CreateKernelDiffractionTest.java
+++ b/src/test/java/net/imagej/ops/create/kernelDiffraction/CreateKernelDiffractionTest.java
@@ -99,7 +99,7 @@ public class CreateKernelDiffractionTest extends AbstractOpTest {
 
 		};
 
-		assertArrayEquals(expected, asArray(kernel), 0.0);
+		assertArrayEquals(expected, asArray(kernel), 1e-4);
 	}
 	
 	/**


### PR DESCRIPTION
`CreateKernelDiffractionTest` was failing on my machine when building `imagej-ops` using Oracle JDK 10 due to floating point imprecision. Fixed by using a reasonable threshold value for comparison.