### PR TITLE
Make Chunk indexes longs

### DIFF
--- a/src/main/java/net/imagej/ops/features/hog/HistogramOfOrientedGradients2D.java
+++ b/src/main/java/net/imagej/ops/features/hog/HistogramOfOrientedGradients2D.java
@@ -191,7 +191,7 @@ public class HistogramOfOrientedGradients2D<T extends RealType<T>>
 		final CursorBasedChunk chunkable = new CursorBasedChunk() {
 
 			@Override
-			public void execute(int startIndex, int stepSize, int numSteps) {
+			public void execute(long startIndex, long stepSize, long numSteps) {
 				final Cursor<FloatType> cursorAngles = Views.flatIterable(angles).localizingCursor();
 				final Cursor<FloatType> cursorMagnitudes = Views.flatIterable(magnitudes).localizingCursor();
 				final Cursor<FloatType> cursorDerivative0 = Views.flatIterable(finalderivative0).localizingCursor();
@@ -202,7 +202,7 @@ public class HistogramOfOrientedGradients2D<T extends RealType<T>>
 				setToStart(cursorDerivative0, startIndex);
 				setToStart(cursorDerivative1, startIndex);
 
-				for (int i = 0; i < numSteps; i++) {
+				for (long i = 0; i < numSteps; i++) {
 					final float x = cursorDerivative0.get().getRealFloat();
 					final float y = cursorDerivative1.get().getRealFloat();
 					cursorAngles.get().setReal(getAngle(x, y));

--- a/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIIAndIIInplaceParallel.java
@@ -64,8 +64,8 @@ public class MapIIAndIIInplaceParallel<EA> extends
 		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
-			public void execute(final int startIndex, final int stepSize,
-				final int numSteps)
+			public void execute(final long startIndex, final long stepSize,
+				final long numSteps)
 			{
 				Maps.inplace(arg, in, (BinaryInplace1Op<EA, EA, EA>) getOp(),
 					startIndex, stepSize, numSteps);
@@ -80,8 +80,8 @@ public class MapIIAndIIInplaceParallel<EA> extends
 		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
-			public void execute(final int startIndex, final int stepSize,
-				final int numSteps)
+			public void execute(final long startIndex, final long stepSize,
+				final long numSteps)
 			{
 				Maps.inplace(in, arg, getOp(), startIndex, stepSize, numSteps);
 			}

--- a/src/main/java/net/imagej/ops/map/MapIIInplaceParallel.java
+++ b/src/main/java/net/imagej/ops/map/MapIIInplaceParallel.java
@@ -54,8 +54,8 @@ public class MapIIInplaceParallel<A> extends
 		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
-			public void execute(final int startIndex, final int stepSize,
-				final int numSteps)
+			public void execute(final long startIndex, final long stepSize,
+				final long numSteps)
 			{
 				Maps.inplace(arg, getOp(), startIndex, stepSize, numSteps);
 			}

--- a/src/main/java/net/imagej/ops/map/MapNullaryII.java
+++ b/src/main/java/net/imagej/ops/map/MapNullaryII.java
@@ -54,8 +54,8 @@ public class MapNullaryII<O> extends
 		ops().run(ChunkerOp.class, new CursorBasedChunk() {
 
 			@Override
-			public void execute(final int startIndex, final int stepSize,
-				final int numSteps)
+			public void execute(final long startIndex, final long stepSize,
+				final long numSteps)
 			{
 				Maps.map(output, getOp(), startIndex, stepSize, numSteps);
 			}

--- a/src/main/java/net/imagej/ops/map/Maps.java
+++ b/src/main/java/net/imagej/ops/map/Maps.java
@@ -131,13 +131,13 @@ public class Maps {
 	}
 
 	public static <O> void map(final IterableInterval<O> a,
-		final NullaryComputerOp<O> op, final int startIndex, final int stepSize,
-		final int numSteps)
+		final NullaryComputerOp<O> op, final long startIndex, final long stepSize,
+		final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<O> aCursor = a.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			op.compute(aCursor.get());
 		}
@@ -284,14 +284,14 @@ public class Maps {
 
 	public static <I, O> void map(final IterableInterval<I> a,
 		final IterableInterval<O> b, final UnaryComputerOp<I, O> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<I> aCursor = a.cursor();
 		final Cursor<O> bCursor = b.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			aCursor.jumpFwd(m);
 			bCursor.jumpFwd(m);
 			op.compute(aCursor.get(), bCursor.get());
@@ -300,13 +300,13 @@ public class Maps {
 
 	public static <I, O> void map(final IterableInterval<I> a,
 		final RandomAccessibleInterval<O> b, final UnaryComputerOp<I, O> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<I> aCursor = a.localizingCursor();
 		final RandomAccess<O> bAccess = b.randomAccess();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			bAccess.setPosition(aCursor);
 			op.compute(aCursor.get(), bAccess.get());
@@ -315,13 +315,13 @@ public class Maps {
 
 	public static <I, O> void map(final RandomAccessibleInterval<I> a,
 		final IterableInterval<O> b, final UnaryComputerOp<I, O> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final RandomAccess<I> aAccess = a.randomAccess();
 		final Cursor<O> bCursor = b.localizingCursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			bCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			aAccess.setPosition(bCursor);
 			op.compute(aAccess.get(), bCursor.get());
@@ -332,16 +332,16 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final IterableInterval<I1> a,
 		final IterableInterval<I2> b, final IterableInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.cursor();
 		final Cursor<I2> bCursor = b.cursor();
 		final Cursor<O> cCursor = c.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			aCursor.jumpFwd(m);
 			bCursor.jumpFwd(m);
 			cCursor.jumpFwd(m);
@@ -351,16 +351,16 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final IterableInterval<I1> a,
 		final IterableInterval<I2> b, final RandomAccessibleInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.localizingCursor();
 		final Cursor<I2> bCursor = b.cursor();
 		final RandomAccess<O> cAccess = c.randomAccess();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			aCursor.jumpFwd(m);
 			bCursor.jumpFwd(m);
 			cAccess.setPosition(aCursor);
@@ -370,16 +370,16 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final IterableInterval<I1> a,
 		final RandomAccessibleInterval<I2> b, final IterableInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.localizingCursor();
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final Cursor<O> cCursor = c.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			aCursor.jumpFwd(m);
 			cCursor.jumpFwd(m);
 			bAccess.setPosition(aCursor);
@@ -389,16 +389,16 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final RandomAccessibleInterval<I1> a,
 		final IterableInterval<I2> b, final IterableInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final RandomAccess<I1> aAccess = a.randomAccess();
 		final Cursor<I2> bCursor = b.localizingCursor();
 		final Cursor<O> cCursor = c.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			bCursor.jumpFwd(m);
 			cCursor.jumpFwd(m);
 			aAccess.setPosition(bCursor);
@@ -408,15 +408,15 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final IterableInterval<I1> a,
 		final RandomAccessibleInterval<I2> b, final RandomAccessibleInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<I1> aCursor = a.localizingCursor();
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final RandomAccess<O> cAccess = c.randomAccess();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			aCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			bAccess.setPosition(aCursor);
 			cAccess.setPosition(aCursor);
@@ -426,15 +426,15 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final RandomAccessibleInterval<I1> a,
 		final IterableInterval<I2> b, final RandomAccessibleInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final RandomAccess<I1> aAccess = a.randomAccess();
 		final Cursor<I2> bCursor = b.localizingCursor();
 		final RandomAccess<O> cAccess = c.randomAccess();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			bCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			aAccess.setPosition(bCursor);
 			cAccess.setPosition(bCursor);
@@ -444,15 +444,15 @@ public class Maps {
 
 	public static <I1, I2, O> void map(final RandomAccessibleInterval<I1> a,
 		final RandomAccessibleInterval<I2> b, final IterableInterval<O> c,
-		final BinaryComputerOp<I1, I2, O> op, final int startIndex,
-		final int stepSize, final int numSteps)
+		final BinaryComputerOp<I1, I2, O> op, final long startIndex,
+		final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final RandomAccess<I1> aAccess = a.randomAccess();
 		final RandomAccess<I2> bAccess = b.randomAccess();
 		final Cursor<O> cCursor = c.localizingCursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			cCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			aAccess.setPosition(cCursor);
 			bAccess.setPosition(cCursor);
@@ -470,13 +470,13 @@ public class Maps {
 	}
 
 	public static <I, O extends I> void inplace(final IterableInterval<O> arg,
-		final UnaryInplaceOp<I, O> op, final int startIndex, final int stepSize,
-		final int numSteps)
+		final UnaryInplaceOp<I, O> op, final long startIndex, final long stepSize,
+		final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<O> argCursor = arg.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			argCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			op.mutate(argCursor.get());
 		}
@@ -522,14 +522,14 @@ public class Maps {
 
 	public static <A, I> void inplace(final IterableInterval<A> arg,
 		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<I> inCursor = in.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			argCursor.jumpFwd(m);
 			inCursor.jumpFwd(m);
 			op.mutate1(argCursor.get(), inCursor.get());
@@ -538,13 +538,13 @@ public class Maps {
 
 	public static <A, I> void inplace(final IterableInterval<A> arg,
 		final RandomAccessibleInterval<I> in, final BinaryInplace1Op<A, I, A> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<A> argCursor = arg.localizingCursor();
 		final RandomAccess<I> inAccess = in.randomAccess();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			argCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			inAccess.setPosition(argCursor);
 			op.mutate1(argCursor.get(), inAccess.get());
@@ -553,13 +553,13 @@ public class Maps {
 
 	public static <A, I> void inplace(final RandomAccessibleInterval<A> arg,
 		final IterableInterval<I> in, final BinaryInplace1Op<A, I, A> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final RandomAccess<A> argAccess = arg.randomAccess();
 		final Cursor<I> inCursor = in.localizingCursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
+		for (long ctr = 0; ctr < numSteps; ctr++) {
 			inCursor.jumpFwd(ctr == 0 ? startIndex + 1 : stepSize);
 			argAccess.setPosition(inCursor);
 			op.mutate1(argAccess.get(), inCursor.get());
@@ -578,14 +578,14 @@ public class Maps {
 
 	public static <A> void inplace(final IterableInterval<A> arg,
 		final IterableInterval<A> in, final BinaryInplaceOp<A, A> op,
-		final int startIndex, final int stepSize, final int numSteps)
+		final long startIndex, final long stepSize, final long numSteps)
 	{
 		if (numSteps <= 0) return;
 		final Cursor<A> argCursor = arg.cursor();
 		final Cursor<A> inCursor = in.cursor();
 
-		for (int ctr = 0; ctr < numSteps; ctr++) {
-			final int m = ctr == 0 ? startIndex + 1 : stepSize;
+		for (long ctr = 0; ctr < numSteps; ctr++) {
+			final long m = ctr == 0 ? startIndex + 1 : stepSize;
 			argCursor.jumpFwd(m);
 			inCursor.jumpFwd(m);
 			op.mutate2(argCursor.get(), inCursor.get());

--- a/src/main/java/net/imagej/ops/thread/chunker/Chunk.java
+++ b/src/main/java/net/imagej/ops/thread/chunker/Chunk.java
@@ -54,6 +54,6 @@ public interface Chunk {
 	 * @param stepSize the step-size between two consecutive elements
 	 * @param numSteps how many steps shall be taken
 	 */
-	void execute(int startIndex, int stepSize, int numSteps);
+	void execute(long startIndex, long stepSize, long numSteps);
 
 }

--- a/src/main/java/net/imagej/ops/thread/chunker/CursorBasedChunk.java
+++ b/src/main/java/net/imagej/ops/thread/chunker/CursorBasedChunk.java
@@ -32,7 +32,7 @@ import net.imglib2.Cursor;
 
 public abstract class CursorBasedChunk implements Chunk {
 	
-	public static void setToStart(final Cursor<?> c, int startIndex) {
+	public static void setToStart(final Cursor<?> c, long startIndex) {
 		c.reset();
 		c.jumpFwd(startIndex + 1);
 	}

--- a/src/main/java/net/imagej/ops/thread/chunker/DefaultChunker.java
+++ b/src/main/java/net/imagej/ops/thread/chunker/DefaultChunker.java
@@ -60,15 +60,15 @@ public class DefaultChunker extends AbstractChunker {
 
 		// TODO: is there a better way to determine the optimal chunk size?
 		
-		final int numSteps = Math.max(1, 
-			(int) (numberOfElements / Runtime.getRuntime().availableProcessors())) ;
+		final long numSteps = Math.max(1, 
+			(long) (numberOfElements / Runtime.getRuntime().availableProcessors())) ;
 		
 		final int numChunks = (int) (numberOfElements / numSteps);
 
 		final ArrayList<Future<?>> futures = new ArrayList<>(numChunks);
 
 		for (int i = 0; i < numChunks - 1; i++) {
-			final int j = i;
+			final long j = i;
 
 			futures.add(threadService.run(new Runnable() {
 

--- a/src/main/java/net/imagej/ops/transform/project/DefaultProjectParallel.java
+++ b/src/main/java/net/imagej/ops/transform/project/DefaultProjectParallel.java
@@ -69,14 +69,14 @@ public class DefaultProjectParallel<T, V> extends
 
 			@Override
 			public void
-				execute(int startIndex, final int stepSize, final int numSteps)
+				execute(long startIndex, final long stepSize, final long numSteps)
 			{
 				final RandomAccess<T> access = input.randomAccess();
 				final Cursor<V> cursor = output.localizingCursor();
 
 				setToStart(cursor, startIndex);
 
-				int ctr = 0;
+				long ctr = 0;
 				while (ctr < numSteps) {
 					for (int d = 0; d < input.numDimensions(); d++) {
 						if (d != dim) {

--- a/src/main/templates/net/imagej/ops/map/MapBinaryComputers.vm
+++ b/src/main/templates/net/imagej/ops/map/MapBinaryComputers.vm
@@ -108,8 +108,8 @@ public class MapBinaryComputers {
 		{
 			ops().run(ChunkerOp.class, new CursorBasedChunk() {
 				@Override
-				public void execute(final int startIndex, final int stepSize,
-					final int numSteps)
+				public void execute(final long startIndex, final long stepSize,
+					final long numSteps)
 				{
 					Maps.map(input1, input2, output, getOp().getIndependentInstance(),
 						startIndex, stepSize, numSteps);

--- a/src/main/templates/net/imagej/ops/map/MapBinaryInplace1s.vm
+++ b/src/main/templates/net/imagej/ops/map/MapBinaryInplace1s.vm
@@ -103,8 +103,8 @@ public class MapBinaryInplace1s {
 		{
 			ops().run(ChunkerOp.class, new CursorBasedChunk() {
 				@Override
-				public void execute(final int startIndex, final int stepSize,
-					final int numSteps)
+				public void execute(final long startIndex, final long stepSize,
+					final long numSteps)
 				{
 					Maps.inplace(arg, in, getOp().getIndependentInstance(),
 						startIndex, stepSize, numSteps);

--- a/src/main/templates/net/imagej/ops/map/MapUnaryComputers.vm
+++ b/src/main/templates/net/imagej/ops/map/MapUnaryComputers.vm
@@ -106,8 +106,8 @@ public class MapUnaryComputers {
 		{
 			ops().run(ChunkerOp.class, new CursorBasedChunk() {
 				@Override
-				public void execute(final int startIndex, final int stepSize,
-					final int numSteps)
+				public void execute(final long startIndex, final long stepSize,
+					final long numSteps)
 				{
 					Maps.map(input, output, getOp().getIndependentInstance(),
 						startIndex, stepSize, numSteps);

--- a/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
+++ b/src/main/templates/net/imagej/ops/math/ConstantToArrayImageP.vm
@@ -56,6 +56,7 @@ import net.imglib2.type.numeric.real.FloatType;
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.util.ArrayUtils;
 
 /**
  * Wrapper class for multi-threaded version of binary math operations between 
@@ -98,15 +99,19 @@ public final class ConstantToArrayImageP {
 			ops().run(ChunkerOp.class, new Chunk() {
 
 				@Override
-				public void execute(final int startIndex, final int stepSize,
-						final int numSteps) {
-					if (stepSize != 1) {
-						for (int i = startIndex, j = 0; j < numSteps; i = i
-								+ stepSize, j++) {
+				public void execute(final long startIndex, final long stepSize,
+						final long numSteps) {
+					
+					final int startIndexSafe32 = (startIndex==0) ? 0 : ArrayUtils.safeMultiply32(startIndex);
+					final int stepSizeSafe32 = (stepSize==0) ? 0 : ArrayUtils.safeMultiply32(stepSize);
+					
+					if (stepSizeSafe32 != 1) {					
+						for (int i = startIndexSafe32, j = 0; j < numSteps; i = i
+								+ stepSizeSafe32, j++) {
 							data[i] ${op.operator}= value;
 						}
 					} else {
-						for (int i = startIndex; i < startIndex + numSteps; i++) {
+						for (int i = startIndexSafe32; i < startIndex + numSteps; i++) {
 							data[i] ${op.operator}= value;
 						}
 					}

--- a/src/test/java/net/imagej/ops/thread/RunDefaultChunker.java
+++ b/src/test/java/net/imagej/ops/thread/RunDefaultChunker.java
@@ -56,7 +56,7 @@ public class RunDefaultChunker<A extends RealType<A>> extends
 
 			@Override
 			public void
-				execute(int startIndex, final int stepSize, final int numSteps)
+				execute(long startIndex, final long stepSize, final long numSteps)
 			{
 				final Cursor<A> cursor = input.localizingCursor();
 				final Cursor<A> cursorOut = output.localizingCursor();

--- a/src/test/java/net/imagej/ops/thread/RunDefaultChunkerArray.java
+++ b/src/test/java/net/imagej/ops/thread/RunDefaultChunkerArray.java
@@ -36,6 +36,7 @@ import net.imagej.ops.thread.chunker.DefaultChunker;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
+import org.scijava.util.ArrayUtils;
 
 @Plugin(type = Op.class, name = "test.chunker",
 	priority = Priority.LOW)
@@ -49,14 +50,15 @@ public class RunDefaultChunkerArray<A> extends AbstractUnaryComputerOp<A[], A[]>
 
 			@Override
 			public void
-				execute(int startIndex, final int stepSize, final int numSteps)
+				execute(long startIndex, final long stepSize, final long numSteps)
 			{
-				int i = startIndex;
+				int i = startIndex == 0 ? 0 : ArrayUtils.safeMultiply32(startIndex);
+				int stepSizeSafe32 = stepSize == 0 ? 0 : ArrayUtils.safeMultiply32(stepSize);
 
 				int ctr = 0;
 				while (ctr < numSteps) {
 					output[i] = input[i];
-					i += stepSize;
+					i += stepSizeSafe32;
 					ctr++;
 				}
 			}

--- a/src/test/java/net/imagej/ops/thread/RunInterleavedChunker.java
+++ b/src/test/java/net/imagej/ops/thread/RunInterleavedChunker.java
@@ -55,7 +55,7 @@ public class RunInterleavedChunker<A extends RealType<A>> extends
 
 			@Override
 			public void
-				execute(int startIndex, final int stepSize, final int numSteps)
+				execute(long startIndex, final long stepSize, final long numSteps)
 			{
 				final Cursor<A> cursor = input.localizingCursor();
 				final Cursor<A> cursorOut = output.localizingCursor();

--- a/src/test/java/net/imagej/ops/thread/RunInterleavedChunkerArray.java
+++ b/src/test/java/net/imagej/ops/thread/RunInterleavedChunkerArray.java
@@ -36,6 +36,7 @@ import net.imagej.ops.thread.chunker.ChunkerInterleaved;
 
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
+import org.scijava.util.ArrayUtils;
 
 @Plugin(type = Op.class, name = "test.chunker",
 	priority = Priority.LOW)
@@ -49,14 +50,15 @@ public class RunInterleavedChunkerArray<A> extends
 
 			@Override
 			public void
-				execute(int startIndex, final int stepSize, final int numSteps)
+				execute(long startIndex, final long stepSize, final long numSteps)
 			{
-				int i = startIndex;
-
+				int i = startIndex==0 ? 0 : ArrayUtils.safeMultiply32(startIndex);
+				int stepSizeSafe32 = stepSize == 0 ? 0 : ArrayUtils.safeMultiply32(stepSize);
+				
 				int ctr = 0;
 				while (ctr < numSteps) {
 					output[i] = input[i];
-					i += stepSize;
+					i += stepSizeSafe32;
 					ctr++;
 				}
 			}


### PR DESCRIPTION
This pull request changes ```Chunk``` to use long indexes instead of int to potentially address [this](https://forum.image.sc/t/big-images-cause-an-array-index-out-of-bounds-exception/216920) forum issue.

The code seems to build successfully and all tests seem to pass, however since many files were changed there could be potential unforeseen consequences.  Let me know if there is any further due diligence I should do for this pull request.   