### PR TITLE
Add Fill Holes command

### DIFF
--- a/src/main/java/net/imagej/ops/commands/morphology/FillHoles.java
+++ b/src/main/java/net/imagej/ops/commands/morphology/FillHoles.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2019 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.commands.morphology;
+
+import net.imagej.ops.OpService;
+import net.imglib2.img.Img;
+import net.imglib2.type.BooleanType;
+
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.plugin.Attr;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This command applies the Fill Holes operation to a binary input image.
+ * 
+ * @author Stefan Helfrich
+ */
+@Plugin(type = Command.class, headless = true,
+	menuPath = "Process>Binary>Fill Holes", attrs = { @Attr(name = "no-legacy") })
+public class FillHoles<T extends BooleanType<T>> implements Command {
+
+	@Parameter
+	private OpService opService;
+
+	@Parameter
+	private Img<T> input;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Img<T> result;
+
+	@Override
+	public void run() {
+		// create output image via ImgFactory. Since T doesn't extend NativeType, we
+		// can't use CreateNamespace.img() methods
+		result = input.factory().create(input);
+		opService.morphology().fillHoles(result, input);
+	}
+
+}


### PR DESCRIPTION
This PR adds a `Command` that wraps the `Ops.Morphology.FillHoles` op.