### PR TITLE
Remove unnecessary loop, function call from DefaultCoordinatesEquation

### DIFF
--- a/src/main/java/net/imagej/ops/image/equation/DefaultCoordinatesEquation.java
+++ b/src/main/java/net/imagej/ops/image/equation/DefaultCoordinatesEquation.java
@@ -65,13 +65,7 @@ public class DefaultCoordinatesEquation<T extends RealType<T>, N extends Number>
 			c.fwd();
 			c.localize(pos);
 
-			for (int i = 0; i < output.numDimensions(); i++) {
-
-				op.calculate(pos);
-
-				c.get().setReal(op.calculate(pos).floatValue());
-
-			}
+			c.get().setReal(op.calculate(pos).floatValue());
 
 		}
 	}


### PR DESCRIPTION
Within `DefaultCoordinatesEquation` there existed both an obsolete for loop (on line 68) and an obsolete function call (on line 70). Both of these were removed in order to speed up the Op. All affected tests pass with this change.