### PR TITLE
WatershedSeeded: Fix NoSuchElementException #579

### DIFF
--- a/src/main/java/net/imagej/ops/image/watershed/WatershedSeeded.java
+++ b/src/main/java/net/imagej/ops/image/watershed/WatershedSeeded.java
@@ -209,9 +209,9 @@ public class WatershedSeeded<T extends RealType<T>, B extends BooleanType<B>>
 				raSeeds.setPosition(neighborhood);
 				raMask.setPosition(neighborhood);
 				raOut.setPosition(neighborhood);
+				if(raOut.isOutOfBounds() || !raMask.get().get() || !raSeeds.get().isEmpty()) continue;
 				final Integer labelNeigh = raOut.get().iterator().next();
-				if (labelNeigh != INQUEUE && labelNeigh != OUTSIDE && !raOut.isOutOfBounds() && raMask.get().get() 
-						&& raSeeds.get().isEmpty()) {
+				if (labelNeigh != INQUEUE && labelNeigh != OUTSIDE) {
 					raOut.setPosition(neighborhood);
 					pq.add(new WatershedVoxel(IntervalIndexer.positionToIndex(neighborhood, in), neighborhood.get().getRealDouble()));
 					raOut.get().clear();


### PR DESCRIPTION
- in case a seed was on the edge of the mask, a `NoSuchElementException` was thrown
- this commit fixes the issue by doing out of bound checks before accessing the labeling value

I am not very familiar with the details of watershed, but this commit should not introduce any change to the algorithm itself. @tischi can you try if that would fix your issue?