### PR TITLE
Parallize BoxCount with more than 1 'translation'

### DIFF
--- a/src/main/java/net/imagej/ops/topology/BoxCount.java
+++ b/src/main/java/net/imagej/ops/topology/BoxCount.java
@@ -30,7 +30,6 @@
 package net.imagej.ops.topology;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.stream.IntStream;
@@ -152,11 +151,9 @@ public class BoxCount<B extends BooleanType<B>> extends
 		final long[] sizes, final long sectionSize)
 	{
 		final int lastDimension = sizes.length - 1;
-		final LongType foreground = new LongType();
-		final long[] sectionPosition = new long[sizes.length];
-		return translations.mapToLong(gridOffset -> {
-			foreground.setZero();
-			Arrays.fill(sectionPosition, 0);
+		return translations.parallel().mapToLong(gridOffset -> {
+			final LongType foreground = new LongType();
+			final long[] sectionPosition = new long[sizes.length];
 			countGrid(input, lastDimension, sizes, gridOffset, sectionPosition,
 				sectionSize, foreground);
 			return foreground.get();

--- a/src/main/java/net/imagej/ops/topology/BoxCount.java
+++ b/src/main/java/net/imagej/ops/topology/BoxCount.java
@@ -117,12 +117,12 @@ public class BoxCount<B extends BooleanType<B>> extends
 		final List<ValuePair<DoubleType, DoubleType>> points = new ArrayList<>();
 		final int dimensions = input.numDimensions();
 		final long[] sizes = new long[dimensions];
-		final long numTranslations = 1 + gridMoves;
 		input.dimensions(sizes);
 		for (long sectionSize = maxSize; sectionSize >= minSize; sectionSize /=
 			scaling)
 		{
-			final long translationAmount = Math.max(1, sectionSize / numTranslations);
+			final long numTranslations = limitTranslations(sectionSize, 1 + gridMoves);
+			final long translationAmount = sectionSize / numTranslations;
 			final Stream<long[]> translations = translationStream(numTranslations,
 				translationAmount, dimensions - 1, new long[dimensions]);
 			final LongStream foregroundCounts = countTranslatedGrids(input,
@@ -135,6 +135,35 @@ public class BoxCount<B extends BooleanType<B>> extends
 			points.add(point);
 		}
 		return points;
+	}
+
+	/**
+	 * A helper method that culls unnecessary translations for finding the best fit.
+	 * <p>
+	 * For example, if size = 2 and there's a 2 x 2 x 2 object in a 3D image, then at worst
+	 * it's in 8 different boxes. The best fit in this case is one box. However the boxes can
+	 * only be adjusted by 1 pixel in each direction, so more than 2 translations is unnecessary.
+	 * </p>
+	 * <p>
+	 * NB the minimum number of translations is 1, which means the boxes are counted once,
+	 * and there are no attempts at adjusting their coordinates for a better fit.
+	 * </p>
+	 * @param size Size n of a box in the algorithm. E.g. in the 3D case it's n * n * n.
+	 * @param translations Number of times the box counting grid is moved in each dimension to find the best fit.
+	 * @return The original or maximum number of meaningful translations if the original was too many.
+	 * @throws IllegalArgumentException if size is non-positive.
+	 */
+	static long limitTranslations(final long size, final long translations)
+			throws IllegalArgumentException {
+		if (size < 1L) {
+			throw new IllegalArgumentException("Size must be positive");
+		}
+
+		if (translations < 1L) {
+			return 1L;
+		}
+
+		return Math.min(size, translations);
 	}
 
 	/**

--- a/src/main/java/net/imagej/ops/topology/BoxCount.java
+++ b/src/main/java/net/imagej/ops/topology/BoxCount.java
@@ -114,6 +114,10 @@ public class BoxCount<B extends BooleanType<B>> extends
 	public List<ValuePair<DoubleType, DoubleType>> calculate(
 		final RandomAccessibleInterval<B> input)
 	{
+		if (scaling <= 1.0) {
+			throw new IllegalArgumentException("Scaling must be > 1.0 or algorithm won't stop.");
+		}
+
 		final List<ValuePair<DoubleType, DoubleType>> points = new ArrayList<>();
 		final int dimensions = input.numDimensions();
 		final long[] sizes = new long[dimensions];

--- a/src/test/java/net/imagej/ops/topology/BoxCountTest.java
+++ b/src/test/java/net/imagej/ops/topology/BoxCountTest.java
@@ -179,6 +179,13 @@ public class BoxCountTest extends AbstractOpTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
+	public void testThrowsIAEIfScalingEqualsOne() {
+		final Img<BitType> img = ArrayImgs.bits(9, 9, 9);
+
+		ops.topology().boxCount(img, 8L, 2L, 1.0);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
 	public void testLimitTranslationsThrowsIAEIfSizeNonPositive() {
 		BoxCount.limitTranslations(0L, 5L);
 	}

--- a/src/test/java/net/imagej/ops/topology/BoxCountTest.java
+++ b/src/test/java/net/imagej/ops/topology/BoxCountTest.java
@@ -177,4 +177,21 @@ public class BoxCountTest extends AbstractOpTest {
 			assertEquals(p.b.get(), counts.next(), 1e-12);
 		});
 	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLimitTranslationsThrowsIAEIfSizeNonPositive() {
+		BoxCount.limitTranslations(0L, 5L);
+	}
+
+	@Test
+	public void testLimitTranslationsNonPositiveTranslations() {
+		assertEquals(1L, BoxCount.limitTranslations(10L, 0L));
+		assertEquals(1L, BoxCount.limitTranslations(100L, -1L));
+	}
+
+	@Test
+	public void testLimitTranslations() {
+		assertEquals(9L, BoxCount.limitTranslations(10L, 9L));
+		assertEquals(10L, BoxCount.limitTranslations(10L, 11L));
+	}
 }


### PR DESCRIPTION
Following issue [196](https://github.com/bonej-org/BoneJ2/issues/196) on the BoneJ2 hub, speeds up the BoxCounting op, when user has requested more than one "translation". Translations move the boxes around in hopes of finding the best fit, but add work in O(n^d) fashion.

I tried the obvious strategy of parallizing the boxes first, but that didn't run much faster.