### PR TITLE
Restore compatibility with existing scripts

### DIFF
--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -40,7 +40,6 @@ import net.imglib2.Dimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
 
@@ -133,7 +132,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final int maxIterations)
+			final O outType, final int maxIterations)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -151,7 +150,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType, final int maxIterations)
+			final O outType, final C fftType, final int maxIterations)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -169,7 +168,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType, final int maxIterations,
+			final O outType, final C fftType, final int maxIterations,
 			final boolean nonCirculant)
 	{
 		@SuppressWarnings("unchecked")
@@ -189,7 +188,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType, final int maxIterations,
+			final O outType, final C fftType, final int maxIterations,
 			final boolean nonCirculant, final boolean accelerate)
 	{
 		@SuppressWarnings("unchecked")
@@ -435,7 +434,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final int maxIterations,
+			final O outType, final int maxIterations,
 			final float regularizationFactor)
 	{
 		@SuppressWarnings("unchecked")
@@ -455,7 +454,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType, final int maxIterations,
+			final O outType, final C fftType, final int maxIterations,
 			final float regularizationFactor)
 	{
 		@SuppressWarnings("unchecked")
@@ -475,7 +474,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType, final int maxIterations,
+			final O outType, final C fftType, final int maxIterations,
 			final boolean nonCirculant, final float regularizationFactor)
 	{
 		@SuppressWarnings("unchecked")
@@ -495,7 +494,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType, final int maxIterations,
+			final O outType, final C fftType, final int maxIterations,
 			final boolean nonCirculant, final boolean accelerate,
 			final float regularizationFactor)
 	{
@@ -605,7 +604,7 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	@OpMethod(op = net.imagej.ops.deconvolve.NonCirculantFirstGuess.class)
 	public <I extends RealType<I>, O extends RealType<O>>
 		RandomAccessibleInterval<O> firstGuess(final RandomAccessibleInterval<I> in,
-			final Type<O> outType, final Dimensions k)
+			final O outType, final Dimensions k)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =

--- a/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
+++ b/src/main/java/net/imagej/ops/deconvolve/DeconvolveNamespace.java
@@ -42,6 +42,7 @@ import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
 
 import org.scijava.plugin.Plugin;
 
@@ -616,6 +617,331 @@ public class DeconvolveNamespace extends AbstractNamespace {
 	@Override
 	public String getName() {
 		return "deconvolve";
+	}
+
+	// -- Deprecated methods --
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final int maxIterations)
+	{
+		return richardsonLucy(create(in), in, kernel, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final int maxIterations)
+	{
+		return richardsonLucy(create(in), in, kernel, borderSize, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final int maxIterations)
+	{
+		return richardsonLucy(create(in), in, kernel, borderSize, obfInput,
+			maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final int maxIterations)
+	{
+		return richardsonLucy(create(in), in, kernel, borderSize, obfInput,
+			obfKernel, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final int maxIterations)
+	{
+		return richardsonLucy(create(in, outType), in, kernel, borderSize, obfInput,
+			obfKernel, outType, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final C fftType, final int maxIterations)
+	{
+		RandomAccessibleInterval<O> out = create(in, outType);
+		return richardsonLucy(out, in, kernel, borderSize, obfInput, obfKernel,
+			outType, fftType, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final C fftType, final int maxIterations,
+			final boolean nonCirculant)
+	{
+		return richardsonLucy(create(in, outType), in, kernel, borderSize, obfInput,
+			obfKernel, outType, fftType, maxIterations, nonCirculant);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final C fftType, final int maxIterations,
+			final boolean nonCirculant, final boolean accelerate)
+	{
+		return richardsonLucy(create(in, outType), in, kernel, borderSize, obfInput,
+			obfKernel, outType, fftType, maxIterations, nonCirculant, accelerate);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final int maxIterations)
+	{
+		return richardsonLucy(create(in1), in1, in2, fftInput, fftKernel,
+			performInputFFT, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final boolean performKernelFFT,
+			final int maxIterations)
+	{
+		return richardsonLucy(create(in1), in1, in2, fftInput, fftKernel,
+			performInputFFT, performKernelFFT, maxIterations);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final boolean performKernelFFT,
+			final int maxIterations, final UnaryInplaceOp<I, I> accelerator)
+	{
+		return richardsonLucy(create(in1), in1, in2, fftInput, fftKernel,
+			performInputFFT, performKernelFFT, maxIterations, accelerator);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<I> richardsonLucy(
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final boolean performKernelFFT,
+			final int maxIterations, final UnaryInplaceOp<I, I> accelerator,
+			final UnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<I>> update)
+	{
+		return richardsonLucy(create(in1), in1, in2, fftInput, fftKernel,
+			performInputFFT, performKernelFFT, maxIterations, accelerator, update);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final boolean performKernelFFT,
+			final int maxIterations, final UnaryInplaceOp<O, O> accelerator,
+			final UnaryComputerOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> update,
+			RandomAccessibleInterval<O> raiExtendedEstimate)
+	{
+		final RandomAccessibleInterval<O> out = create(in1, raiExtendedEstimate);
+		return richardsonLucy(out, in1, in2, fftInput, fftKernel, performInputFFT,
+			performKernelFFT, maxIterations, accelerator, update,
+			raiExtendedEstimate);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucy(
+			final RandomAccessibleInterval<I> in1,
+			final RandomAccessibleInterval<K> in2,
+			final RandomAccessibleInterval<C> fftInput,
+			final RandomAccessibleInterval<C> fftKernel,
+			final boolean performInputFFT, final boolean performKernelFFT,
+			final int maxIterations, final UnaryInplaceOp<O, O> accelerator,
+			final UnaryComputerOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>> update,
+			RandomAccessibleInterval<O> raiExtendedEstimate,
+			final ArrayList<UnaryInplaceOp<RandomAccessibleInterval<O>, RandomAccessibleInterval<O>>> iterativePostProcessing)
+	{
+		final RandomAccessibleInterval<O> out = create(in1, raiExtendedEstimate);
+		return richardsonLucy(out, in1, in2, fftInput, fftKernel, performInputFFT,
+			performKernelFFT, maxIterations, accelerator, update, raiExtendedEstimate,
+			iterativePostProcessing);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final int maxIterations,
+			final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in), in, kernel, maxIterations,
+			regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final int maxIterations, final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in), in, kernel, borderSize, maxIterations,
+			regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final int maxIterations, final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in), in, kernel, borderSize, obfInput,
+			maxIterations, regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I> & NativeType<I>, K extends RealType<K>>
+		RandomAccessibleInterval<I> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final int maxIterations, final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in), in, kernel, borderSize, obfInput,
+			obfKernel, maxIterations, regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>>
+		RandomAccessibleInterval<O> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final int maxIterations,
+			final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in, outType), in, kernel, borderSize,
+			obfInput, obfKernel, outType, maxIterations, regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final C fftType, final int maxIterations,
+			final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in, outType), in, kernel, borderSize,
+			obfInput, obfKernel, outType, fftType, maxIterations,
+			regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final C fftType, final int maxIterations,
+			final boolean nonCirculant, final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in, outType), in, kernel, borderSize,
+			obfInput, obfKernel, outType, fftType, maxIterations, nonCirculant,
+			regularizationFactor);
+	}
+
+	@Deprecated
+	public <I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>, C extends ComplexType<C>>
+		RandomAccessibleInterval<O> richardsonLucyTV(
+			final RandomAccessibleInterval<I> in,
+			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
+			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
+			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
+			final O outType, final C fftType, final int maxIterations,
+			final boolean nonCirculant, final boolean accelerate,
+			final float regularizationFactor)
+	{
+		return richardsonLucyTV(create(in, outType), in, kernel, borderSize,
+			obfInput, obfKernel, outType, fftType, maxIterations, nonCirculant,
+			accelerate, regularizationFactor);
+	}
+
+	// -- Helper methods --
+
+	private <T extends NativeType<T>> RandomAccessibleInterval<T> create(
+		final RandomAccessibleInterval<T> in)
+	{
+		return ops().create().img(in);
+	}
+
+	private <T extends RealType<T> & NativeType<T>> RandomAccessibleInterval<T>
+		create(Dimensions in, T outType)
+	{
+		return ops().create().img(in, outType);
+	}
+
+	private <O extends RealType<O> & NativeType<O>, I extends RealType<I>>
+		RandomAccessibleInterval<O> create(final RandomAccessibleInterval<I> in,
+			RandomAccessibleInterval<O> imageOfCorrectType)
+	{
+		if (imageOfCorrectType == null) {
+			throw new IllegalArgumentException("No way to discern output type");
+		}
+		return create(in, Util.getTypeFromInterval(imageOfCorrectType));
 	}
 
 }

--- a/src/main/java/net/imagej/ops/deconvolve/NonCirculantFirstGuess.java
+++ b/src/main/java/net/imagej/ops/deconvolve/NonCirculantFirstGuess.java
@@ -38,7 +38,6 @@ import net.imagej.ops.special.hybrid.UnaryHybridCF;
 import net.imglib2.Dimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
 
@@ -66,7 +65,7 @@ public class NonCirculantFirstGuess<I extends RealType<I>, O extends RealType<O>
 {
 
 	@Parameter
-	Type<O> outType;
+	private O outType;
 
 	/**
 	 * k is the size of the measurement window. That is the size of the acquired

--- a/src/main/java/net/imagej/ops/deconvolve/NonCirculantNormalizationFactor.java
+++ b/src/main/java/net/imagej/ops/deconvolve/NonCirculantNormalizationFactor.java
@@ -269,7 +269,7 @@ public class NonCirculantNormalizationFactor<I extends RealType<I>, O extends Re
 		public void mutate1(final I input, final I outin) {
 			final I tmp = outin.copy();
 
-			if (outin.getRealFloat() > 0) {
+			if (input.getRealFloat() > 0) {
 
 				tmp.set(outin);
 				tmp.div(input);

--- a/src/main/java/net/imagej/ops/deconvolve/NonCirculantNormalizationFactor.java
+++ b/src/main/java/net/imagej/ops/deconvolve/NonCirculantNormalizationFactor.java
@@ -261,7 +261,7 @@ public class NonCirculantNormalizationFactor<I extends RealType<I>, O extends Re
 		}
 	}
 
-	private static class DivideHandleZeroOp<I extends RealType<I> & NumericType<I>, O extends RealType<O> & NumericType<O>>
+	private static class DivideHandleZeroOp<I extends RealType<I> & NumericType<I>>
 		extends AbstractBinaryInplace1Op<I, I>
 	{
 

--- a/src/main/java/net/imagej/ops/filter/AbstractFFTFilterC.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractFFTFilterC.java
@@ -91,25 +91,11 @@ public abstract class AbstractFFTFilterC<I extends RealType<I>, O extends RealTy
 	 */
 	private UnaryFunctionOp<Dimensions, RandomAccessibleInterval<C>> createOp;
 
-	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void initialize() {
-		super.initialize();
-
+	protected RandomAccessibleInterval<C> getFFTInput() {
 		if (fftType == null) {
 			fftType = (ComplexType<C>) ops().create().nativeType(
 				ComplexFloatType.class);
 		}
-
-		/**
-		 * Op used to create the complex FFTs
-		 */
-		createOp = (UnaryFunctionOp) Functions.unary(ops(),
-			CreateOutputFFTMethods.class, RandomAccessibleInterval.class,
-			Dimensions.class, fftType, true);
-	}
-
-	protected RandomAccessibleInterval<C> getFFTInput() {
 		return fftInput;
 	}
 
@@ -136,6 +122,11 @@ public abstract class AbstractFFTFilterC<I extends RealType<I>, O extends RealTy
 	public UnaryFunctionOp<Dimensions, RandomAccessibleInterval<C>>
 		getCreateOp()
 	{
+		if (createOp == null) {
+			createOp = (UnaryFunctionOp) Functions.unary(ops(),
+				CreateOutputFFTMethods.class, RandomAccessibleInterval.class,
+				Dimensions.class, fftType, true);
+		}
 		return createOp;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/AbstractPadAndFFTFilter.java
+++ b/src/main/java/net/imagej/ops/filter/AbstractPadAndFFTFilter.java
@@ -42,7 +42,6 @@ import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -89,7 +88,7 @@ public abstract class AbstractPadAndFFTFilter<I extends RealType<I>, O extends R
 	 * The output type. If null a default output type will be used.
 	 */
 	@Parameter(required = false)
-	private Type<O> outType;
+	private O outType;
 
 	/**
 	 * FFT type
@@ -165,13 +164,13 @@ public abstract class AbstractPadAndFFTFilter<I extends RealType<I>, O extends R
 				.getTypeFromInterval(kernel).getClass())
 			{
 				Object temp = Util.getTypeFromInterval(input).createVariable();
-				outType = (Type<O>) temp;
+				outType = (O) temp;
 
 			}
 			// otherwise default to float
 			else {
 				Object temp = new FloatType();
-				outType = (Type<O>) temp;
+				outType = (O) temp;
 			}
 		}
 
@@ -272,7 +271,7 @@ public abstract class AbstractPadAndFFTFilter<I extends RealType<I>, O extends R
 		this.obfKernel = obfKernel;
 	}
 
-	protected Type<O> getOutType() {
+	protected O getOutType() {
 		return outType;
 	}
 }

--- a/src/main/java/net/imagej/ops/filter/FFTMethodsLinearFFTFilterC.java
+++ b/src/main/java/net/imagej/ops/filter/FFTMethodsLinearFFTFilterC.java
@@ -63,24 +63,22 @@ public class FFTMethodsLinearFFTFilterC<I extends RealType<I>, O extends RealTyp
 	@Parameter
 	private BinaryComputerOp<RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>> frequencyOp;
 
-	private UnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<C>> fftIn;
-
-	private UnaryComputerOp<RandomAccessibleInterval<K>, RandomAccessibleInterval<C>> fftKernel;
-
-	private UnaryComputerOp<RandomAccessibleInterval<C>, RandomAccessibleInterval<O>> ifft;
+	private UnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<C>> fftInOp;
+	private UnaryComputerOp<RandomAccessibleInterval<K>, RandomAccessibleInterval<C>> fftKernelOp;
+	private UnaryComputerOp<RandomAccessibleInterval<C>, RandomAccessibleInterval<O>> ifftOp;
 
 	@Override
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void initialize() {
 		super.initialize();
 
-		fftIn = (UnaryComputerOp) Computers.unary(ops(), FFTMethodsOpC.class,
+		fftInOp = (UnaryComputerOp) Computers.unary(ops(), FFTMethodsOpC.class,
 			getFFTInput(), RandomAccessibleInterval.class);
 
-		fftKernel = (UnaryComputerOp) Computers.unary(ops(), FFTMethodsOpC.class,
+		fftKernelOp = (UnaryComputerOp) Computers.unary(ops(), FFTMethodsOpC.class,
 			getFFTKernel(), RandomAccessibleInterval.class);
 
-		ifft = (UnaryComputerOp) Computers.unary(ops(), IFFTMethodsOpC.class,
+		ifftOp = (UnaryComputerOp) Computers.unary(ops(), IFFTMethodsOpC.class,
 			RandomAccessibleInterval.class, getFFTKernel());
 
 	}
@@ -104,12 +102,12 @@ public class FFTMethodsLinearFFTFilterC<I extends RealType<I>, O extends RealTyp
 		
 		// perform input FFT if needed
 		if (getPerformInputFFT()) {
-			fftIn.compute(in, getFFTInput());
+			fftInOp.compute(in, getFFTInput());
 		}
 
 		// perform kernel FFT if needed
 		if (getPerformKernelFFT()) {
-			fftKernel.compute(kernel, getFFTKernel());
+			fftKernelOp.compute(kernel, getFFTKernel());
 		}
 
 		// perform the operation in frequency domain (ie multiplication for
@@ -118,7 +116,7 @@ public class FFTMethodsLinearFFTFilterC<I extends RealType<I>, O extends RealTyp
 		frequencyOp.compute(getFFTInput(), getFFTKernel(), getFFTInput());
 
 		// perform inverse fft
-		ifft.compute(getFFTInput(), out);
+		ifftOp.compute(getFFTInput(), out);
 		// linearFilter.compute(in, kernel, out);
 	}
 }

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -29,8 +29,6 @@
 
 package net.imagej.ops.filter;
 
-import java.util.List;
-
 import net.imagej.ops.AbstractNamespace;
 import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
@@ -169,7 +167,7 @@ public class FilterNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
-			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Correlate.class,
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Convolve.class,
 				in, kernel);
 		return result;
 	}
@@ -184,7 +182,7 @@ public class FilterNamespace extends AbstractNamespace {
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
-			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Correlate.class, output,
+			(RandomAccessibleInterval<O>) ops().run(Ops.Filter.Convolve.class, output,
 				raiExtendedInput, raiExtendedKernel);
 		return result;
 	}

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -150,7 +150,7 @@ public class FilterNamespace extends AbstractNamespace {
 	
 	// -- convolve --
 	
-	/** Executes the "correlate" operation on the given arguments. */
+	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveNaiveF.class,
 		net.imagej.ops.filter.convolve.PadAndConvolveFFTF.class })
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -165,7 +165,7 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 	
-	/** Executes the "correlate" operation on the given arguments. */
+	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveFFTC.class,
 		net.imagej.ops.filter.convolve.PadAndConvolveFFT.class })
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
@@ -332,6 +332,7 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveFFTC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> convolve(
@@ -350,6 +351,7 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	/** Executes the "convolve" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveFFTC.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> convolve(
@@ -369,7 +371,8 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	// -- correlate --
-	/** Executes the "Correlate" operation on the given arguments. */
+
+	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(ops = {net.imagej.ops.filter.correlate.CorrelateFFTC.class,net.imagej.ops.filter.correlate.PadAndCorrelateFFT.class})
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 		RandomAccessibleInterval<O> correlate(final RandomAccessibleInterval<O> out,final RandomAccessibleInterval<I> in,
@@ -382,7 +385,7 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "Correlate" operation on the given arguments. */
+	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.correlate.PadAndCorrelateFFT.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 		RandomAccessibleInterval<O> correlate(final RandomAccessibleInterval<O> out,final RandomAccessibleInterval<I> in,
@@ -395,7 +398,7 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/** Executes the "Correlate" operation on the given arguments. */
+	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.correlate.PadAndCorrelateFFT.class)
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 		RandomAccessibleInterval<O> correlate(final RandomAccessibleInterval<O> out,final RandomAccessibleInterval<I> in,
@@ -455,8 +458,6 @@ public class FilterNamespace extends AbstractNamespace {
 				kernel, borderSize, obfInput, obfKernel, outType, fftType);
 		return result;
 	}
-
-
 
 	/** Executes the "correlate" operation on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.correlate.CorrelateFFTC.class)

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -45,7 +45,6 @@ import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.img.Img;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.RealType;
@@ -211,7 +210,7 @@ public class FilterNamespace extends AbstractNamespace {
 		RandomAccessibleInterval<O> convolve(final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obf,
-			final Type<O> outType)
+			final O outType)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -269,7 +268,7 @@ public class FilterNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType)
+			final O outType)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -285,7 +284,7 @@ public class FilterNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType)
+			final O outType, final C fftType)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -439,7 +438,7 @@ public class FilterNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType)
+			final O outType)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -455,7 +454,7 @@ public class FilterNamespace extends AbstractNamespace {
 			final RandomAccessibleInterval<K> kernel, final long[] borderSize,
 			final OutOfBoundsFactory<I, RandomAccessibleInterval<I>> obfInput,
 			final OutOfBoundsFactory<K, RandomAccessibleInterval<K>> obfKernel,
-			final Type<O> outType, final C fftType)
+			final O outType, final C fftType)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<O> result =
@@ -616,7 +615,7 @@ public class FilterNamespace extends AbstractNamespace {
 		RandomAccessibleInterval<C> fft(final RandomAccessibleInterval<T> in,
 			final long[] borderSize, final boolean fast,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> obf,
-			final Type<C> fftType)
+			final C fftType)
 	{
 		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<C> result =

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -131,16 +131,9 @@ public class FilterNamespace extends AbstractNamespace {
 		return result;
 	}
 
-	/**
-	 * Executes a bilateral filter on the given arguments.
-	 *
-	 * @param in
-	 * @param out
-	 * @param sigmaR
-	 * @param sigmaS
-	 * @param radius
-	 * @return
-	 */
+	// -- bilateral --
+
+	/** Executes the "bilateral" filter on the given arguments. */
 	@OpMethod(op = net.imagej.ops.filter.bilateral.DefaultBilateral.class)
 	public <I extends RealType<I>, O extends RealType<O>>
 		RandomAccessibleInterval<O> bilateral(final RandomAccessibleInterval<O> out,

--- a/src/main/java/net/imagej/ops/filter/FilterNamespace.java
+++ b/src/main/java/net/imagej/ops/filter/FilterNamespace.java
@@ -159,7 +159,8 @@ public class FilterNamespace extends AbstractNamespace {
 	// -- convolve --
 	
 	/** Executes the "correlate" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveNaiveF.class)
+	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveNaiveF.class,
+		net.imagej.ops.filter.convolve.PadAndConvolveFFTF.class })
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> convolve(
 			final RandomAccessibleInterval<I> in,
@@ -173,7 +174,8 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 	
 	/** Executes the "correlate" operation on the given arguments. */
-	@OpMethod(ops = {net.imagej.ops.filter.convolve.ConvolveFFTC.class, net.imagej.ops.filter.convolve.PadAndConvolveFFT.class})
+	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveFFTC.class,
+		net.imagej.ops.filter.convolve.PadAndConvolveFFT.class })
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		RandomAccessibleInterval<O> convolve(
 			final RandomAccessibleInterval<O> output,
@@ -188,7 +190,8 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	/** Executes the "convolve" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveNaiveF.class)
+	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveNaiveF.class,
+		net.imagej.ops.filter.convolve.PadAndConvolveFFTF.class })
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 		RandomAccessibleInterval<O> convolve(final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel,
@@ -202,7 +205,8 @@ public class FilterNamespace extends AbstractNamespace {
 	}
 
 	/** Executes the "convolve" operation on the given arguments. */
-	@OpMethod(op = net.imagej.ops.filter.convolve.ConvolveNaiveF.class)
+	@OpMethod(ops = { net.imagej.ops.filter.convolve.ConvolveNaiveF.class,
+		net.imagej.ops.filter.convolve.PadAndConvolveFFTF.class })
 	public <I extends RealType<I>, O extends RealType<O>, K extends RealType<K>>
 		RandomAccessibleInterval<O> convolve(final RandomAccessibleInterval<I> in,
 			final RandomAccessibleInterval<K> kernel,

--- a/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTC.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/ConvolveFFTC.java
@@ -64,24 +64,6 @@ public class ConvolveFFTC<I extends RealType<I>, O extends RealType<O>, K extend
 
 	private BinaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>> linearFilter;
 
-	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void initialize() {
-		super.initialize();
-
-		mul = Hybrids.binaryCF(ops(), IIToIIOutputII.Multiply.class, getFFTInput(),
-			getFFTKernel(), getFFTInput());
-
-		// create a convolver by creating a linear filter and passing the multiplier as
-		// the frequency operation
-		linearFilter = (BinaryComputerOp) Computers.binary(ops(),
-			FFTMethodsLinearFFTFilterC.class, RandomAccessibleInterval.class,
-			RandomAccessibleInterval.class, RandomAccessibleInterval.class,
-			getFFTInput(), getFFTKernel(), getPerformInputFFT(),
-			getPerformKernelFFT(), mul);
-
-	}
-
 	/**
 	 * Call the linear filter that is set up to perform convolution
 	 */
@@ -89,6 +71,20 @@ public class ConvolveFFTC<I extends RealType<I>, O extends RealType<O>, K extend
 	public void compute(RandomAccessibleInterval<I> in,
 		RandomAccessibleInterval<K> kernel, RandomAccessibleInterval<O> out)
 	{
+		if (linearFilter == null) {
+			System.out.println("ConvolveFFTC: fftInput = " + getFFTInput() + ", fftKernel = " + getFFTKernel());
+			mul = Hybrids.binaryCF(ops(), IIToIIOutputII.Multiply.class, getFFTInput(),
+				getFFTKernel(), getFFTInput());
+
+			// create a convolver by creating a linear filter and passing the multiplier as
+			// the frequency operation
+			linearFilter = (BinaryComputerOp) Computers.binary(ops(),
+				FFTMethodsLinearFFTFilterC.class, RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class, RandomAccessibleInterval.class,
+				getFFTInput(), getFFTKernel(), getPerformInputFFT(),
+				getPerformKernelFFT(), mul);
+		}
+
 		linearFilter.compute(in, kernel, out);
 	}
 }

--- a/src/main/java/net/imagej/ops/filter/convolve/ConvolveNaiveF.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/ConvolveNaiveF.java
@@ -38,7 +38,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
@@ -70,7 +69,7 @@ public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & Nativ
 	 * The output type. If null a default output type will be used.
 	 */
 	@Parameter(required = false)
-	private Type<O> outType;
+	private O outType;
 
 	private UnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> convolver;
 
@@ -100,13 +99,13 @@ public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & Nativ
 				.getTypeFromInterval(kernel).getClass())
 			{
 				Object temp = Util.getTypeFromInterval(input).createVariable();
-				outType = (Type<O>) temp;
+				outType = (O) temp;
 
 			}
 			// otherwise default to float
 			else {
 				Object temp = new FloatType();
-				outType = (Type<O>) temp;
+				outType = (O) temp;
 			}
 		}
 

--- a/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFT.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFT.java
@@ -89,7 +89,7 @@ public class PadAndConvolveFFT<I extends RealType<I> & NativeType<I>, O extends 
 
 	@Override
 	public boolean conforms() {
-		// conforms only if the kernel is sufficiently small
+		// conforms only if the kernel is sufficiently large
 		return Intervals.numElements(in2()) > 9;
 	}
 

--- a/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
@@ -31,8 +31,8 @@ package net.imagej.ops.filter.convolve;
 
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.BinaryComputerOp;
 import net.imagej.ops.special.computer.Computers;
-import net.imagej.ops.special.computer.UnaryComputerOp;
 import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
@@ -50,10 +50,10 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
- * Function adapter for {@link ConvolveFFTC}.
+ * Function adapter for {@link PadAndConvolveFFT}.
  */
 @Plugin(type = Ops.Filter.Convolve.class, priority = Priority.HIGH + 1)
-public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>>
+public class PadAndConvolveFFTF<I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>>
 	extends
 	AbstractBinaryFunctionOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>>
 	implements Ops.Filter.Convolve, Contingent
@@ -72,15 +72,15 @@ public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & Nativ
 	@Parameter(required = false)
 	private Type<O> outType;
 
-	private UnaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> convolver;
+	private BinaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>> convolver;
 
 	@Override
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void initialize() {
 		super.initialize();
 
-		convolver = (UnaryComputerOp) Computers.unary(ops(), ConvolveNaiveC.class,
-			RandomAccessibleInterval.class, RandomAccessibleInterval.class, in2());
+		convolver = (BinaryComputerOp) Computers.binary(ops(),
+			PadAndConvolveFFT.class, RandomAccessibleInterval.class, in1(), in2());
 
 	}
 
@@ -146,8 +146,8 @@ public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & Nativ
 
 	@Override
 	public boolean conforms() {
-		// conforms only if the kernel is sufficiently small
-		return Intervals.numElements(in2()) <= 9;
+		// conforms only if the kernel is sufficiently large
+		return Intervals.numElements(in2()) > 9;
 	}
 
 }

--- a/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
@@ -38,7 +38,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
@@ -70,7 +69,7 @@ public class PadAndConvolveFFTF<I extends RealType<I>, O extends RealType<O> & N
 	 * The output type. If null a default output type will be used.
 	 */
 	@Parameter(required = false)
-	private Type<O> outType;
+	private O outType;
 
 	private BinaryComputerOp<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>> convolver;
 
@@ -100,13 +99,13 @@ public class PadAndConvolveFFTF<I extends RealType<I>, O extends RealType<O> & N
 				.getTypeFromInterval(kernel).getClass())
 			{
 				Object temp = Util.getTypeFromInterval(input).createVariable();
-				outType = (Type<O>) temp;
+				outType = (O) temp;
 
 			}
 			// otherwise default to float
 			else {
 				Object temp = new FloatType();
-				outType = (Type<O>) temp;
+				outType = (O) temp;
 			}
 		}
 

--- a/src/main/java/net/imagej/ops/filter/fft/FFTMethodsOpF.java
+++ b/src/main/java/net/imagej/ops/filter/fft/FFTMethodsOpF.java
@@ -41,7 +41,6 @@ import net.imglib2.Dimensions;
 import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
-import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -90,7 +89,7 @@ public class FFTMethodsOpF<T extends RealType<T>, C extends ComplexType<C>>
 	 * The complex type of the output
 	 */
 	@Parameter(required = false)
-	private Type<C> fftType;
+	private C fftType;
 
 	private BinaryFunctionOp<RandomAccessibleInterval<T>, Dimensions, RandomAccessibleInterval<T>> padOp;
 

--- a/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
+++ b/src/test/java/net/imagej/ops/deconvolve/DeconvolveTest.java
@@ -112,9 +112,9 @@ public class DeconvolveTest extends AbstractOpTest {
 			0.025289025f, 0.02266813f, 0.020409783f, 0.018752098f, 0.017683199f,
 			0.016951872f, 0.016685976f };
 
-		float[] deconvolvedValues2 = { 0.2630328f, 0.3163978f, 0.37502986f,
-			0.436034f, 0.4950426f, 0.5468085f, 0.58636993f, 0.6105018f, 0.6186566f,
-			0.61295974f, 0.59725416f, 0.575831f, 0.5524411f, 0.5307535f, 0.5109127f };
+		float[] deconvolvedValues2 = { 0.2630342f, 0.3163991f, 0.37503138f,
+			0.43603566f, 0.49504462f, 0.54681045f, 0.5863713f, 0.6105026f, 0.6186579f,
+			0.6129602f, 0.5972553f, 0.57583135f, 0.55244136f, 0.53075385f, 0.5109135f };
 
 		for (int i = 0; i < deconvolvedValues.length; i++) {
 			assertEquals(deconvolvedValues[i], deconvolvedCursor.next().get(), 0.0f);

--- a/src/test/java/net/imagej/ops/filter/convolve/ConvolveTest.java
+++ b/src/test/java/net/imagej/ops/filter/convolve/ConvolveTest.java
@@ -282,10 +282,9 @@ public class ConvolveTest extends AbstractOpTest {
 		ops.stats().max(max, Views.iterable(convolved));
 		ops.stats().min(min, Views.iterable(convolved));
 
-		assertEquals(sum.getRealDouble(), 8750.00, 0.001);
-		assertEquals(max.getRealDouble(), 3.155, 0.001);
-		assertEquals(min.getRealDouble(), 2.978E-7, 0.001);
-
+		assertEquals(sum.getRealDouble(), 8750.000184601617, 0.0);
+		assertEquals(max.getRealDouble(), 3.154534101486206, 0.0);
+		assertEquals(min.getRealDouble(), -2.9776862220387557E-7, 0.0);
 	}
 
 }


### PR DESCRIPTION
With recent changes to imagej-ops including #594, some of the imagej-scripting examples broke. This branch addresses the issues by restoring missing functionality / method signatures. It also fixes some small bugs, such as NonCirculantNormalizationFactor division by zero.

Note that to fully reconcile imagej-ops with imagej-scripting, another set of fixes was also necessary for imagej-common: imagej/imagej-common#90.

See also these unmerged branches:

* #611, which also contained one of the bug fixes here;
* imagej/imagej-scripting#33, which updated imagej-scripting to use the updated imagej-ops API.