### PR TITLE
Optimise BoxCount further

### DIFF
--- a/src/main/java/net/imagej/ops/morphology/outline/Outline.java
+++ b/src/main/java/net/imagej/ops/morphology/outline/Outline.java
@@ -2,7 +2,7 @@
  * #%L
  * ImageJ software for multidimensional image processing and analysis.
  * %%
- * Copyright (C) 2014 - 2018 ImageJ developers.
+ * Copyright (C) 2014 - 2020 ImageJ developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imagej/ops/morphology/outline/Outline.java
+++ b/src/main/java/net/imagej/ops/morphology/outline/Outline.java
@@ -29,8 +29,6 @@
 
 package net.imagej.ops.morphology.outline;
 
-import java.util.Arrays;
-
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.hybrid.AbstractBinaryHybridCF;
 import net.imglib2.Cursor;
@@ -38,12 +36,10 @@ import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBounds;
-import net.imglib2.roi.labeling.BoundingBox;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.util.Util;
 import net.imglib2.view.ExtendedRandomAccessibleInterval;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 import org.scijava.plugin.Plugin;
@@ -73,7 +69,7 @@ public class Outline<B extends BooleanType<B>> extends
 	/**
 	 * Copies the outlines of the objects in the input interval into the output
 	 *
-	 * @param input a binary interval
+	 * @param input an N-dimensional binary interval
 	 * @param excludeEdges are elements on stack edges outline or not
 	 *          <p>
 	 *          For example, a 2D square:<br>
@@ -92,15 +88,15 @@ public class Outline<B extends BooleanType<B>> extends
 		final RandomAccessibleInterval<BitType> output)
 	{
 		final Cursor<B> inputCursor = Views.iterable(input).localizingCursor();
-		final long[] coordinates = new long[input.numDimensions()];
-		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> extendedInput =
-			extendInterval(input);
+		final long[] inputPosition = new long[input.numDimensions()];
+		final OutOfBounds<B> neighbourhoodAccess = extendInterval(input).randomAccess();
 		final RandomAccess<BitType> outputAccess = output.randomAccess();
 		while (inputCursor.hasNext()) {
 			inputCursor.fwd();
-			inputCursor.localize(coordinates);
-			if (isOutline(extendedInput, coordinates)) {
-				outputAccess.setPosition(coordinates);
+			inputCursor.localize(inputPosition);
+			neighbourhoodAccess.setPosition(inputPosition);
+			if (isOutline(neighbourhoodAccess, inputPosition)) {
+				outputAccess.setPosition(inputPosition);
 				outputAccess.get().set(inputCursor.get().get());
 			}
 		}
@@ -115,36 +111,19 @@ public class Outline<B extends BooleanType<B>> extends
 		return Views.extendValue(interval, type);
 	}
 
-	/**
-	 * Creates a view that spans from (x-1, y-1, ... i-1) to (x+1, y+1, ... i+1)
-	 * around the given coordinates
-	 *
-	 * @param interval the space of the coordinates
-	 * @param coordinates coordinates (x, y, ... i)
-	 * @return a view of a neighbourhood in the space
-	 */
-	private IntervalView<B> neighbourhoodInterval(
-		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> interval,
-		final long[] coordinates)
-	{
-		final int dimensions = interval.numDimensions();
-		final BoundingBox box = new BoundingBox(dimensions);
-		final long[] minBounds = Arrays.stream(coordinates).map(c -> c - 1)
-			.toArray();
-		final long[] maxBounds = Arrays.stream(coordinates).map(c -> c + 1)
-			.toArray();
-		box.update(minBounds);
-		box.update(maxBounds);
-		return Views.offsetInterval(interval, box);
-	}
-
-	/** Checks if any element in the neighbourhood is background */
-	private boolean isAnyBackground(final IntervalView<B> neighbourhood) {
-		final Cursor<B> cursor = neighbourhood.cursor();
-		while (cursor.hasNext()) {
-			cursor.fwd();
-			if (!cursor.get().get()) {
-				return true;
+	/** Checks if any element in the N-dimensional neighbourhood is background */
+	private boolean isAnyNeighborBackground(final int dimension, final OutOfBounds<B> access,
+											final long[] position) {
+		for (long p = -1; p <= 1; p++) {
+			access.setPosition(position[dimension] + p, dimension);
+			if (dimension == 0) {
+				if (!access.get().get()) {
+					return true;
+				}
+			} else {
+				if (isAnyNeighborBackground(dimension - 1, access, position)) {
+					return true;
+				}
 			}
 		}
 		return false;
@@ -153,24 +132,15 @@ public class Outline<B extends BooleanType<B>> extends
 	/**
 	 * Checks if an element is part of the outline of an object
 	 *
-	 * @param source the location of the element
-	 * @param coordinates coordinates of the element
+	 * @param access an access to an extended view of the input interval
+	 * @param position current position in the input image
 	 * @return true if element is foreground and has at least one background
 	 *         neighbour
 	 */
-	private boolean isOutline(
-		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> source,
-		final long[] coordinates)
+	private boolean isOutline(final OutOfBounds<B> access, final long[] position)
 	{
-		final OutOfBounds<B> access = source.randomAccess();
-		access.setPosition(coordinates);
-		if (!access.get().get()) {
-			return false;
-		}
-
-		final IntervalView<B> neighbourhood = neighbourhoodInterval(source,
-			coordinates);
-		return isAnyBackground(neighbourhood);
+		final int dimension = access.numDimensions() - 1;
+		return access.get().get() && isAnyNeighborBackground(dimension, access, position);
 	}
 	// endregion
 }

--- a/src/main/java/net/imagej/ops/topology/BoxCount.java
+++ b/src/main/java/net/imagej/ops/topology/BoxCount.java
@@ -2,7 +2,7 @@
  * #%L
  * ImageJ software for multidimensional image processing and analysis.
  * %%
- * Copyright (C) 2014 - 2018 ImageJ developers.
+ * Copyright (C) 2014 - 2020 ImageJ developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imagej/ops/topology/BoxCount.java
+++ b/src/main/java/net/imagej/ops/topology/BoxCount.java
@@ -117,7 +117,7 @@ public class BoxCount<B extends BooleanType<B>> extends
 	public List<ValuePair<DoubleType, DoubleType>> calculate(
 		final RandomAccessibleInterval<B> input)
 	{
-		if (scaling <= 1.0) {
+		if (scaling < 1.0 || (scaling == 1.0 && maxSize > minSize)) {
 			throw new IllegalArgumentException("Scaling must be > 1.0 or algorithm won't stop.");
 		}
 

--- a/src/test/java/net/imagej/ops/morphology/outline/OutlineTest.java
+++ b/src/test/java/net/imagej/ops/morphology/outline/OutlineTest.java
@@ -56,7 +56,7 @@ public class OutlineTest extends AbstractOpTest {
 
 	/** Test basic properties of the op's output */
 	@Test
-	public void testOutput() throws Exception {
+	public void testOutput() {
 		// SETUP
 		final long[] inputDims = { 3, 3, 3 };
 		final Img<BitType> img = ArrayImgs.bits(inputDims);
@@ -74,7 +74,7 @@ public class OutlineTest extends AbstractOpTest {
 
 	/** Test the op with an interval that's full of background elements */
 	@Test
-	public void testAllBackground() throws Exception {
+	public void testAllBackground() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(3, 3, 3);
 
@@ -89,7 +89,7 @@ public class OutlineTest extends AbstractOpTest {
 
 	/** Test the op with an interval that's full of foreground elements */
 	@Test
-	public void testAllForeground() throws Exception {
+	public void testAllForeground() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(3, 3, 3);
 		img.forEach(BitType::setOne);
@@ -105,7 +105,7 @@ public class OutlineTest extends AbstractOpTest {
 
 	/** Test the op with a 2x2 square. The square is in the middle of a 4x4 img */
 	@Test
-	public void testSquare() throws Exception {
+	public void testSquare() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(4, 4);
 		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
@@ -130,7 +130,7 @@ public class OutlineTest extends AbstractOpTest {
 	 * the middle of a 5x5 img
 	 */
 	@Test
-	public void testOutlineSquare() throws Exception {
+	public void testOutlineSquare() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(5, 5);
 		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
@@ -162,7 +162,7 @@ public class OutlineTest extends AbstractOpTest {
 	 * @see #testEdgeSquare()
 	 */
 	@Test
-	public void testEdgeSquare() throws Exception {
+	public void testEdgeSquare() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(5, 5);
 		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
@@ -193,7 +193,7 @@ public class OutlineTest extends AbstractOpTest {
 	 * @see #testEdgeSquare()
 	 */
 	@Test
-	public void testEdgeSquareExcludeEdgesFalse() throws Exception {
+	public void testEdgeSquareExcludeEdgesFalse() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(5, 5);
 		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] {
@@ -217,7 +217,7 @@ public class OutlineTest extends AbstractOpTest {
 	 * 5x5x5x5 img
 	 */
 	@Test
-	public void testHyperCube() throws Exception {
+	public void testHyperCube() {
 		// SETUP
 		final Img<BitType> img = ArrayImgs.bits(5, 5, 5, 5);
 		final IntervalView<BitType> hyperCube = Views.offsetInterval(img,

--- a/src/test/java/net/imagej/ops/topology/BoxCountTest.java
+++ b/src/test/java/net/imagej/ops/topology/BoxCountTest.java
@@ -2,7 +2,7 @@
  * #%L
  * ImageJ software for multidimensional image processing and analysis.
  * %%
- * Copyright (C) 2014 - 2018 ImageJ developers.
+ * Copyright (C) 2014 - 2020 ImageJ developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -176,6 +176,29 @@ public class BoxCountTest extends AbstractOpTest {
 			assertEquals(p.a.get(), sizes.next(), 1e-12);
 			assertEquals(p.b.get(), counts.next(), 1e-12);
 		});
+	}
+
+	// Covers a bug I had during development that other tests didn't detect.
+	// When interval size wasn't an even multiple of box size, the op didn't
+	// check the whole image, and missed foreground pixels at the edges
+	@Test
+	public void testUnevenBoxes() {
+		// SETUP
+		final int size = 10;
+		final int max = size - 1;
+		final long boxSize = size - 1;
+		final Img<BitType> img = ArrayImgs.bits(size, size, size);
+		final IntervalView<BitType> lastXYSlice = Views.interval(img,
+				new long[] { 0, 0, max}, new long[] { max, max, max});
+		lastXYSlice.forEach(BitType::setOne);
+
+		// EXECUTE
+		final List<ValuePair<DoubleType, DoubleType>> points = ops.topology()
+				.boxCount(img, boxSize, boxSize, 3.0);
+
+		// VERIFY
+		final ValuePair<DoubleType, DoubleType> point = points.get(0);
+		assertEquals(point.b.get(), Math.log(4), 1e-12);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/net/imagej/ops/topology/BoxCountTest.java
+++ b/src/test/java/net/imagej/ops/topology/BoxCountTest.java
@@ -179,10 +179,17 @@ public class BoxCountTest extends AbstractOpTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testThrowsIAEIfScalingEqualsOne() {
+	public void testThrowsIAEIfScalingLTOne() {
 		final Img<BitType> img = ArrayImgs.bits(9, 9, 9);
 
-		ops.topology().boxCount(img, 8L, 2L, 1.0);
+		ops.topology().boxCount(img, 2L, 2L, 0.99);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testThrowsIAEIfScalingOneAndMaxGTMin() {
+		final Img<BitType> img = ArrayImgs.bits(9, 9, 9);
+
+		ops.topology().boxCount(img, 2L, 1L, 1.0);
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Further optimises ops related to issue https://github.com/bonej-org/BoneJ2/issues/196

Changes execution times for a 256 x 256 x 256 binary image:
* BoxCount _25 s -> 1.1 s_ (Paremeters: maxSize 256, minSize 1, scaling 2.0) 
* Outline _2 s -> 500 ms_