### PR TITLE
Fix work per thread in Outline

### DIFF
--- a/src/main/java/net/imagej/ops/morphology/outline/Outline.java
+++ b/src/main/java/net/imagej/ops/morphology/outline/Outline.java
@@ -46,12 +46,12 @@ import net.imglib2.view.Views;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.thread.ThreadService;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import org.scijava.thread.ThreadService;
 
 /**
  * The Op creates an output interval where the objects are hollow versions from

--- a/src/main/java/net/imagej/ops/morphology/outline/Outline.java
+++ b/src/main/java/net/imagej/ops/morphology/outline/Outline.java
@@ -39,7 +39,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.outofbounds.OutOfBounds;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
-import net.imglib2.util.Util;
 import net.imglib2.view.ExtendedRandomAccessibleInterval;
 import net.imglib2.view.Views;
 
@@ -103,7 +102,7 @@ public class Outline<B extends BooleanType<B>> extends
 		final RandomAccessibleInterval<BitType> output)
 	{
 		final ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>> extendedInput =
-				extendInterval(input);
+				Views.extendValue(input, excludeEdges);
 		final List<Future<?>> futures = new ArrayList<>();
 		final IterableInterval<B> iterable = Views.iterable(input);
 		final int cores = Runtime.getRuntime().availableProcessors();
@@ -157,14 +156,6 @@ public class Outline<B extends BooleanType<B>> extends
 				inputCursor.jumpFwd(jump);
 			}
 		};
-	}
-
-	private ExtendedRandomAccessibleInterval<B, RandomAccessibleInterval<B>>
-		extendInterval(RandomAccessibleInterval<B> interval)
-	{
-		final B type = Util.getTypeFromInterval(interval).createVariable();
-		type.set(in2());
-		return Views.extendValue(interval, type);
 	}
 
 	/** Checks if any element in the N-dimensional neighbourhood is background */


### PR DESCRIPTION
In PR #618 @ctrueden reported `Outline` tests failing on a Linux box. Since neither of us could reproduce the issue in other environments and Travis CI was happy, I eventually shrugged it off as an isolated incident. Now @mdoube has reported failing tests in BoneJ, which depend on `Outline`. I think it's the same bug. This PR has been tested to fix the issue for him.

~~I don't have the resources to actually solve the bug right now (still can't reproduce). Rather than leave the issue lurking, I'm reverting the op to single threaded execution.~~

@ctrueden Could you please check whether this fixes the issue on the Linux box you mentioned?