### PR TITLE
Allow OOBF to be passed on to PadAndConvolveFFT

### DIFF
--- a/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
@@ -79,7 +79,7 @@ public class PadAndConvolveFFTF<I extends RealType<I>, O extends RealType<O> & N
 		super.initialize();
 
 		convolver = (BinaryComputerOp) Computers.binary(ops(),
-			PadAndConvolveFFT.class, RandomAccessibleInterval.class, in1(), in2());
+			PadAndConvolveFFT.class, RandomAccessibleInterval.class, in1(), in2(), null, obf);
 
 	}
 

--- a/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
+++ b/src/main/java/net/imagej/ops/filter/convolve/PadAndConvolveFFTF.java
@@ -78,6 +78,13 @@ public class PadAndConvolveFFTF<I extends RealType<I>, O extends RealType<O> & N
 	public void initialize() {
 		super.initialize();
 
+		// N.B. The null value in this op call is passed to the long[] borderSize
+		// parameter. Unfortunately in order to provide an OutOfBoundsFactory to
+		// this Op we also have to provide a long[] borderSize. This is not provided
+		// to us, however, so we just want to use the reasonable default as defined
+		// in PadAndConvolveFFT. This is why we pass a null before obf.
+		// Also note that if obf is null then it will be set to a reasonable default
+		// within PadAndConvolveFFT.
 		convolver = (BinaryComputerOp) Computers.binary(ops(),
 			PadAndConvolveFFT.class, RandomAccessibleInterval.class, in1(), in2(), null, obf);
 

--- a/src/test/java/net/imagej/ops/filter/convolve/PaddingTest.java
+++ b/src/test/java/net/imagej/ops/filter/convolve/PaddingTest.java
@@ -1,0 +1,34 @@
+package net.imagej.ops.filter.convolve;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imagej.ops.AbstractOpTest;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.outofbounds.OutOfBoundsPeriodicFactory;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+
+public class PaddingTest extends AbstractOpTest  {
+	@Test
+	public void theTest() {
+	
+		Img<FloatType> ramp = ArrayImgs.floats(256, 256);
+		Img<FloatType> average = ArrayImgs.floats(64, 64);
+
+		int i = 0;
+		for (FloatType iv : ramp)
+			iv.set(i / 256 + (i++) % 256);
+		for (FloatType kv : average)
+			kv.set(1f / (64 * 64));
+
+		RandomAccessibleInterval<FloatType> one=ops.filter().convolve(ramp, average);
+		RandomAccessibleInterval<FloatType> two=ops.filter().convolve(ramp, average, new OutOfBoundsPeriodicFactory<>());
+	
+		assertEquals(ops.stats().mean(Views.iterable(one)).getRealDouble(), 224.5312520918087, 0.0);
+		assertEquals(ops.stats().mean(Views.iterable(two)).getRealDouble(), 255.0000066360226, 0.0);
+	}
+}


### PR DESCRIPTION
It is often desired to pass some `OutOfBoundsFactory` to `PadAndConvolveFFTF`, and when one does this it is expected that the `OOBF` is passed on to the underlying convolve Op. This was not happening, however, and a `OutOfBoundsConstantValueFactory` was always being used. This PR allows an `OOBF` being passed to `PadAndConvolveFFTF` to be given to the underlying convolve Op, ensuring expected behavior.

author: @bnorthan 

Closes #628 