### PR TITLE
Bugfix: Grey-value co-occurrence matrices should be symmetric

### DIFF
--- a/src/main/java/net/imagej/ops/image/cooccurrenceMatrix/CooccurrenceMatrix3D.java
+++ b/src/main/java/net/imagej/ops/image/cooccurrenceMatrix/CooccurrenceMatrix3D.java
@@ -126,7 +126,8 @@ public class CooccurrenceMatrix3D<T extends RealType<T>> extends
 							&& pixels[sz][sy][sx] != Integer.MAX_VALUE) {
 
 						matrix[pixels[z][y][x]][pixels[sz][sy][sx]]++;
-						nrPairs++;
+						matrix[pixels[sz][sy][sx]][pixels[z][y][x]]++;
+						nrPairs += 2;
 
 					}
 				}


### PR DESCRIPTION
Hi all,

as discussed with a user and @imagejan on the[forum](https://forum.image.sc/t/clij-optimisation-on-glcm/41240/21) we assume that the grey level co-occurrence matrices should be symmetric. Otherwise, the direction of the read-out would play a role in further post-processing of the matrix.

Maybe @dietzc has an opinion here.

Thanks!

Cheers,
Robert