### PR TITLE
DefaultOpService: Fix setMaxThreads to check range of local variable

### DIFF
--- a/src/main/java/net/imagej/ops/DefaultOpService.java
+++ b/src/main/java/net/imagej/ops/DefaultOpService.java
@@ -93,7 +93,7 @@ public class DefaultOpService extends AbstractPTService<Op> implements
 
 	@Override
 	public void setMaxThreads(final int maxThreads) {
-		if (this.maxThreads < 1) {
+		if (maxThreads < 1) {
 			throw new IllegalArgumentException("Max threads must be at least 1");
 		}
 		this.maxThreads = maxThreads;


### PR DESCRIPTION
The range of the global variable maxThreads is being checked in the
setMaxThreads method, but the local variable should be checked. The
global one is zero by default before being set so calling the function
always triggers the IllegalArgumentException no matter what value is
provided.