### PR TITLE
Various OpListing Improvements

### DIFF
--- a/src/main/java/net/imagej/ops/OpListingModule.java
+++ b/src/main/java/net/imagej/ops/OpListingModule.java
@@ -97,9 +97,6 @@ class OpListingModule extends AbstractModule {
 	 */
 	private Object[] opArgs() {
 		final List<Object> args = new ArrayList<>();
-		// Add preallocated outputs
-		for (final ModuleItem<?> item : info.outputs())
-			if (item.isInput()) args.add(getOutput(item.getName()));
 		for (final ModuleItem<?> item : info.inputs())
 			args.add(getInput(item.getName()));
 		return args.toArray();

--- a/src/main/java/net/imagej/ops/search/OpSearcher.java
+++ b/src/main/java/net/imagej/ops/search/OpSearcher.java
@@ -169,7 +169,7 @@ public class OpSearcher implements Searcher {
 	 */
 	private String filterString(String text) {
 		if (text == null) text = "";
-		return text.toLowerCase().replaceAll("[^a-zA-Z0-9]", "");
+		return text.toLowerCase();
 	}
 
 	private int namePriority(final String opName, final String searchText) {
@@ -181,10 +181,10 @@ public class OpSearcher implements Searcher {
 
 	private boolean startsWith(final String name, final String desiredLower) {
 		return name != null && //
-			name.toLowerCase().matches("(^|.*\\.)" + desiredLower + ".*");
+			name.toLowerCase().startsWith(desiredLower.toLowerCase());
 	}
 
 	private boolean hasSubstring(final String name, final String desiredLower) {
-		return name != null && name.matches(".*" + desiredLower + ".*");
+		return name != null && name.contains(desiredLower);
 	}
 }

--- a/src/test/java/net/imagej/ops/OpListingTest.java
+++ b/src/test/java/net/imagej/ops/OpListingTest.java
@@ -33,9 +33,9 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
 import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
 import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 import net.imglib2.RandomAccessibleInterval;
@@ -138,7 +138,7 @@ public class OpListingTest extends AbstractOpTest{
 		final OpInfo info = new OpInfo(FooOp.class);
 		final OpListing sig = info.listing();
 		final String expected =
-			"test.opListing(img, unsignedByteType \"unnecessary\") -> string";
+			"test.opListing(img \"in\", unsignedByteType \"unnecessary\") -> (string \"out\")";
 		assertEquals(expected, sig.toString());
 	}
 
@@ -164,7 +164,7 @@ public class OpListingTest extends AbstractOpTest{
 		assertEquals(expectedOut, sig.getReturnTypes());
 		// test string
 		final String expected =
-			"test.opListing(randomAccessibleInterval, number \"unnecessary\") -> list";
+			"test.opListing(randomAccessibleInterval \"in\", number \"unnecessary\") -> (list \"out\")";
 		assertEquals(expected, sig.toString());
 	}
 
@@ -200,6 +200,39 @@ public class OpListingTest extends AbstractOpTest{
 		module.run();
 		assertEquals(0.5, module.getOutput("out"));
 		assertEquals(2.0, module.getOutput("bDividedByA"));
+	}
+	
+	/**
+	 * A test Computer
+	 * 
+	 * @author Gabriel Selzer
+	 */
+	@Plugin(type = Op.class, name = "test.opListingComputer")
+	public static class ComputerOp extends
+		AbstractUnaryComputerOp<Img<UnsignedByteType>, Img<UnsignedByteType>>
+	{
+
+		@Override
+		public void compute(final Img<UnsignedByteType> in,
+			final Img<UnsignedByteType> out)
+		{}
+	}
+
+	@Test
+	public void testComputerReduction() {
+		final OpInfo info = new OpInfo(ComputerOp.class);
+		final OpListing sig = info.listing().reduce(exampleReducer);
+		// test input types
+		final List<Type> expectedIns = Arrays.asList(RandomAccessibleInterval.class,
+				RandomAccessibleInterval.class);
+		assertEquals(expectedIns, sig.getInputTypes());
+		final List<Type> expectedOut = Collections.singletonList(RandomAccessibleInterval.class);
+		assertEquals(expectedOut, sig.getReturnTypes());
+		// test string
+		final String expected =
+				"test.opListingComputer(randomAccessibleInterval \"out\", randomAccessibleInterval \"in\") -> (randomAccessibleInterval \"out\")";
+		assertEquals(expected, sig.toString());
+		
 	}
 
 

--- a/src/test/java/net/imagej/ops/OpSearcherTest.java
+++ b/src/test/java/net/imagej/ops/OpSearcherTest.java
@@ -104,7 +104,7 @@ public class OpSearcherTest extends AbstractOpTest {
 
 		final String sig = results.get(0).name();
 
-		Assert.assertEquals("test.opSearcher(img, number \"value\") -> string",
+		Assert.assertEquals("test.opSearcher(img \"in\", number \"value\") -> (string \"out\")",
 			sig);
 		final ModuleInfo info = ((OpSearchResult) results.get(0)).info();
 		final Module module = info.createModule();


### PR DESCRIPTION
This PR was originally designed to address imagej/imagej-ops#645, but breaks from the plan addressed in that PR a bit.

This PR does include the `OpListing` refactoring described in that issue, which is part of what we need for imagej/napari-imagej#96 (we'll need a release of imagej-ops, plus a PR in that repository to actually address the issue). Specifically, I wrote the *private* class `OpListing.Parameter` to keep track of all the needed state. This class also makes it significantly easier to make improvements to the stringification of each parameter.

The other improvement made by this PR is the re-inclusion of *all* parameter names. Previously, we were leaving out any names conforming to either `"out"` or `"inX"`, because I thought they were redundant. It turns out that this got confusing, so I added them back. I actually tried making a bunch of different modifications to the `OpListing` strings (see [this zulip thread](https://imagesc.zulipchat.com/#narrow/stream/327236-ImageJ2/topic/OpListing.20indicator.20for.20Mutable.20Outputs/near/298647346)), but for now I'm going to leave them out, and add them in later if people need (thanks for the suggestion @hinerm)

I'm not sure this fully solves #645, as I did not include the additional `OpListing` filtering I talked about in that PR. *But*, if we do it, I'd rather address it in another PR as it is a separate issue.