### PR TITLE
Allow copies across boolean types

### DIFF
--- a/src/main/java/net/imagej/ops/copy/CopyBooleanType.java
+++ b/src/main/java/net/imagej/ops/copy/CopyBooleanType.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops.copy;
+
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.AbstractUnaryComputerOp;
+import net.imagej.ops.special.hybrid.AbstractUnaryHybridCF;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.Type;
+
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Copy {@link BooleanType} to another {@link BooleanType}
+ *
+ * @author Gabriel Selzer
+ * @param <B1>
+ * @param <B2>
+ */
+@Plugin(type = Ops.Copy.Type.class)
+public class CopyBooleanType<B1 extends BooleanType<B1>, B2 extends BooleanType<B2>>
+	extends AbstractUnaryComputerOp<B1, B2> implements Ops.Copy.Type
+{
+
+	@Override
+	public void compute(final B1 input, final B2 output) {
+		output.set(input.get());
+	}
+
+}

--- a/src/main/java/net/imagej/ops/copy/CopyNamespace.java
+++ b/src/main/java/net/imagej/ops/copy/CopyNamespace.java
@@ -38,6 +38,7 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.roi.labeling.LabelingMapping;
+import net.imglib2.type.BooleanType;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.IntegerType;
@@ -182,4 +183,15 @@ public class CopyNamespace extends AbstractNamespace {
 				in);
 		return result;
 	}
+
+	@OpMethod(op = net.imagej.ops.copy.CopyBooleanType.class)
+	public <B1 extends BooleanType<B1>, B2 extends BooleanType<B2>> B2 type(
+		final B2 out, final B1 in)
+	{
+		@SuppressWarnings("unchecked")
+		final B2 result = (B2) ops().run(net.imagej.ops.copy.CopyType.class, out,
+			in);
+		return result;
+	}
+
 }

--- a/src/test/java/net/imagej/ops/copy/CopyRAITest.java
+++ b/src/test/java/net/imagej/ops/copy/CopyRAITest.java
@@ -31,6 +31,7 @@ package net.imagej.ops.copy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import net.imagej.ops.AbstractOpTest;
 import net.imagej.ops.special.hybrid.Hybrids;
@@ -43,6 +44,8 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.NativeBoolType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
@@ -55,6 +58,7 @@ import org.scijava.util.MersenneTwisterFast;
  * Test {@link CopyRAI}.
  *
  * @author Tim-Oliver Buchholz (University of Konstanz)
+ * @author Gabriel Selzer
  */
 public class CopyRAITest extends AbstractOpTest {
 
@@ -168,6 +172,25 @@ public class CopyRAITest extends AbstractOpTest {
 
 		copy.compute(viewPlanar, outFromPlanar);
 		assertEquals(ops.stats().mean(outFromPlanar).getRealDouble(), 100.0, delta);
+
+	}
+
+	@Test
+	public void copyBooleanTypesTest() {
+
+		final Img<NativeBoolType> in = ops.create().img(new FinalDimensions(size2),
+			new NativeBoolType());
+		Cursor<NativeBoolType> cursor = in.cursor();
+		while (cursor.hasNext()) {
+			cursor.next().set(true);
+		}
+
+		final Img<BitType> out = ops.create().img(new FinalDimensions(size2),
+			new BitType());
+
+		ops.run("copy.rai", out, in);
+
+		assertTrue(out.firstElement().get());
 
 	}
 }


### PR DESCRIPTION
Currently, Ops can only copy between the same `RealType` implementations. This is because the `set`/`get` methods only work on values of the same type. We could copy across different `BooleanType` implementations, though, as *their* `set`/`get` methods work on `boolean`. This PR does just that.