### PR TITLE
Use non-normalized normals in Mesh centroid

### DIFF
--- a/src/main/java/net/imagej/ops/geom/CentroidMesh.java
+++ b/src/main/java/net/imagej/ops/geom/CentroidMesh.java
@@ -70,9 +70,6 @@ public class CentroidMesh extends AbstractUnaryFunctionOp<Mesh, RealLocalizable>
 			final long v0 = input.triangles().vertex0(i);
 			final long v1 = input.triangles().vertex1(i);
 			final long v2 = input.triangles().vertex2(i);
-			final double nx = input.triangles().nx(i);
-			final double ny = input.triangles().ny(i);
-			final double nz = input.triangles().nz(i);
 			final double v0x = input.vertices().x(v0);
 			final double v0y = input.vertices().y(v0);
 			final double v0z = input.vertices().z(v0);
@@ -82,6 +79,18 @@ public class CentroidMesh extends AbstractUnaryFunctionOp<Mesh, RealLocalizable>
 			final double v2x = input.vertices().x(v2);
 			final double v2y = input.vertices().y(v2);
 			final double v2z = input.vertices().z(v2);
+
+			// Recompute (non-normalized) normals
+			final double ux = v1x - v0x;
+			final double uy = v1y - v0y;
+			final double uz = v1z - v0z;
+			final double vx = v2x - v0x;
+			final double vy = v2y - v0y;
+			final double vz = v2z - v0z;
+			final double nx = (uy * vz - uz * vy);
+			final double ny = -(ux * vz - uz * vx);
+			final double nz = (ux * vy - uy * vx);
+
 			c_x += (1 / 24d) * nx * (Math.pow((v0x + v1x), 2)
 					+ Math.pow((v1x + v2x), 2)
 					+ Math.pow((v2x + v0x), 2));
@@ -98,6 +107,6 @@ public class CentroidMesh extends AbstractUnaryFunctionOp<Mesh, RealLocalizable>
 		c_y *= d;
 		c_z *= d;
 
-		return new RealPoint(-c_x, -c_y, -c_z);
+		return new RealPoint(c_x, c_y, c_z);
 	}
 }


### PR DESCRIPTION
This PR adds the fixes I discussed with @tibuch on Zulip ([here](https://imagesc.zulipchat.com/#narrow/stream/327240-ImgLib2/topic/Opifying.20Imglib2.20Mesh/near/446705794)), while trying to determine the difference in return between the `geom.centroid` Op operating on `Mesh`es and the static algorithm [`MeshStats.centroid()`](https://github.com/imglib/imglib2-mesh/blob/c8d2c16ed63dd6ec0496bfa89d39241df2159898/src/main/java/net/imglib2/mesh/MeshStats.java#L241) from imglib2-mesh.

> @Tim-Oliver Buchholz I have finally figured out the difference - if you call `mesh.triangles().add(idx1, idx2, idx3)`, the library will automatically [normalize the normal vector](https://github.com/imglib/imglib2-mesh/blob/c8d2c16ed63dd6ec0496bfa89d39241df2159898/src/main/java/net/imglib2/mesh/Triangles.java#L452). The `geom.centroid` Op expects the normal vector of each triangle to be non-normalized, as it [uses those values directly](https://github.com/imagej/imagej-ops/blob/d9d15281373b0377aa5b7bbc80ef14df3a298b2c/src/main/java/net/imagej/ops/geom/CentroidMesh.java#L73) in the computation (SciJava Ops Image does the same thing), however the algorithm in the paper requires non-normlized normal vectors. If you recompute the normal vector within the `CentroidMesh` Op, then you get the negative of `MeshStats.centroid`, because of the inversion [here](https://github.com/imagej/imagej-ops/blob/d9d15281373b0377aa5b7bbc80ef14df3a298b2c/src/main/java/net/imagej/ops/geom/CentroidMesh.java#L101)

The reason for the draft PR is that I am unsure how to fix the tests - there are three failures in Mesh features that *depend upon* the centroid Op which fail with these changes, and two suggest that the values were verified against MATLAB. I don't know which MATLAB code was used/how to verify.