### PR TITLE
Overhaul of Voxelization ops with new algorithm. Also included test

### DIFF
--- a/src/main/java/net/imagej/ops/geom/GeomNamespace.java
+++ b/src/main/java/net/imagej/ops/geom/GeomNamespace.java
@@ -691,6 +691,28 @@ public class GeomNamespace extends AbstractNamespace {
 		return result;
 	}
 
+	//Two OpMethods below cause a Mismatched inputs error, though they both work fine if built with 'Skip tests'
+//	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
+//	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, double wallThickness) {
+//		final RandomAccessibleInterval<BitType> result =
+//				(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, null, false, wallThickness);
+//		return result;
+//	}
+//
+//	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
+//	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final Interval dimensions, double wallThickness) {
+//		final RandomAccessibleInterval<BitType> result =
+//				(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, dimensions, false, wallThickness);
+//		return result;
+//	}
+
+	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
+	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final Interval dimensions, boolean scaleMeshToDimesions, double wallThickness) {
+		final RandomAccessibleInterval<BitType> result =
+				(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, dimensions, scaleMeshToDimesions, wallThickness);
+		return result;
+	}
+
 	
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultVerticesCountPolygon.class)
 	public DoubleType verticesCount(final Polygon2D in) {

--- a/src/main/java/net/imagej/ops/geom/GeomNamespace.java
+++ b/src/main/java/net/imagej/ops/geom/GeomNamespace.java
@@ -37,6 +37,7 @@ import net.imagej.ops.Namespace;
 import net.imagej.ops.OpMethod;
 import net.imagej.ops.Ops.Geometric.Voxelization;
 import net.imagej.ops.geom.geom3d.mesh.VertexInterpolator;
+import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealLocalizable;
@@ -278,13 +279,6 @@ public class GeomNamespace extends AbstractNamespace {
 			net.imagej.ops.Ops.Geometric.ConvexHull.class, in);
 		return result;
 	}
-	
-	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
-	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final int width, final int height, final int depth ) {
-		final RandomAccessibleInterval<BitType> result = (RandomAccessibleInterval<BitType>) ops().run(
-				Voxelization.class, in, width, height, depth );
-	 	return result;
-	}	
 
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultConvexityPolygon.class)
 	public DoubleType convexity(final Polygon2D in) {
@@ -678,26 +672,25 @@ public class GeomNamespace extends AbstractNamespace {
 	
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
 	public RandomAccessibleInterval<BitType> voxelization(final Mesh in) {
-		@SuppressWarnings("unchecked")
 		final RandomAccessibleInterval<BitType> result =
 			(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
-	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final int width) {
-		@SuppressWarnings("unchecked")
+	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final Interval dimensions) {
 		final RandomAccessibleInterval<BitType> result =
-			(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, width);
+			(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, dimensions);
 		return result;
 	}
 
 	@OpMethod(op = net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class)
-	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final int width, final int height) {
+	public RandomAccessibleInterval<BitType> voxelization(final Mesh in, final Interval dimensions, boolean scaleMeshToDimesions) {
 		final RandomAccessibleInterval<BitType> result =
-			(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, width, height);
+				(RandomAccessibleInterval<BitType>) ops().run(net.imagej.ops.geom.geom3d.DefaultVoxelization3D.class, in, dimensions, scaleMeshToDimesions);
 		return result;
 	}
+
 	
 	@OpMethod(op = net.imagej.ops.geom.geom2d.DefaultVerticesCountPolygon.class)
 	public DoubleType verticesCount(final Polygon2D in) {

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
@@ -67,9 +67,6 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 	@Parameter
 	private OpService ops;
 
-	@Parameter
-	private LogService logService;
-
 	private final double wallThickness = 1.0; //This could be made into a parameter if needed
 	private final long[] offset = new long[] {0,0,0};
 	private double scale = 1.0;
@@ -81,7 +78,7 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 			float[] bounds = Meshes.boundingBox(input);
 			long[] outputInterval = new long[3];
 			for (int i = 0; i < 3; i++) {
-				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i]);
+				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i])+1;
 			}
 			dimensions = new FinalInterval(outputInterval);
 			setScale(input, bounds);

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
@@ -78,7 +78,7 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 			float[] bounds = Meshes.boundingBox(input);
 			long[] outputInterval = new long[3];
 			for (int i = 0; i < 3; i++) {
-				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i])+2;
+				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i]);
 			}
 			dimensions = new FinalInterval(outputInterval);
 			setScale(input, bounds);
@@ -128,7 +128,7 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 		double[] axisScaling = new double[3];
 		for (int i = 0; i < 3; i++) {
 			offset[i] = (long) Math.floor(bounds[i]) - dimensions.min(i);
-			axisScaling[i] = (dimensions.max(i) - dimensions.min(i)) / (bounds[i + 3] - bounds[i]);//dimensionRange/boundingboxRange
+			axisScaling[i] = (dimensions.max(i) - dimensions.min(i)) / ((bounds[i + 3]+2) - bounds[i]);
 		}
 		scale = Math.min(axisScaling[0], Math.min(axisScaling[1], axisScaling[2]));
 	}

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
@@ -67,9 +67,6 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 	@Parameter
 	private OpService ops;
 
-	@Parameter
-	private LogService logService;
-
 	private final double wallThickness = 1.0; //This could be made into a parameter if needed
 	private final long[] offset = new long[] {0,0,0};
 	private double scale = 1.0;

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
@@ -78,7 +78,7 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 			float[] bounds = Meshes.boundingBox(input);
 			long[] outputInterval = new long[3];
 			for (int i = 0; i < 3; i++) {
-				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i])+1;
+				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i])+2;
 			}
 			dimensions = new FinalInterval(outputInterval);
 			setScale(input, bounds);

--- a/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
+++ b/src/main/java/net/imagej/ops/geom/geom3d/DefaultVoxelization3D.java
@@ -78,7 +78,7 @@ public class DefaultVoxelization3D extends AbstractUnaryFunctionOp<Mesh, RandomA
 			float[] bounds = Meshes.boundingBox(input);
 			long[] outputInterval = new long[3];
 			for (int i = 0; i < 3; i++) {
-				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i]);
+				outputInterval[i] = (long)Math.ceil(bounds[i+3]-bounds[i])+2;
 			}
 			dimensions = new FinalInterval(outputInterval);
 			setScale(input, bounds);

--- a/src/test/java/net/imagej/ops/geom/MeshFeatureTests.java
+++ b/src/test/java/net/imagej/ops/geom/MeshFeatureTests.java
@@ -37,22 +37,12 @@ import net.imagej.mesh.Mesh;
 import net.imagej.mesh.Triangle;
 import net.imagej.ops.Ops;
 import net.imagej.ops.features.AbstractFeatureTest;
-import net.imagej.ops.geom.geom3d.DefaultBoxivityMesh;
-import net.imagej.ops.geom.geom3d.DefaultCompactness;
-import net.imagej.ops.geom.geom3d.DefaultConvexityMesh;
-import net.imagej.ops.geom.geom3d.DefaultMainElongation;
-import net.imagej.ops.geom.geom3d.DefaultMarchingCubes;
-import net.imagej.ops.geom.geom3d.DefaultMedianElongation;
-import net.imagej.ops.geom.geom3d.DefaultSolidityMesh;
-import net.imagej.ops.geom.geom3d.DefaultSparenessMesh;
-import net.imagej.ops.geom.geom3d.DefaultSphericity;
-import net.imagej.ops.geom.geom3d.DefaultSurfaceArea;
-import net.imagej.ops.geom.geom3d.DefaultSurfaceAreaConvexHullMesh;
-import net.imagej.ops.geom.geom3d.DefaultVerticesCountConvexHullMesh;
-import net.imagej.ops.geom.geom3d.DefaultVerticesCountMesh;
-import net.imagej.ops.geom.geom3d.DefaultVolumeConvexHullMesh;
-import net.imagej.ops.geom.geom3d.DefaultVolumeMesh;
+import net.imagej.ops.geom.geom3d.*;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.neighborhood.DiamondShape;
+import net.imglib2.roi.Regions;
 import net.imglib2.roi.labeling.LabelRegion;
+import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.real.DoubleType;
 
 import org.junit.BeforeClass;
@@ -201,6 +191,13 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 
 	@Test
 	public void voxelization3D() {
-		// https://github.com/imagej/imagej-ops/issues/422
+		/*Value of 184 here corresponds with:
+		RandomAccessibleInterval<BitType> result = (RandomAccessibleInterval<BitType>) ops.run(DefaultVoxelization3D.class, mesh, ROI);
+		ops.morphology().fillHoles(result, result, new DiamondShape(1));
+		assertEquals(Ops.Geometric.Voxelization.NAME, ROI.size(), Regions.countTrue(result));
+		 */
+		assertEquals(Ops.Geometric.Voxelization.NAME, 184,
+		Regions.countTrue((RandomAccessibleInterval<BitType>) ops.run(DefaultVoxelization3D.class, mesh, ROI)));
+
 	}
 }


### PR DESCRIPTION
Wanted to address a major issue with the voxelization Op not working appropriately. The old algorithm was returning every pixel of every triangle's entire bounding box as true. This new method only sets the pixels that the surface goes through to true.

In general, this method should now be more symmetric with marching cubes, so that after:
```
mesh = ops.geom().marchingCubes(image);
result = ops.geom().voxelization(mesh, image);
ops.morphology().fillHoles(result, result, new DiamondShape(1));
```
Image and result should match in the majority of cases. The notable exception would be images with holes themselves, generating a surface encompassed entirely by a surface in marching cubes. Voxelization would generate both surfaces, but I believe all encompassed holes would be filled after the fillHoles call, though I haven't tested this yet.

I did add some comments in the code for some optional changes that could be made. Originally I had an additional parameter for the wall thickness, but wasn't sure if this was really beneficial. I also wasn't sure if I should be using another Op (fill holes) during the voxelization Op testing, so I left it out and just compared the result to a static number.

Edit: was just looking through and noticed I forgot to delete the LogService parameter, which I was using for troubleshooting an issue.
